### PR TITLE
Komodo object

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/RepositoryTools.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/RepositoryTools.java
@@ -1,0 +1,210 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.repository;
+
+import java.io.File;
+import java.io.PrintStream;
+import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoObjectVisitor;
+import org.komodo.spi.repository.Property;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.utils.ArgCheck;
+import org.modeshape.jcr.api.JcrConstants;
+import org.modeshape.jcr.api.JcrTools;
+
+/**
+ * Utility functions for adding remove objects from repositories
+ */
+public class RepositoryTools implements StringConstants {
+
+    private RepositoryTools() {}
+
+    /**
+     * Get or create a KomodoObject at the specified path.
+     * @param transaction transaction
+     * @param parent the parent KomodoObject. may not be null
+     * @param path the path of the desired child KomodoObject. may not be null
+     * @param defaultType the default KomodoObject type. may be null
+     * @param finalType the optional final KomodoObject type. may be null
+     * @return the existing or newly created KomodoObject
+     * @throws Exception if an error occurs
+     * @throws IllegalArgumentException if either the parent or path argument is null
+     */
+    public static KomodoObject findOrCreate(UnitOfWork transaction,
+                                  KomodoObject parent,
+                                  String path,
+                                  String defaultType,
+                                  String finalType ) throws Exception {
+        ArgCheck.isNotNull(parent, "parentKomodoObject"); //$NON-NLS-1$
+        ArgCheck.isNotNull(path, "path"); //$NON-NLS-1$
+        // Remove leading and trailing slashes ...
+        String relPath = path.replaceAll("^/+", "").replaceAll("/+$", ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+
+        // Look for the KomodoObject first ...
+        if (parent.hasChild(transaction, relPath))
+            return parent.getChild(transaction, relPath);
+
+        // Create the KomodoObject, which has to be done segment by segment ...
+        String[] pathSegments = relPath.split("/"); //$NON-NLS-1$
+        KomodoObject komodoObject = parent;
+        for (int i = 0, len = pathSegments.length; i != len; ++i) {
+            String pathSegment = pathSegments[i];
+            pathSegment = pathSegment.trim();
+            if (pathSegment.length() == 0) continue;
+            if (komodoObject.hasChild(transaction, pathSegment)) {
+                // Find the existing KomodoObject ...
+                komodoObject = komodoObject.getChild(transaction, pathSegment);
+            } else {
+                // Make sure there is no index on the final segment ...
+                String pathSegmentWithNoIndex = pathSegment.replaceAll("(\\[\\d+\\])+$", ""); //$NON-NLS-1$ //$NON-NLS-2$
+                // Create the KomodoObject ...
+                String komodoObjectType = defaultType;
+                if (i == len - 1 && finalType != null)
+                    komodoObjectType = finalType;
+
+                if (komodoObjectType != null) {
+                    komodoObject = komodoObject.addChild(transaction, pathSegmentWithNoIndex, komodoObjectType);
+                } else {
+                    komodoObject = komodoObject.addChild(transaction, pathSegmentWithNoIndex, JcrConstants.NT_UNSTRUCTURED);
+                }
+            }
+        }
+
+        return komodoObject;
+    }
+
+    /**
+     * Get or create a KomodoObject with the specified KomodoObject under the specified parent KomodoObject.
+     * @param transaction the transaction
+     * @param parent the parent KomodoObject. may not be null
+     * @param name the name of the child KomodoObject. may not be null
+     * @return the existing or newly created child KomodoObject
+     * @throws Exception if an error occurs
+     * @throws IllegalArgumentException if either the parent or name argument is null
+     */
+    public static KomodoObject findOrCreateChild(UnitOfWork transaction, KomodoObject parent, String name ) throws Exception {
+        return findOrCreateChild(transaction, parent, name, null);
+    }
+
+    /**
+     * Get or create a KomodoObject with the specified KomodoObject and KomodoObject type under the specified parent KomodoObject.
+     * @param transaction the transaction
+     * @param parent the parent KomodoObject. may not be null
+     * @param name the name of the child KomodoObject. may not be null
+     * @param komodoObjectType the KomodoObject type. may be null
+     * @return the existing or newly created child KomodoObject
+     * @throws Exception if an error occurs
+     */
+    public static KomodoObject findOrCreateChild(UnitOfWork transaction,
+                                   KomodoObject parent,
+                                   String name,
+                                   String komodoObjectType ) throws Exception {
+        return findOrCreate(transaction, parent, name, komodoObjectType, komodoObjectType);
+    }
+
+    /**
+     * Traverses the graph of the given {@link KomodoObject} and returns its
+     * String representation.
+     *
+     * @param kObject object to be traversed
+     * @return string representation of object's graph
+     * @throws Exception if error occurs
+     */
+    public static String traverse(KomodoObject kObject) throws Exception {
+        TraversalOutputVisitor visitor = new TraversalOutputVisitor();
+        return visitor.visit(kObject);
+    }
+
+    /**
+     * Visitor for printing out the full tree of a {@link KomodoObject}.
+     *
+     * This can do the same job as {@link JcrTools#printNode(javax.jcr.Node)}, however
+     * the latter only prints to System.out while this visitor returns the string allowing
+     * it to be sent to alternative {@link PrintStream}s.
+     * 
+     */
+    public static class TraversalOutputVisitor implements KomodoObjectVisitor {
+
+        private final StringBuffer buffer = new StringBuffer(NEW_LINE);
+
+        /**
+         * @param property
+         * @return String representation of property and its values
+         * @throws Exception 
+         */
+        private String toString(Property property) throws Exception {
+            StringBuilder sb = new StringBuilder();
+            try {
+                sb.append(property.getName(null)).append('=');
+                if (property.isMultiple()) {
+                    sb.append('[');
+                    Object[] values = property.getValues();
+                    for (int i = 0; i < values.length; ++i) {
+                        Object value = values[i];
+                        sb.append(value);
+                        if ((i + 1) < values.length)
+                            sb.append(',');
+                    }
+                    sb.append(']');
+                } else {
+                    Object value = property.getValue();
+                    sb.append(value);
+                }
+            } catch (Exception e) {
+                sb.append(" on deleted node ").append(property.getAbsolutePath()); //$NON-NLS-1$
+            }
+
+            return sb.toString();
+        }
+
+        private String createIndent(String path) {
+            StringBuffer indent = new StringBuffer(TAB);
+            String[] levels = path.split(File.separator);
+
+            for (int i = 0; i < levels.length; ++i) {
+                indent.append(TAB);
+            }
+
+            return indent.toString();
+        }
+
+        @Override
+        public String visit(KomodoObject object) throws Exception {
+            String indent = createIndent(object.getAbsolutePath());
+            buffer.append(indent + object.getName(null) + NEW_LINE);
+
+            String[] propertyNames = object.getPropertyNames(null);
+
+            for (String propertyName : propertyNames) {
+                Property property = object.getProperty(null, propertyName);
+                buffer.append(indent + TAB + AT + toString(property) + NEW_LINE);
+            }
+
+            KomodoObject[] children = object.getChildren(null);
+            for (int i = 0; i < children.length; ++i)
+                children[i].visit(this);
+
+            return buffer.toString();
+        }
+    }
+}

--- a/plugins/org.komodo.modeshape.teiid.sql.sequencer/src/org/komodo/modeshape/teiid/Messages.java
+++ b/plugins/org.komodo.modeshape.teiid.sql.sequencer/src/org/komodo/modeshape/teiid/Messages.java
@@ -39,43 +39,6 @@ public class Messages {
     private static final String UNDERSCORE = "_"; //$NON-NLS-1$
 
     @SuppressWarnings( "javadoc" )
-    public enum ArgCheck {
-        isNonNegativeInt,
-        isNonPositiveInt,
-        isNegativeInt,
-        isPositiveInt,
-        isStringNonZeroLength,
-        isNonNull,
-        isNull,
-        isInstanceOf,
-        isCollectionNotEmpty,
-        isMapNotEmpty,
-        isArrayNotEmpty,
-        isNotSame,
-        contains,
-        containsKey;
-
-        @Override
-        public String toString() {
-            return getEnumName(this) + DOT + name();
-        }
-    }
-
-    @SuppressWarnings( "javadoc" )
-    public enum MMClob {
-        MMBlob_0,
-        MMBlob_1,
-        MMBlob_2,
-        MMBlob_3;
-
-        @Override
-        public String toString() {
-            // Cannot use dots in enums
-            return getEnumName(this) + DOT + name().replaceAll(UNDERSCORE, DOT);
-        }
-    }
-
-    @SuppressWarnings( "javadoc" )
     public enum TeiidSqlSequencer {
         ErrorSequencingContent,
         ErrorParsingContent;

--- a/plugins/org.komodo.modeshape.teiid.sql.sequencer/src/org/komodo/modeshape/teiid/messages.properties
+++ b/plugins/org.komodo.modeshape.teiid.sql.sequencer/src/org/komodo/modeshape/teiid/messages.properties
@@ -1,24 +1,3 @@
-
-ArgCheck.isNonNegativeInt=Expected argument to be non-negative but argument= {0}
-ArgCheck.isNonPositiveInt=Expected argument to be non-positive but argument= {0}
-ArgCheck.isNegativeInt=Expected argument to be negative but argument= {0}
-ArgCheck.isPositiveInt=Expected argument to be positive but argument= {0}
-ArgCheck.isStringNonZeroLength=Expected argument to have at least one character
-ArgCheck.isNonNull=Expected argument to be non-null but got null
-ArgCheck.isNull=Expected argument to be null but got non-null
-ArgCheck.isInstanceOf=Expected argument to be an instance of {0}; was instance of {1}
-ArgCheck.isCollectionNotEmpty=Expected collection to be non-empty
-ArgCheck.isMapNotEmpty=Expected map to be non-empty
-ArgCheck.isArrayNotEmpty=Expected array to be non-empty
-ArgCheck.isNotSame={0} must not be the same as {1}.
-ArgCheck.contains=Expected collection to contain value, but it did not
-ArgCheck.containsKey=Expected map to contain key, but it did not
-
-MMClob.MMBlob.0=Invalid column index: {0}
-MMClob.MMBlob.1=Invalid length argument to getSubString(): {0}
-MMClob.MMBlob.2=Invalid argument for start position, {0}, must be > 0.
-MMClob.MMBlob.3=Invalid length argument to getBytes(): {0}
-
 TeiidSqlSequencer.ErrorSequencingContent = Error while sequencing the Teiid SQL content: {0}
 TeiidSqlSequencer.ErrorParsingContent = Error while parsing the Teiid SQL content: {0}
 

--- a/plugins/org.komodo.spi/src/org/komodo/spi/constants/StringConstants.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/constants/StringConstants.java
@@ -64,6 +64,11 @@ public interface StringConstants {
     String TAB = "\t"; //$NON-NLS-1$
 
     /**
+     * AT sign.
+     */
+    String AT= "@"; //$NON-NLS-1$
+
+    /**
      * A Comma.
      */
     String COMMA = ","; //$NON-NLS-1$

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
@@ -260,4 +260,11 @@ public interface KomodoObject extends KNode {
                       final String propertyName,
                       final Object... values ) throws KException;
 
+    /**
+     * Visit this object with the given visitor
+     *
+     * @param visitor the visitor
+     * @throws Exception if error occurs
+     */
+    void visit(KomodoObjectVisitor visitor) throws Exception;
 }

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObjectVisitor.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObjectVisitor.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.spi.repository;
+
+/**
+ *
+ */
+public interface KomodoObjectVisitor {
+
+    /**
+     * Visit the given object
+     *
+     * @param object the ojbect to be visited
+     * @return an object according to implementation
+     * @throws Exception if error in visiting occurs
+     */
+    Object visit(KomodoObject object) throws Exception;
+
+}

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/Property.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/Property.java
@@ -136,4 +136,9 @@ public interface Property extends KNode {
      */
     void set( final Object... values ) throws KException;
 
+    /**
+     * @return this property has multiple values
+     * @throws Exception
+     */
+    boolean isMultiple() throws Exception;
 }

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/Repository.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/Repository.java
@@ -55,7 +55,7 @@ public interface Repository {
     /**
      * Library and workspace searches using keywords will use one of these criteria.
      */
-    public enum KeywordCriteria {
+    enum KeywordCriteria {
 
         /**
          * All keywords must be present in the search result.
@@ -84,7 +84,7 @@ public interface Repository {
     /**
      * The repository state.
      */
-    public enum State {
+    enum State {
 
         /**
          * The repository cannot be reached.
@@ -106,7 +106,7 @@ public interface Repository {
     /**
      * The repository type.
      */
-    public enum Type {
+    enum Type {
 
         /**
          * The local workspace repository.
@@ -123,7 +123,7 @@ public interface Repository {
     /**
      * Represents one or more operations grouped together forming a {@link Repository repository} transaction.
      */
-    public interface UnitOfWork {
+    interface UnitOfWork {
 
         /**
          * Saves all changes made during the transaction. If this is a roll back transaction then {@link #rollback()} is called.
@@ -155,7 +155,7 @@ public interface Repository {
     /**
      * A listener notified when a unit of work completes.
      */
-    public interface UnitOfWorkListener {
+    interface UnitOfWorkListener {
 
         /**
          * @param error
@@ -184,7 +184,7 @@ public interface Repository {
      * @throws KException
      *         if the parent path does not exist or an error occurs
      */
-    public KomodoObject add( final UnitOfWork transaction,
+    KomodoObject add( final UnitOfWork transaction,
                              final String parentPath,
                              final String name,
                              final String primaryType ) throws KException;
@@ -213,7 +213,7 @@ public interface Repository {
      * @throws KException
      *         if an error occurs
      */
-    public UnitOfWork createTransaction( final String name,
+    UnitOfWork createTransaction( final String name,
                                          final boolean rollbackOnly,
                                          final UnitOfWorkListener callback ) throws KException;
 
@@ -230,7 +230,7 @@ public interface Repository {
      * @throws KException
      *         if parent path does not exist or an error occurs
      */
-    public ArtifactDescriptor[] find( final UnitOfWork transaction,
+    ArtifactDescriptor[] find( final UnitOfWork transaction,
                                       final List< String > keywords,
                                       final KeywordCriteria criteria,
                                       final String... artifactTypes ) throws KException;
@@ -244,10 +244,12 @@ public interface Repository {
      * @throws KException
      *         if parent path does not exist or an error occurs
      */
-    public ArtifactDescriptor[] find( final UnitOfWork transaction,
+    ArtifactDescriptor[] find( final UnitOfWork transaction,
                                       final String... artifactTypes ) throws KException;
 
     /**
+     * Get an object from the workspace part of the repository.
+     *
      * The path can be workspace relative or absolute.
      *
      * @param transaction
@@ -258,7 +260,7 @@ public interface Repository {
      * @throws KException
      *         if an error occurs
      */
-    public KomodoObject get( final UnitOfWork transaction,
+    KomodoObject getFromWorkspace( final UnitOfWork transaction,
                              final String path ) throws KException;
 
     /**
@@ -272,7 +274,7 @@ public interface Repository {
      * @throws KException
      *         if an error occurs
      */
-    public KomodoObject getUsingId( final UnitOfWork transaction,
+    KomodoObject getUsingId( final UnitOfWork transaction,
                                     final String jcrUuid ) throws KException;
 
     /**
@@ -303,7 +305,7 @@ public interface Repository {
      * @throws KException
      *         if an error occurs
      */
-    public KomodoObject importFile( final UnitOfWork transaction,
+    KomodoObject importFile( final UnitOfWork transaction,
                                     final File file,
                                     final String name,
                                     final String parentPath ) throws KException;
@@ -321,7 +323,7 @@ public interface Repository {
      * @throws KException
      *         if an error occurs
      */
-    public KomodoObject importResource( final UnitOfWork transaction,
+    KomodoObject importResource( final UnitOfWork transaction,
                                         final URL url,
                                         final String name,
                                         final String parentPath ) throws KException;
@@ -350,7 +352,7 @@ public interface Repository {
      * @throws KException
      *         if artifact already exists and not in overwrite mode or an error occurs
      */
-    public void publish( final UnitOfWork transaction,
+    void publish( final UnitOfWork transaction,
                          final boolean overwrite,
                          final ArtifactDescriptor descriptor,
                          final KomodoObject komodoObject ) throws KException;
@@ -363,7 +365,7 @@ public interface Repository {
      * @throws KException
      *         if a workspace path does not exist or an error occurs
      */
-    public void remove( final UnitOfWork transaction,
+    void remove( final UnitOfWork transaction,
                         final String... paths ) throws KException;
 
     /**
@@ -388,7 +390,7 @@ public interface Repository {
      * @throws KException
      *         if an artifact does not exist or an error occurs
      */
-    public Artifact[] retrieve( final UnitOfWork transaction,
+    Artifact[] retrieve( final UnitOfWork transaction,
                                 final String... artifactPaths ) throws KException;
 
     /**
@@ -399,7 +401,28 @@ public interface Repository {
      * @throws KException
      *         if an artifact does not exist in the library or an error occurs
      */
-    public void unpublish( final UnitOfWork transaction,
+    void unpublish( final UnitOfWork transaction,
                            final String... artifactPaths ) throws KException;
 
+    /**
+     * The komodo library in the repository, ie. /tko:komodo/tko:library
+     *
+     * @param transaction
+     *        the transaction (can be <code>null</code> if operation should be automatically committed)
+     *
+     * @return the komodo library
+     * @throws KException if an error occurs
+     */
+    KomodoObject komodoLibrary( final UnitOfWork transaction) throws KException;
+
+    /**
+     * The komodo workspace in the repository, ie. /tko:komodo/tko:workspace
+     *
+     * @param transaction
+     *        the transaction (can be <code>null</code> if operation should be automatically committed)
+     *
+     * @return the komodo workspace
+     * @throws KException if an error occurs
+     */
+    KomodoObject komodoWorkspace( final UnitOfWork transaction) throws KException;
 }

--- a/plugins/org.komodo.teiid.client/common-core/org/teiid/core/util/ArgCheck.java
+++ b/plugins/org.komodo.teiid.client/common-core/org/teiid/core/util/ArgCheck.java
@@ -24,7 +24,7 @@ package org.teiid.core.util;
 
 import java.util.Collection;
 import java.util.Map;
-import org.teiid.runtime.client.Messages;
+import org.komodo.utils.Messages;
 
 
 /**

--- a/plugins/org.komodo.teiid.client/src/org/teiid/runtime/client/Messages.java
+++ b/plugins/org.komodo.teiid.client/src/org/teiid/runtime/client/Messages.java
@@ -39,29 +39,6 @@ public class Messages {
     private static final String UNDERSCORE = "_"; //$NON-NLS-1$
 
     @SuppressWarnings( "javadoc" )
-    public enum ArgCheck {
-        isNonNegativeInt,
-        isNonPositiveInt,
-        isNegativeInt,
-        isPositiveInt,
-        isStringNonZeroLength,
-        isNonNull,
-        isNull,
-        isInstanceOf,
-        isCollectionNotEmpty,
-        isMapNotEmpty,
-        isArrayNotEmpty,
-        isNotSame,
-        contains,
-        containsKey;
-
-        @Override
-        public String toString() {
-            return getEnumName(this) + DOT + name();
-        }
-    }
-
-    @SuppressWarnings( "javadoc" )
     public enum TeiidInstance {
         versionFailure,
         parentNotStartedMessage,

--- a/plugins/org.komodo.teiid.client/src/org/teiid/runtime/client/messages.properties
+++ b/plugins/org.komodo.teiid.client/src/org/teiid/runtime/client/messages.properties
@@ -1,19 +1,3 @@
-
-ArgCheck.isNonNegativeInt=Expected argument to be non-negative but argument= {0}
-ArgCheck.isNonPositiveInt=Expected argument to be non-positive but argument= {0}
-ArgCheck.isNegativeInt=Expected argument to be negative but argument= {0}
-ArgCheck.isPositiveInt=Expected argument to be positive but argument= {0}
-ArgCheck.isStringNonZeroLength=Expected argument to have at least one character
-ArgCheck.isNonNull=Expected argument to be non-null but got null
-ArgCheck.isNull=Expected argument to be null but got non-null
-ArgCheck.isInstanceOf=Expected argument to be an instance of {0}; was instance of {1}
-ArgCheck.isCollectionNotEmpty=Expected collection to be non-empty
-ArgCheck.isMapNotEmpty=Expected map to be non-empty
-ArgCheck.isArrayNotEmpty=Expected array to be non-empty
-ArgCheck.isNotSame={0} must not be the same as {1}.
-ArgCheck.contains=Expected collection to contain value, but it did not
-ArgCheck.containsKey=Expected map to contain key, but it did not
-
 TeiidInstance.versionFailure = Failed to determine teiid version of this host {0}
 TeiidInstance.parentNotStartedMessage = The host {0} is not available
 TeiidInstance.reconnectErrorMsg = Cannot establish a connection to the Teiid instance {0}.

--- a/tests/org.komodo.modeshape.test.utils/META-INF/MANIFEST.MF
+++ b/tests/org.komodo.modeshape.test.utils/META-INF/MANIFEST.MF
@@ -7,8 +7,10 @@ Bundle-Vendor: %Bundle-Vendor.0
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.junit;bundle-version="4.11.0",
+ org.jboss.tools.locus.mockito;bundle-version="1.9.5",
  org.komodo.spi,
  org.komodo.modeshape.lib;bundle-version="1.0.0",
- org.komodo.utils;bundle-version="1.0.0"
+ org.komodo.utils;bundle-version="1.0.0",
+ org.komodo.core
 Export-Package: org.komodo.modeshape.test.utils
 Eclipse-RegisterBuddy: org.komodo.modeshape.lib

--- a/tests/org.komodo.modeshape.test.utils/src/org/komodo/modeshape/test/utils/AbstractLocalRepositoryTest.java
+++ b/tests/org.komodo.modeshape.test.utils/src/org/komodo/modeshape/test/utils/AbstractLocalRepositoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.modeshape.test.utils;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.BeforeClass;
+import org.komodo.repository.LocalRepository;
+import org.komodo.spi.repository.Repository.State;
+import org.komodo.spi.repository.RepositoryClient;
+import org.komodo.spi.repository.RepositoryClientEvent;
+import org.komodo.spi.repository.RepositoryObserver;
+
+/**
+ *
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public class AbstractLocalRepositoryTest extends AbstractLoggingTest {
+
+    protected static LocalRepository _repo = null;
+
+    @BeforeClass
+    public static void getLocalRepositoryInstance() throws Exception {
+
+        _repo = LocalRepository.getInstance();
+        assertThat(_repo.getState(), is(State.UNKNOWN));
+        assertThat(_repo.ping(), is(false));
+
+        final CountDownLatch updateLatch = new CountDownLatch(1);
+        final RepositoryObserver observer = new RepositoryObserver() {
+
+            @Override
+            public void stateChanged() {
+                updateLatch.countDown();
+            }
+        };
+
+        _repo.addObserver(observer);
+
+        // Start the repository
+        final RepositoryClient client = mock(RepositoryClient.class);
+        final RepositoryClientEvent event = RepositoryClientEvent.createStartedEvent(client);
+        _repo.notify(event);
+
+        // Wait for the starting of the repository or timeout of 1 minute
+        if (!updateLatch.await(1, TimeUnit.MINUTES)) {
+            throw new RuntimeException("Local repository did not start");
+        }
+    }
+
+}


### PR DESCRIPTION
* Minor tidy-up of ArgCheck

* Improves resiliance of path field in ObjectImpl where it fails due to use of session.encode/decode. Some paths use these while other's do not

* See commit messages for further details