### PR TITLE
Provides unit testing for DDL / TSQL sequencers acting together

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/local-repository-config.json
+++ b/plugins/org.komodo.core/src/org/komodo/repository/local-repository-config.json
@@ -12,13 +12,17 @@
         "removeDerivedContentWithOriginal" : true,
         "threadPool" : "modeshape-workers",
         "sequencers" : {
+            "DDL Sequencer" : {
+                "classname" : "DdlSequencer",
+                "pathExpressions" : [ "://(*.ddl/jcr:content)[@jcr:data] => /$1" ]
+            },
             "Teiid SQL Sequencer" : {
-            	"classname" : "org.komodo.modeshape.teiid.TeiidSqlSequencer",
-            	"pathExpressions" : [ "default://(*.tsql)/jcr:content[@jcr:data] => /tsql" ]
-           	},
-           	"DDL Sequencer" : {
-               	"classname" : "DdlSequencer",
-               	"pathExpressions" : [ "default://(*.ddl)/jcr:content[@jcr:data] => /ddl" ]
+                "classname" : "org.komodo.modeshape.teiid.TeiidSqlSequencer",
+                "pathExpressions" :
+                [
+                    "://(*.ddl/ddl:statements/*)[@ddl:queryExpression] => /$1",
+                    "://(*.ddl/ddl:statements//*)[@teiidddl:queryExpression] => /$1"
+                ]
             }
         }
     }

--- a/plugins/org.komodo.modeshape.teiid.sql.sequencer/demigen/org/komodo/modeshape/teiid/cnd/TeiidSql.cnd
+++ b/plugins/org.komodo.modeshape.teiid.sql.sequencer/demigen/org/komodo/modeshape/teiid/cnd/TeiidSql.cnd
@@ -38,17 +38,18 @@
 //==================================================
 //  Derived from Language Object Interfaces
 //==================================================
-[tsql:expressionStatement] mixin
-	- tsql:expectedTypeClass (string)
-	+ tsql:expression (tsql:expression)
-
 [tsql:labeled] mixin
 	- tsql:label (string)
 
 [tsql:targetedCommand] mixin
 	+ tsql:group (tsql:groupSymbol)
 
+[tsql:expressionStatement] mixin
+	- tsql:expectedTypeClass (string)
+	+ tsql:expression (tsql:expression)
+
 [tsql:languageObject] mixin
+	- tsql:teiidVersion (string)
 
 [tsql:expression]	>	tsql:languageObject mixin
 	- tsql:typeClass (string)
@@ -364,7 +365,6 @@
 
 [tsql:declareStatement]	>	tsql:assignmentStatement mixin
 	- tsql:variableType (string)
-	+ tsql:command (tsql:command)
 
 [tsql:returnStatement]	>	tsql:assignmentStatement mixin
 
@@ -398,8 +398,8 @@
 	+ tsql:condition (tsql:criteria)
 
 [tsql:exceptionExpression]	>	tsql:expression mixin
-	+ tsql:message (tsql:expression)
 	+ tsql:errorCode (tsql:expression)
+	+ tsql:message (tsql:expression)
 	+ tsql:sqlState (tsql:expression)
 	+ tsql:parentExpression (tsql:expression)
 
@@ -412,16 +412,16 @@
 [tsql:aggregateSymbol]	>	tsql:function mixin
 	- tsql:windowed (boolean)
 	- tsql:aggregateFunction (string)
-	- tsql:distinct (boolean)
 	- tsql:name (string)
+	- tsql:distinct (boolean)
 	+ tsql:orderBy (tsql:orderBy)
 	+ tsql:args (tsql:expression) sns
 	+ tsql:condition (tsql:expression)
 
 [tsql:symbol]	>	tsql:languageObject mixin abstract
 	- tsql:shortName (string)
-	- tsql:outputName (string)
 	- tsql:name (string)
+	- tsql:outputName (string)
 
 [tsql:aliasSymbol]	>	tsql:symbol, tsql:expression mixin
 	+ tsql:symbol (tsql:expression)

