### PR TITLE
added ddl sequencer to lib, set modeshape version

### DIFF
--- a/plugins/libs/org.komodo.modeshape.lib/.classpath
+++ b/plugins/libs/org.komodo.modeshape.lib/.classpath
@@ -7,6 +7,7 @@
 	<classpathentry exported="true" kind="lib" path="lib/jcr.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/logback-core.jar" sourcepath="libsrc/logback-core-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/modeshape-common.jar" sourcepath="libsrc/modeshape-common-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/modeshape-sequencer-ddl.jar" sourcepath="libsrc/modeshape-sequencer-ddl-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/modeshape-jcr.jar" sourcepath="libsrc/modeshape-jcr-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/slf4j-api.jar" sourcepath="libsrc/slf4j-api-sources.jar"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/libs/org.komodo.modeshape.lib/META-INF/MANIFEST.MF
+++ b/plugins/libs/org.komodo.modeshape.lib/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Bundle-ClassPath: .,
  lib/logback-core.jar,
  lib/logback-classic.jar,
  lib/modeshape-common.jar,
+ lib/modeshape-sequencer-ddl.jar,
  lib/modeshape-jcr.jar,
  lib/slf4j-api.jar
 Export-Package: org.modeshape.common,
@@ -61,5 +62,12 @@ Export-Package: org.modeshape.common,
  org.modeshape.jcr.value.binary.infinispan,
  org.modeshape.jcr.xml,
  org.modeshape.jmx,
- org.modeshape.sequencer.cnd
-
+ org.modeshape.sequencer.cnd,
+ org.modeshape.sequencer.ddl,
+ org.modeshape.sequencer.ddl.datatype,
+ org.modeshape.sequencer.ddl.dialect.derby,
+ org.modeshape.sequencer.ddl.dialect.mysql,
+ org.modeshape.sequencer.ddl.dialect.oracle,
+ org.modeshape.sequencer.ddl.dialect.postgres,
+ org.modeshape.sequencer.ddl.dialect.teiid,
+ org.modeshape.sequencer.ddl.node

--- a/plugins/libs/org.komodo.modeshape.lib/build.xml
+++ b/plugins/libs/org.komodo.modeshape.lib/build.xml
@@ -20,6 +20,7 @@
 	<property name="libs" value="jcr.jar,
 								 modeshape-jcr.jar,
 								 modeshape-common.jar,
+								 modeshape-sequencer-ddl.jar,
 		                         logback-core.jar,
 								 logback-classic.jar,
 								 slf4j-api.jar"/>

--- a/plugins/libs/org.komodo.modeshape.lib/pom.xml
+++ b/plugins/libs/org.komodo.modeshape.lib/pom.xml
@@ -13,7 +13,7 @@
     <packaging>eclipse-plugin</packaging>
 
     <properties>
-        <modeshape.version>4.0.0.Alpha3</modeshape.version>
+        <modeshape.version>3.8.0.Final</modeshape.version>
         <version.slf4j.api>1.6.1</version.slf4j.api>
         <version.logback>0.9.29</version.logback>
     </properties>
@@ -51,6 +51,11 @@
                                         <artifactItem>
                                             <groupId>org.modeshape</groupId>
                                             <artifactId>modeshape-common</artifactId>
+                                            <classifier>sources</classifier>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.modeshape</groupId>
+                                            <artifactId>modeshape-sequencer-ddl</artifactId>
                                             <classifier>sources</classifier>
                                         </artifactItem>
                                         <artifactItem>
@@ -105,6 +110,10 @@
                                 <artifactItem>
                                     <groupId>org.modeshape</groupId>
                                     <artifactId>modeshape-common</artifactId>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.modeshape</groupId>
+                                    <artifactId>modeshape-sequencer-ddl</artifactId>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>ch.qos.logback</groupId>
@@ -262,6 +271,10 @@
         <dependency>
             <groupId>org.modeshape</groupId>
             <artifactId>modeshape-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.modeshape</groupId>
+            <artifactId>modeshape-sequencer-ddl</artifactId>
         </dependency>
         <!-- Our code implements a custom logger using LogBack (which implements 
             the SLF4J API) and implements ModeShape's logging factory -->


### PR DESCRIPTION
- Added ddl sequencer jar to the libs
- Set modeshape version to 3.8.0.Final - allows jdk 1.6 for time being.