--- a/plugins/org.komodo.modeshape.teiid.sql.sequencer/demigen/org/komodo/modeshape/teiid/cnd/TeiidSqlLexicon.java
+++ b/plugins/org.komodo.modeshape.teiid.sql.sequencer/demigen/org/komodo/modeshape/teiid/cnd/TeiidSqlLexicon.java
@@ -41,39 +41,6 @@ public class TeiidSqlLexicon implements StringConstants {
 	}
 
 	/**
-	 * Property name used for specifying a teiid version. This property should
-	 * be added to the Sequencer's output node prior to sequencing.
-	 */
-	public static String TEIID_VERSION_PROPERTY = Namespace.PREFIX + COLON + "teiidVersion";
-
-	/**
-	 * tsql:expressionStatement
-	 */
-	public interface ExpressionStatement {
-
-		String ID = Namespace.PREFIX + COLON + "expressionStatement";
-
-		/**
-		 * EXPECTED_TYPE_CLASS Property
-		 */
-		String EXPECTED_TYPE_CLASS_PROP_NAME = Namespace.PREFIX + COLON + "expectedTypeClass";
-
-		Class<?> EXPECTED_TYPE_CLASS_PROP_TYPE =  String.class;
-
-		boolean EXPECTED_TYPE_CLASS_PROP_MULTIPLE = false;
-
-		/**
-		 * EXPRESSION Reference
-		 */
-		String EXPRESSION_REF_NAME = Namespace.PREFIX + COLON + "expression";
-
-		Class<?> EXPRESSION_REF_TYPE =  Expression.class;
-
-		boolean EXPRESSION_REF_MULTIPLE = false;
-
-	}
-
-	/**
 	 * tsql:labeled
 	 */
 	public interface Labeled {
@@ -110,11 +77,47 @@ public class TeiidSqlLexicon implements StringConstants {
 	}
 
 	/**
+	 * tsql:expressionStatement
+	 */
+	public interface ExpressionStatement {
+
+		String ID = Namespace.PREFIX + COLON + "expressionStatement";
+
+		/**
+		 * EXPECTED_TYPE_CLASS Property
+		 */
+		String EXPECTED_TYPE_CLASS_PROP_NAME = Namespace.PREFIX + COLON + "expectedTypeClass";
+
+		Class<?> EXPECTED_TYPE_CLASS_PROP_TYPE =  String.class;
+
+		boolean EXPECTED_TYPE_CLASS_PROP_MULTIPLE = false;
+
+		/**
+		 * EXPRESSION Reference
+		 */
+		String EXPRESSION_REF_NAME = Namespace.PREFIX + COLON + "expression";
+
+		Class<?> EXPRESSION_REF_TYPE =  Expression.class;
+
+		boolean EXPRESSION_REF_MULTIPLE = false;
+
+	}
+
+	/**
 	 * tsql:languageObject
 	 */
 	public interface LanguageObject {
 
 		String ID = Namespace.PREFIX + COLON + "languageObject";
+
+		/**
+		 * TEIID_VERSION Property
+		 */
+		String TEIID_VERSION_PROP_NAME = Namespace.PREFIX + COLON + "teiidVersion";
+
+		Class<?> TEIID_VERSION_PROP_TYPE =  String.class;
+
+		boolean TEIID_VERSION_PROP_MULTIPLE = false;
 
 	}
 
@@ -2462,15 +2465,6 @@ public class TeiidSqlLexicon implements StringConstants {
 
 		boolean VARIABLE_TYPE_PROP_MULTIPLE = false;
 
-		/**
-		 * COMMAND Reference
-		 */
-		String COMMAND_REF_NAME = Namespace.PREFIX + COLON + "command";
-
-		Class<?> COMMAND_REF_TYPE =  Command.class;
-
-		boolean COMMAND_REF_MULTIPLE = false;
-
 	}
 
 	/**
@@ -2708,15 +2702,6 @@ public class TeiidSqlLexicon implements StringConstants {
 		boolean IS_ABSTRACT = false;
 
 		/**
-		 * MESSAGE Reference
-		 */
-		String MESSAGE_REF_NAME = Namespace.PREFIX + COLON + "message";
-
-		Class<?> MESSAGE_REF_TYPE =  Expression.class;
-
-		boolean MESSAGE_REF_MULTIPLE = false;
-
-		/**
 		 * ERROR_CODE Reference
 		 */
 		String ERROR_CODE_REF_NAME = Namespace.PREFIX + COLON + "errorCode";
@@ -2724,6 +2709,15 @@ public class TeiidSqlLexicon implements StringConstants {
 		Class<?> ERROR_CODE_REF_TYPE =  Expression.class;
 
 		boolean ERROR_CODE_REF_MULTIPLE = false;
+
+		/**
+		 * MESSAGE Reference
+		 */
+		String MESSAGE_REF_NAME = Namespace.PREFIX + COLON + "message";
+
+		Class<?> MESSAGE_REF_TYPE =  Expression.class;
+
+		boolean MESSAGE_REF_MULTIPLE = false;
 
 		/**
 		 * SQL_STATE Reference
@@ -2820,15 +2814,6 @@ public class TeiidSqlLexicon implements StringConstants {
 		boolean AGGREGATE_FUNCTION_PROP_MULTIPLE = false;
 
 		/**
-		 * DISTINCT Property
-		 */
-		String DISTINCT_PROP_NAME = Namespace.PREFIX + COLON + "distinct";
-
-		Class<?> DISTINCT_PROP_TYPE =  Boolean.class;
-
-		boolean DISTINCT_PROP_MULTIPLE = false;
-
-		/**
 		 * NAME Property
 		 */
 		String NAME_PROP_NAME = Namespace.PREFIX + COLON + "name";
@@ -2836,6 +2821,15 @@ public class TeiidSqlLexicon implements StringConstants {
 		Class<?> NAME_PROP_TYPE =  String.class;
 
 		boolean NAME_PROP_MULTIPLE = false;
+
+		/**
+		 * DISTINCT Property
+		 */
+		String DISTINCT_PROP_NAME = Namespace.PREFIX + COLON + "distinct";
+
+		Class<?> DISTINCT_PROP_TYPE =  Boolean.class;
+
+		boolean DISTINCT_PROP_MULTIPLE = false;
 
 		/**
 		 * ORDER_BY Reference
@@ -2885,15 +2879,6 @@ public class TeiidSqlLexicon implements StringConstants {
 		boolean SHORT_NAME_PROP_MULTIPLE = false;
 
 		/**
-		 * OUTPUT_NAME Property
-		 */
-		String OUTPUT_NAME_PROP_NAME = Namespace.PREFIX + COLON + "outputName";
-
-		Class<?> OUTPUT_NAME_PROP_TYPE =  String.class;
-
-		boolean OUTPUT_NAME_PROP_MULTIPLE = false;
-
-		/**
 		 * NAME Property
 		 */
 		String NAME_PROP_NAME = Namespace.PREFIX + COLON + "name";
@@ -2901,6 +2886,15 @@ public class TeiidSqlLexicon implements StringConstants {
 		Class<?> NAME_PROP_TYPE =  String.class;
 
 		boolean NAME_PROP_MULTIPLE = false;
+
+		/**
+		 * OUTPUT_NAME Property
+		 */
+		String OUTPUT_NAME_PROP_NAME = Namespace.PREFIX + COLON + "outputName";
+
+		Class<?> OUTPUT_NAME_PROP_TYPE =  String.class;
+
+		boolean OUTPUT_NAME_PROP_MULTIPLE = false;
 
 	}
 
@@ -3742,11 +3736,11 @@ public class TeiidSqlLexicon implements StringConstants {
 	 * Enumeration of lexicon classes and their identifiers
 	 */
 	public enum LexTokens {
-		EXPRESSION_STATEMENT (ExpressionStatement.ID, ExpressionStatement.class),
-
 		LABELED (Labeled.ID, Labeled.class),
 
 		TARGETED_COMMAND (TargetedCommand.ID, TargetedCommand.class),
+
+		EXPRESSION_STATEMENT (ExpressionStatement.ID, ExpressionStatement.class),
 
 		LANGUAGE_OBJECT (LanguageObject.ID, LanguageObject.class),
 
@@ -3989,9 +3983,9 @@ public class TeiidSqlLexicon implements StringConstants {
 	private static Map<String, LexTokens> astIndex = new HashMap<String, LexTokens>();
 
 	static {
-		astIndex.put(ExpressionStatement.class.getSimpleName(), LexTokens.EXPRESSION_STATEMENT);
 		astIndex.put(Labeled.class.getSimpleName(), LexTokens.LABELED);
 		astIndex.put(TargetedCommand.class.getSimpleName(), LexTokens.TARGETED_COMMAND);
+		astIndex.put(ExpressionStatement.class.getSimpleName(), LexTokens.EXPRESSION_STATEMENT);
 		astIndex.put(LanguageObject.class.getSimpleName(), LexTokens.LANGUAGE_OBJECT);
 		astIndex.put(Expression.class.getSimpleName(), LexTokens.EXPRESSION);
 		astIndex.put(PredicateCriteria.class.getSimpleName(), LexTokens.PREDICATE_CRITERIA);

--- a/plugins/org.komodo.modeshape.teiid.sql.sequencer/demigen/org/komodo/modeshape/teiid/generators/TeiidCndGenerator.java
+++ b/plugins/org.komodo.modeshape.teiid.sql.sequencer/demigen/org/komodo/modeshape/teiid/generators/TeiidCndGenerator.java
@@ -52,6 +52,7 @@ import org.komodo.spi.annotation.AnnotationUtils;
 import org.komodo.spi.annotation.Removed;
 import org.komodo.spi.annotation.Since;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.runtime.version.ITeiidVersion;
 import org.komodo.spi.runtime.version.TeiidVersion.Version;
 import org.komodo.utils.ArgCheck;
 import org.modeshape.jcr.value.Reference;
@@ -108,7 +109,7 @@ public class TeiidCndGenerator implements GeneratorConstants {
     };
 
     private static final String[] IGNORED_METHOD_NAMES = {
-        "getTeiidParser", "getTeiidVersion"
+        "getTeiidParser"
     };
 
     private static final List<String> IGNORED_METHOD_LIST = Arrays.asList(IGNORED_METHOD_NAMES);
@@ -451,24 +452,6 @@ public class TeiidCndGenerator implements GeneratorConstants {
         lex(PUBLIC + SPACE + CLASS + SPACE + TEIID_SQL_LEXICON + " implements StringConstants" + SPACE + OPEN_BRACE);
         lex(NEW_LINE);
         lex(NEW_LINE);
-    }
-
-    /**
-     * Generate the teiid version property constant of the Lexicon java file
-     *
-     * @throws Exception
-     */
-    private void lexTeiidVersionProperty() throws Exception {
-        StringBuffer buf = new StringBuffer();
-        buf.append(TAB + "/**" + NEW_LINE)
-             .append(TAB + " * Property name used for specifying a teiid version. This property should" + NEW_LINE)
-             .append(TAB + " * be added to the Sequencer's output node prior to sequencing." + NEW_LINE)
-             .append(TAB + " */" + NEW_LINE)
-             .append(TAB + PUBLIC + SPACE + STATIC + SPACE + "String TEIID_VERSION_PROPERTY = ")
-             .append("Namespace.PREFIX + COLON + \"teiidVersion\"" + SEMI_COLON)
-             .append(NEW_LINE)
-             .append(NEW_LINE);
-        lex(buf.toString());
     }
 
     /**
@@ -1221,8 +1204,9 @@ public class TeiidCndGenerator implements GeneratorConstants {
             PropertyAspect propAspect = new PropertyAspect(aspectName, ModeshapeType.STRING, multiple);
             propAspect.setConstraints(constraints);
             aspect = propAspect;
-        }
-        else
+        } else if (parameterClass.equals(ITeiidVersion.class)) {
+            aspect = new PropertyAspect(aspectName, ModeshapeType.STRING, multiple);
+        } else
             System.out.println("The class " + classNode.klazz().getSimpleName() + " has the setter method " + method.getName() + " with a parameter type '" + aspectType + "' is not supported");
 
         if (aspect != null) {
@@ -1595,8 +1579,6 @@ public class TeiidCndGenerator implements GeneratorConstants {
             cndSection1Comment("@generated using " + getClass().getCanonicalName());
             cnd(NEW_LINE);
             writeNamespaces();
-
-            lexTeiidVersionProperty();
 
             cndSection1Comment("NODETYPES");
             writeClassTree();

--- a/plugins/org.komodo.spi/src/org/komodo/spi/runtime/version/TeiidVersionProvider.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/runtime/version/TeiidVersionProvider.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.spi.runtime.version;
+
+import org.komodo.spi.runtime.version.TeiidVersion.Version;
+
+/**
+ * Provider class that holds the default teiid version
+ */
+public final class TeiidVersionProvider {
+
+    private static TeiidVersionProvider instance;
+
+    private ITeiidVersion teiidVersion = Version.DEFAULT_TEIID_VERSION.get();
+
+    /**
+     * @return singleton instance of provider
+     */
+    public static TeiidVersionProvider getInstance() {
+        if (instance == null)
+            instance = new TeiidVersionProvider();
+
+        return instance;
+    }
+
+    private TeiidVersionProvider() {}
+
+    /**
+     * @return the teiidVersion
+     */
+    public ITeiidVersion getTeiidVersion() {
+        return this.teiidVersion;
+    }
+
+    /**
+     * @param teiidVersion the teiidVersion to set
+     */
+    public void setTeiidVersion(ITeiidVersion teiidVersion) {
+        this.teiidVersion = teiidVersion;
+    }
+
+}

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/META-INF/MANIFEST.MF
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/META-INF/MANIFEST.MF
@@ -7,4 +7,5 @@ Bundle-Vendor: %Bundle-Vendor.0
 Fragment-Host: org.komodo.modeshape.teiid.sql.sequencer;bundle-version="[1.0.0,2.0.0)"
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit;bundle-version="4.11.0"
+Require-Bundle: org.junit;bundle-version="4.11.0",
+ org.komodo.spi

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/MultiUseAbstractTest.java
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/MultiUseAbstractTest.java
@@ -21,10 +21,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301 USA.
  */
-package org.komodo.modeshape.teiid.sequencer;
+package org.komodo.modeshape;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
@@ -55,7 +57,7 @@ import org.modeshape.jcr.api.nodetype.NodeTypeManager;
 public abstract class MultiUseAbstractTest {
 
     /**
-     * 
+     * Configuration of the test repository
      */
     private static final String TEST_REPOSITORY_CONFIG = "test-repository-config.json";
 
@@ -135,8 +137,18 @@ public abstract class MultiUseAbstractTest {
         }
     }
 
+    private static File configureLogPath(KLog logger) throws IOException, Exception {
+        File newLogFile = File.createTempFile("TestKLog", ".log");
+        newLogFile.deleteOnExit();
+
+        logger.setLogPath(newLogFile.getAbsolutePath());
+        assertEquals(newLogFile.getAbsolutePath(), logger.getLogPath());
+        return newLogFile;
+    }
+
     @BeforeClass
     public static void beforeAll() throws Exception {
+        configureLogPath(KLog.getLogger());
         startRepository();
         clearRepository();
     }

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/AllTests.java
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/AllTests.java
@@ -23,14 +23,19 @@ package org.komodo.modeshape.teiid;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import org.komodo.modeshape.teiid.sequencer.v8.Test8Sequencers;
 import org.komodo.modeshape.teiid.sequencer.v8.Test8SqlNodeVisitor;
 import org.komodo.modeshape.teiid.sequencer.v8.TestTeiid8SqlSequencer;
+import org.komodo.modeshape.teiid.sequencer.v84.Test84Sequencers;
 import org.komodo.modeshape.teiid.sequencer.v84.Test84SqlNodeVisitor;
 import org.komodo.modeshape.teiid.sequencer.v84.TestTeiid84SqlSequencer;
+import org.komodo.modeshape.teiid.sequencer.v85.Test85Sequencers;
 import org.komodo.modeshape.teiid.sequencer.v85.Test85SqlNodeVisitor;
 import org.komodo.modeshape.teiid.sequencer.v85.TestTeiid85SqlSequencer;
+import org.komodo.modeshape.teiid.sequencer.v86.Test86Sequencers;
 import org.komodo.modeshape.teiid.sequencer.v86.Test86SqlNodeVisitor;
 import org.komodo.modeshape.teiid.sequencer.v86.TestTeiid86SqlSequencer;
+import org.komodo.modeshape.teiid.sequencer.v87.Test87Sequencers;
 import org.komodo.modeshape.teiid.sequencer.v87.Test87SqlNodeVisitor;
 import org.komodo.modeshape.teiid.sequencer.v87.TestTeiid87SqlSequencer;
 import org.komodo.modeshape.teiid.sql.v8.Test8Cloning;
@@ -70,7 +75,14 @@ import org.komodo.modeshape.teiid.sql.v87.TestQuery87Parser;
                                         TestTeiid84SqlSequencer.class,
                                         TestTeiid85SqlSequencer.class,
                                         TestTeiid86SqlSequencer.class,
-                                        TestTeiid87SqlSequencer.class
+                                        TestTeiid87SqlSequencer.class,
+
+                                        // sequencers
+                                        Test8Sequencers.class,
+                                        Test84Sequencers.class,
+                                        Test85Sequencers.class,
+                                        Test86Sequencers.class,
+                                        Test87Sequencers.class
                                     } )
 public class AllTests {
     // nothing to do

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/AbstractTestSequencers.java
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/AbstractTestSequencers.java
@@ -1,0 +1,250 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.modeshape.teiid.sequencer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.jcr.Node;
+import javax.jcr.observation.EventIterator;
+import javax.jcr.observation.EventListener;
+import javax.jcr.observation.ObservationManager;
+import org.junit.Test;
+import org.komodo.modeshape.AbstractSequencerTest;
+import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon.AbstractCompareCriteria;
+import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon.CompareCriteria;
+import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon.ElementSymbol;
+import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon.From;
+import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon.Function;
+import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon.JoinPredicate;
+import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon.MultipleElementSymbol;
+import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon.Query;
+import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon.Select;
+import org.komodo.spi.query.sql.lang.IJoinType;
+import org.komodo.spi.runtime.version.ITeiidVersion;
+import org.modeshape.jcr.api.observation.Event;
+
+/**
+ *
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public abstract class AbstractTestSequencers extends AbstractSequencerTest {
+
+    /**
+     * @param teiidVersion
+     */
+    public AbstractTestSequencers(ITeiidVersion teiidVersion) {
+        super(teiidVersion);
+    }
+
+    /**
+     * @param countdown equivalent to number of sql query expressions to be sequenced
+     * @param pattern wilcarded pattern against which to compare the sequenced nodes
+     * @return the latch for awaiting the sequencing
+     * @throws Exception
+     */
+    protected CountDownLatch addPathLatchListener(int countdown, final String pattern) throws Exception {
+        ObservationManager manager = getObservationManager();
+        assertNotNull(manager);
+
+        final CountDownLatch updateLatch = new CountDownLatch(countdown);
+
+        manager.addEventListener(new EventListener() {
+
+            @Override
+            public void onEvent(EventIterator events) {
+                while (events.hasNext()) {
+                    try {
+                        Event event = (Event) events.nextEvent();
+
+                        String nodePath = event.getPath();
+                        if (nodePath.matches(pattern))
+                            updateLatch.countDown();
+
+                    } catch (Exception ex) {
+                        fail(ex.getMessage());
+                    }
+                }
+            }
+        }, NODE_SEQUENCED, null, true, null, null, false);
+
+        return updateLatch;
+    }
+
+    @Test(timeout = 5000000)
+    public void testBasicDDLStatement() throws Exception {
+        CountDownLatch updateLatch = addPathLatchListener(1, ".*\\/ddl:statements\\/Tweet\\/tsql:query");
+
+        String ddl =  "CREATE VIEW Tweet AS select * FROM twitterview.getTweets;";        
+        Node fileNode = prepareSequence(ddl, SequenceType.DDL);
+
+        // Wait for the starting of the repository or timeout of 3 minutes
+        updateLatch.await(3, TimeUnit.MINUTES);
+
+        traverse(fileNode);
+
+        //
+        // Sequencing completed, now verify
+        //
+
+        // DDL sequencer create the statements node
+        Node statementsNode = fileNode.getNode("ddl:statements");
+        assertNotNull(statementsNode);
+
+        // DDL Sequencer creates the 'Tweet' node 
+        Node tweetNode = statementsNode.getNode("Tweet");
+        assertNotNull(tweetNode);
+
+        // TSQL Sequencer is triggered from the Tweet node's queryExpression property
+        // and sequences its string value into TSQL nodes starting with a query node
+        Node queryNode = verify(tweetNode, Query.ID, Query.ID);
+
+        // Query should have a SELECT
+        Node selectNode = verify(queryNode, Query.SELECT_REF_NAME, Select.ID);
+
+        // Select should have a symbols collection
+        // Select has a * so symbolsNode should be a MultipleElementSymbol
+        verify(selectNode, Select.SYMBOLS_REF_NAME, MultipleElementSymbol.ID);
+
+        // Should have a FROM
+        Node fromNode = verify(queryNode, Query.FROM_REF_NAME, From.ID);
+
+        // UnaryFromClause should have a group
+        verifyUnaryFromClauseGroup(fromNode, From.CLAUSES_REF_NAME, 1, "twitterview.getTweets");
+    }
+
+    @Test(timeout=5000000)
+    public void testComplexDDLStatement() throws Exception {
+        StringBuffer ddl = new StringBuffer();
+
+        ddl.append("CREATE FOREIGN SCHEMA TWITTER (connection-jndi-name=\"java:/twitterDS\":translator-name=\"rest\") ")
+             .append("CREATE VIRTUAL PROCEDURE getTweets(query varchar) RETURNS (created_on varchar(25), from_user varchar(25), to_user varchar(25), ")
+             .append("profile_image_url varchar(25), source varchar(25), text varchar(140)) AS ") 
+                     .append("select tweet.* from ")
+                     .append("(call twitter.invokeHTTP(action => 'GET', endpoint =>querystring(\'',query as \"q\"))) w,  ")
+                             .append("XMLTABLE('results' passing JSONTOXML('myxml', w.result) columns ")
+                             .append("created_on string PATH 'created_at', ")
+                             .append("from_user string PATH 'from_user', ")
+                             .append("to_user string PATH 'to_user', ")
+                             .append("profile_image_url string PATH 'profile_image_url', ") 
+                             .append("source string PATH 'source', ")
+                             .append("text string PATH 'text') tweet; ")
+             .append("CREATE VIEW Tweet AS select * FROM twitterview.getTweets; ")
+             .append("CREATE FOREIGN SCHEMA PARTSSUPPLIER (connection-jndi-name=\"parts-oracle\":translator-name=\"jdbc\"); ")
+             .append("CREATE FOREIGN TABLE PARTSSUPPLIER.PART (id integer PRIMARY KEY,  name   varchar(25), color varchar(25),  weight integer); ") 
+             .append("CREATE VIRTUAL SCHEMA PARTS_VIEWS; ")
+             .append("CREATE VIEW PARTS_VIEWS.PARTS ( ")
+                 .append("PART_ID integer PRIMARY KEY, ")
+                 .append("PART_NAME varchar(255), ")
+                 .append("PART_COLOR varchar(30), ")
+                 .append("PART_WEIGHT varchar(255) ")
+                 .append(") AS ")
+                     .append("SELECT ")
+                         .append("a.id as PART_ID, ")
+                         .append("a.name as PART_NAME, ")
+                         .append("b.color as PART_COLOR, ")
+                         .append("b.weight as PART_WEIGHT ")
+                     .append("FROM PARTSSUPPLIER.part a, PARTSSUPPLIER.part b WHERE a.id = b.id; ")
+             .append("CREATE FOREIGN SCHEMA PRODUCT (connection-jndi-name=\"product-oracle\":translator-name=\"jdbc\"); ")
+             .append("CREATE FOREIGN TABLE PRODUCT.Customer ( ")
+                 .append("id integer PRIMARY KEY, ")
+                 .append("firstname  varchar(25), ")
+                 .append("lastname varchar(25), ")
+                 .append("dob timestamp); ")
+             .append("CREATE FOREIGN TABLE PRODUCT.Order ( ")
+                 .append("id integer PRIMARY KEY, ")
+                 .append("customerid  integer, ")
+                 .append("saledate date, ")
+                 .append("amount decimal(25,4)) (CONSTRAINT FOREIGN  KEY(customerid)  REFERENCES Customer(id)); ")
+             .append("CREATE VIRTUAL SCHEMA PRODUCT_VIEWS; ")
+             .append("CREATE VIEW PRODUCT_VIEWS.CustomerOrders ( ")
+                 .append("name varchar(50), ")
+                 .append("saledate date, ")
+                 .append("amount decimal) OPTIONS (CARDINALITY 100, ANNOTATION 'Example') ")
+                 .append("AS ")
+                 .append("SELECT ")
+                     .append("concat(c.firstname, c.lastname) as name, ")
+                     .append("o.saledate as saledate, ")
+                     .append("o.amount as amount ")
+                     .append("FROM Customer C INNER JOIN o ON c.id = o.customerid; ");
+
+        CountDownLatch updateLatch = addPathLatchListener(3, ".*\\/ddl:statements\\/.*\\/tsql:query");
+
+        Node fileNode = prepareSequence(ddl.toString(), SequenceType.DDL);
+
+        // Wait for the starting of the repository or timeout of 5 minutes
+        updateLatch.await(5, TimeUnit.MINUTES);
+
+        traverse(fileNode);
+
+        //
+        // Sequencing completed, now verify
+        //
+
+        // DDL sequencer create the statements node
+        Node statementsNode = fileNode.getNode("ddl:statements");
+        assertNotNull(statementsNode);
+
+        // DDL Sequencer creates the 'Tweet' node
+        Node tweetNode = statementsNode.getNode("Tweet");
+        assertNotNull(tweetNode);
+        Node queryNode = verify(tweetNode, Query.ID, Query.ID);
+        Node selectNode = verify(queryNode, Query.SELECT_REF_NAME, Select.ID);
+        verify(selectNode, Select.SYMBOLS_REF_NAME, MultipleElementSymbol.ID);
+        Node fromNode = verify(queryNode, Query.FROM_REF_NAME, From.ID);
+        verifyUnaryFromClauseGroup(fromNode, From.CLAUSES_REF_NAME, 1, "twitterview.getTweets");
+
+        // DDL Sequencer create the 'PARTS_VIEWS.PARTS' node
+        Node partsNode = statementsNode.getNode("PARTS_VIEWS.PARTS");
+        assertNotNull(partsNode);
+        queryNode = verify(partsNode, Query.ID, Query.ID);
+        selectNode = verify(queryNode, Query.SELECT_REF_NAME, Select.ID);
+        verifyAliasSymbol(selectNode, Select.SYMBOLS_REF_NAME, 1, "PART_ID", ElementSymbol.ID);
+        verifyAliasSymbol(selectNode, Select.SYMBOLS_REF_NAME, 2, "PART_NAME", ElementSymbol.ID);
+        verifyAliasSymbol(selectNode, Select.SYMBOLS_REF_NAME, 3, "PART_COLOR", ElementSymbol.ID);
+        verifyAliasSymbol(selectNode, Select.SYMBOLS_REF_NAME, 4, "PART_WEIGHT", ElementSymbol.ID);
+        fromNode = verify(queryNode, Query.FROM_REF_NAME, From.ID);
+        verifyUnaryFromClauseGroup(fromNode, From.CLAUSES_REF_NAME, 1, "a");
+        verifyUnaryFromClauseGroup(fromNode, From.CLAUSES_REF_NAME, 2, "b");
+        Node criteriaNode = verify(queryNode, Query.CRITERIA_REF_NAME, CompareCriteria.ID);
+        verifyElementSymbol(criteriaNode, CompareCriteria.RIGHT_EXPRESSION_REF_NAME, "b.id");
+        verifyElementSymbol(criteriaNode, AbstractCompareCriteria.LEFT_EXPRESSION_REF_NAME, "a.id");
+
+        // DDL Sequencer create the 'PRODUCT_VIEWS.CustomerOrders' node
+        Node productNode = statementsNode.getNode("PRODUCT_VIEWS.CustomerOrders");
+        assertNotNull(productNode);
+        queryNode = verify(productNode, Query.ID, Query.ID);
+        selectNode = verify(queryNode, Query.SELECT_REF_NAME, Select.ID);
+        verifyAliasSymbol(selectNode, Select.SYMBOLS_REF_NAME, 1, "name", Function.ID);
+        verifyAliasSymbol(selectNode, Select.SYMBOLS_REF_NAME, 2, "saledate", ElementSymbol.ID);
+        verifyAliasSymbol(selectNode, Select.SYMBOLS_REF_NAME, 3, "amount", ElementSymbol.ID);
+        fromNode = verify(queryNode, Query.FROM_REF_NAME, From.ID);
+        Node fromClause = verify(fromNode, From.CLAUSES_REF_NAME, JoinPredicate.ID);
+        verifyJoin(fromClause, IJoinType.Types.JOIN_INNER);
+        criteriaNode = verify(fromClause, JoinPredicate.JOIN_CRITERIA_REF_NAME, CompareCriteria.ID);
+        verifyElementSymbol(criteriaNode, CompareCriteria.RIGHT_EXPRESSION_REF_NAME, "o.customerid");
+        verifyElementSymbol(criteriaNode, AbstractCompareCriteria.LEFT_EXPRESSION_REF_NAME, "c.id");
+        verifyUnaryFromClauseGroup(fromClause, JoinPredicate.RIGHT_CLAUSE_REF_NAME, "o");
+        verifyUnaryFromClauseGroup(fromClause, JoinPredicate.LEFT_CLAUSE_REF_NAME, "C");
+    }
+}

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v8/Test8Sequencers.java
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v8/Test8Sequencers.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.modeshape.teiid.sequencer.v8;
+
+import org.komodo.modeshape.teiid.sequencer.AbstractTestSequencers;
+import org.komodo.spi.runtime.version.ITeiidVersion;
+import org.komodo.spi.runtime.version.TeiidVersion.Version;
+
+/**
+ *
+ */
+@SuppressWarnings( {"javadoc"} )
+public class Test8Sequencers extends AbstractTestSequencers {
+
+    public Test8Sequencers() {
+        super(Version.TEIID_8_0.get());
+    }
+
+    protected Test8Sequencers(ITeiidVersion teiidVersion) {
+        super(teiidVersion);
+    }
+
+}

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v84/Test84Sequencers.java
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v84/Test84Sequencers.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.modeshape.teiid.sequencer.v84;
+
+import org.komodo.modeshape.teiid.sequencer.v8.Test8Sequencers;
+import org.komodo.spi.runtime.version.ITeiidVersion;
+import org.komodo.spi.runtime.version.TeiidVersion.Version;
+
+/**
+ *
+ */
+@SuppressWarnings( {"javadoc"} )
+public class Test84Sequencers extends Test8Sequencers {
+
+    public Test84Sequencers() {
+        super(Version.TEIID_8_4.get());
+    }
+
+    protected Test84Sequencers(ITeiidVersion teiidVersion) {
+        super(teiidVersion);
+    }
+
+}

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v85/Test85Sequencers.java
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v85/Test85Sequencers.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.modeshape.teiid.sequencer.v85;
+
+import org.komodo.modeshape.teiid.sequencer.v84.Test84Sequencers;
+import org.komodo.spi.runtime.version.ITeiidVersion;
+import org.komodo.spi.runtime.version.TeiidVersion.Version;
+
+/**
+ *
+ */
+@SuppressWarnings( {"javadoc"} )
+public class Test85Sequencers extends Test84Sequencers {
+
+    public Test85Sequencers() {
+        super(Version.TEIID_8_5.get());
+    }
+
+    protected Test85Sequencers(ITeiidVersion teiidVersion) {
+        super(teiidVersion);
+    }
+
+}

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v86/Test86Sequencers.java
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v86/Test86Sequencers.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.modeshape.teiid.sequencer.v86;
+
+import org.komodo.modeshape.teiid.sequencer.v85.Test85Sequencers;
+import org.komodo.spi.runtime.version.ITeiidVersion;
+import org.komodo.spi.runtime.version.TeiidVersion.Version;
+
+/**
+ *
+ */
+@SuppressWarnings( {"javadoc"} )
+public class Test86Sequencers extends Test85Sequencers {
+
+    public Test86Sequencers() {
+        super(Version.TEIID_8_6.get());
+    }
+
+    protected Test86Sequencers(ITeiidVersion teiidVersion) {
+        super(teiidVersion);
+    }
+
+}

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v87/Test87Sequencers.java
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/teiid/sequencer/v87/Test87Sequencers.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.modeshape.teiid.sequencer.v87;
+
+import org.komodo.modeshape.teiid.sequencer.v86.Test86Sequencers;
+import org.komodo.spi.runtime.version.ITeiidVersion;
+import org.komodo.spi.runtime.version.TeiidVersion.Version;
+
+/**
+ *
+ */
+@SuppressWarnings( {"javadoc"} )
+public class Test87Sequencers extends Test86Sequencers {
+
+    public Test87Sequencers() {
+        super(Version.TEIID_8_7.get());
+    }
+
+    protected Test87Sequencers(ITeiidVersion teiidVersion) {
+        super(teiidVersion);
+    }
+
+}

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/test-repository-config.json
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/src/org/komodo/modeshape/test-repository-config.json
@@ -12,9 +12,18 @@
         "removeDerivedContentWithOriginal" : true,
         "threadPool" : "modeshape-workers",
         "sequencers" : {
+        	"DDL Sequencer" : {
+               	"classname" : "DdlSequencer",
+               	"pathExpressions" : [ "://(*.ddl/jcr:content)[@jcr:data] => /$1" ]
+            },
           	"Teiid SQL Sequencer" : {
             	"classname" : "org.komodo.modeshape.teiid.TeiidSqlSequencer",
-            	"pathExpressions" : [ "default://(*.tsql)/jcr:content[@jcr:data] => /tsql" ]
+            	"pathExpressions" :
+                [
+                        "://(*.tsql)/jcr:content[@jcr:data] => /tsql",
+                        "://(*.ddl/ddl:statements//*)[@ddl:queryExpression] => /$1",
+                        "://(*.ddl/ddl:statements//*)[@teiidddl:queryExpression] => /$1"
+                ]
            	}
         }
     }


### PR DESCRIPTION
- *.json
  - Fixes the path expressions of the sequencers so that the TSQL sequencer
    is initialised when a [teiid]ddl:queryExpression property is added to
    the repository
- TeiidSql.cnd
- TeiidSqlLexicon
- TeiidCndGenerator
- TeiidSqlSequencer
  - Rather than storing the teiid version in the output node, it would be
    better to attach it to each language object as it is sequenced
- TeiidVersionProvider
  - The Teiid version is vital to the correct parsing of SQL statements so
    should be obtainable from an easily accessible source. Likewise, it
    should be easily updateable. Thus this provider in the spi simply stores
    the current teiid version value, allowing it to be accessed from the
    sequencers as well as any other part of the application
- Refactors tests to better co-ordinate abstract parent classes and reduce
  method duplication. Also, adds Sequencers tests for testing the
  sequencing of DDL statements using both sequencers
