### PR TITLE
More result set changes

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/KomodoTypeRegistry.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/KomodoTypeRegistry.java
@@ -130,6 +130,8 @@ public class KomodoTypeRegistry {
 
         index(KomodoType.PUSHDOWN_FUNCTION, TeiidDdlLexicon.CreateProcedure.FUNCTION_STATEMENT);
 
+        index(KomodoType.RESULT_SET_COLUMN, TeiidDdlLexicon.CreateProcedure.RESULT_COLUMN);
+
         index(KomodoType.SCHEMA, KomodoLexicon.Schema.NODE_TYPE);
 
         index(KomodoType.STATEMENT_OPTION, StandardDdlLexicon.TYPE_STATEMENT_OPTION);

--- a/plugins/org.komodo.relational/src/org/komodo/relational/internal/TypeResolverRegistry.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/internal/TypeResolverRegistry.java
@@ -35,6 +35,7 @@ import org.komodo.relational.model.internal.ModelImpl;
 import org.komodo.relational.model.internal.ParameterImpl;
 import org.komodo.relational.model.internal.PrimaryKeyImpl;
 import org.komodo.relational.model.internal.PushdownFunctionImpl;
+import org.komodo.relational.model.internal.ResultSetColumnImpl;
 import org.komodo.relational.model.internal.SchemaImpl;
 import org.komodo.relational.model.internal.StatementOptionImpl;
 import org.komodo.relational.model.internal.StoredProcedureImpl;
@@ -118,6 +119,8 @@ public class TypeResolverRegistry {
         index(KomodoType.TABLE, TableImpl.RESOLVER);
 
         index(KomodoType.TABULAR_RESULT_SET, TabularResultSetImpl.RESOLVER);
+
+        index(KomodoType.RESULT_SET_COLUMN, ResultSetColumnImpl.RESOLVER);
 
         index(KomodoType.TEIID, TeiidImpl.RESOLVER);
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/Column.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/Column.java
@@ -299,6 +299,15 @@ public interface Column extends OptionContainer, RelationalObject {
     /**
      * @param transaction
      *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>UUID</code> option (can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    String getUuid( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
      * @return <code>true</code> if auto-incremented
      * @throws KException
      *         if an error occurs
@@ -643,5 +652,16 @@ public interface Column extends OptionContainer, RelationalObject {
      */
     void setUpdatable( final UnitOfWork transaction,
                        final boolean newUpdatable ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newUuid
+     *        the new value of the <code>UUID</code> option (can only be empty when removing)
+     * @throws KException
+     *         if an error occurs
+     */
+    void setUuid( final UnitOfWork transaction,
+                  final String newUuid ) throws KException;
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/ResultSetColumn.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/ResultSetColumn.java
@@ -1,0 +1,236 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.model;
+
+import org.komodo.relational.RelationalConstants;
+import org.komodo.relational.RelationalConstants.Nullable;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+
+/**
+ * Represents a relational model result set column.
+ */
+public interface ResultSetColumn extends OptionContainer, RelationalObject {
+
+    /**
+     * Identifier of this object
+     */
+    KomodoType IDENTIFIER = KomodoType.RESULT_SET_COLUMN;
+
+    /**
+     * An empty array of columns.
+     */
+    ResultSetColumn[] NO_COLUMNS = new ResultSetColumn[0];
+
+    /*
+        [teiidddl:resultColumn] mixin
+        - ddl:datatypeName (string)
+        - ddl:datatypeLength (long)
+        - ddl:datatypePrecision (long)
+        - ddl:datatypeScale (long)
+        - ddl:nullable (string) = 'NULL' mandatory autocreated < 'NULL', 'NOT NULL'
+        + * (ddl:statementOption) = ddl:statementOption
+     */
+
+    /**
+     * The type identifier.
+     */
+    int TYPE_ID = ResultSetColumn.class.hashCode();
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>datatype name</code> property (can be empty)
+     * @throws KException
+     *         if an error occurs
+     * @see RelationalConstants#DEFAULT_DATATYPE_NAME
+     */
+    String getDatatypeName( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>default value</code> property (can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    String getDefaultValue( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>description</code> property (can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    String getDescription( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>datatype length</code> property
+     * @throws KException
+     *         if an error occurs
+     * @see RelationalConstants#DEFAULT_LENGTH
+     */
+    long getLength( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if the query should be automatically committed)
+     * @return the value of the <code>name in source</code> property (can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    String getNameInSource( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>nullable</code> property (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     * @see Nullable#DEFAULT_VALUE
+     */
+    Nullable getNullable( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>datatype precision</code> property
+     * @throws KException
+     *         if an error occurs
+     * @see RelationalConstants#DEFAULT_PRECISION
+     */
+    int getPrecision( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>datatype scale</code> property
+     * @throws KException
+     *         if an error occurs
+     * @see RelationalConstants#DEFAULT_SCALE
+     */
+    int getScale( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>UUID</code> option (can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    String getUuid( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newTypeName
+     *        the new value of the <code>datatype name</code> property
+     * @throws KException
+     *         if an error occurs
+     * @see RelationalConstants#DEFAULT_DATATYPE_NAME
+     */
+    void setDatatypeName( final UnitOfWork transaction,
+                          final String newTypeName ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newDefaultValue
+     *        the new value of the <code>default value</code> property (can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    void setDefaultValue( final UnitOfWork transaction,
+                          final String newDefaultValue ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newDescription
+     *        the new value of the <code>description</code> property (can only be empty when removing)
+     * @throws KException
+     *         if an error occurs
+     */
+    void setDescription( final UnitOfWork transaction,
+                         final String newDescription ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newLength
+     *        the new value of the <code>datatype length</code> property
+     * @throws KException
+     *         if an error occurs
+     * @see RelationalConstants#DEFAULT_LENGTH
+     */
+    void setLength( final UnitOfWork transaction,
+                    final long newLength ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if the update should be automatically committed)
+     * @param newNameInSource
+     *        the new name in source (can only be empty when removing)
+     * @throws KException
+     *         if an error occurs
+     */
+    void setNameInSource( final UnitOfWork transaction,
+                          final String newNameInSource ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newNullable
+     *        the new value of the <code>nullable</code> property (can be <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     * @see Nullable#DEFAULT_VALUE
+     */
+    void setNullable( final UnitOfWork transaction,
+                      final Nullable newNullable ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newPrecision
+     *        the new value of the <code>datatype precision</code> property
+     * @throws KException
+     *         if an error occurs
+     * @see RelationalConstants#DEFAULT_PRECISION
+     */
+    void setPrecision( final UnitOfWork transaction,
+                       final int newPrecision ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newScale
+     *        the new value of the <code>datatype scale</code> property
+     * @throws KException
+     *         if an error occurs
+     * @see RelationalConstants#DEFAULT_SCALE
+     */
+    void setScale( final UnitOfWork transaction,
+                   final int newScale ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newUuid
+     *        the new value of the <code>UUID</code> option (can only be empty when removing)
+     * @throws KException
+     *         if an error occurs
+     */
+    void setUuid( final UnitOfWork transaction,
+                  final String newUuid ) throws KException;
+
+}

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/StoredProcedure.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/StoredProcedure.java
@@ -98,17 +98,19 @@ public interface StoredProcedure extends Procedure {
     /**
      * Deletes the current result set and returns a new one of the requested type.
      *
+     * @param <T>
+     *        the type of result set
      * @param transaction
      *        the transaction (can be <code>null</code> if update should be automatically committed)
-     * @param tabularResultSet
-     *        <code>true</code> if the result set should be tabular; <code>false</code> if the result set is a data type
+     * @param resultSetType
+     *        the type of result set being requested
      * @return the new result set (never <code>null</code>)
      * @throws KException
      *         if an error occurs
      * @see TabularResultSet
      * @see DataTypeResultSet
      */
-    ProcedureResultSet setResultSet( final UnitOfWork transaction,
-                                     final boolean tabularResultSet ) throws KException;
+    < T extends ProcedureResultSet > T setResultSet( final UnitOfWork transaction,
+                                                     final Class< T > resultSetType ) throws KException;
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/TabularResultSet.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/TabularResultSet.java
@@ -14,7 +14,7 @@ import org.komodo.spi.repository.Repository.UnitOfWork;
 /**
  * Represents a tabular result set.
  */
-public interface TabularResultSet extends ProcedureResultSet, Table {
+public interface TabularResultSet extends ProcedureResultSet {
 
     /**
      * Identifier of this object.
@@ -27,85 +27,35 @@ public interface TabularResultSet extends ProcedureResultSet, Table {
     int TYPE_ID = TabularResultSet.class.hashCode();
 
     /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.relational.model.Table#addAccessPattern(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
-     * @throws UnsupportedOperationException
-     *         if called
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param columnName
+     *        the name of the column being added (cannot be empty)
+     * @return the new column (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
      */
-    @Override
-    public AccessPattern addAccessPattern( final UnitOfWork transaction,
-                                           final String accessPatternName ) throws KException;
+    ResultSetColumn addColumn( final UnitOfWork transaction,
+                               final String columnName ) throws KException;
 
     /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.relational.model.Table#addForeignKey(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String,
-     *      org.komodo.relational.model.Table)
-     * @throws UnsupportedOperationException
-     *         if called
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the columns (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
      */
-    @Override
-    public ForeignKey addForeignKey( final UnitOfWork transaction,
-                                     final String foreignKeyName,
-                                     final Table referencedTable ) throws KException;
+    ResultSetColumn[] getColumns( final UnitOfWork transaction ) throws KException;
 
     /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.relational.model.Table#addUniqueConstraint(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      java.lang.String)
-     * @throws UnsupportedOperationException
-     *         if called
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param columnToRemove
+     *        the name of the column being removed (cannot be empty)
+     * @throws KException
+     *         if an error occurs
      */
-    @Override
-    public UniqueConstraint addUniqueConstraint( final UnitOfWork transaction,
-                                                 final String constraintName ) throws KException;
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.relational.model.Table#removeAccessPattern(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      java.lang.String)
-     * @throws UnsupportedOperationException
-     *         if called
-     */
-    @Override
-    public void removeAccessPattern( final UnitOfWork transaction,
-                                     final String accessPatternToRemove ) throws KException;
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.relational.model.Table#removeForeignKey(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
-     * @throws UnsupportedOperationException
-     *         if called
-     */
-    @Override
-    public void removeForeignKey( final UnitOfWork transaction,
-                                  final String foreignKeyToRemove ) throws KException;
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.relational.model.Table#removeUniqueConstraint(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      java.lang.String)
-     * @throws UnsupportedOperationException
-     *         if called
-     */
-    @Override
-    public void removeUniqueConstraint( final UnitOfWork transaction,
-                                        final String constraintToRemove ) throws KException;
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.relational.model.Table#setPrimaryKey(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
-     * @throws UnsupportedOperationException
-     *         if called
-     */
-    @Override
-    public PrimaryKey setPrimaryKey( final UnitOfWork transaction,
-                                     final String newPrimaryKeyName ) throws KException;
+    void removeColumn( final UnitOfWork transaction,
+                       final String columnToRemove ) throws KException;
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ColumnImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ColumnImpl.java
@@ -507,6 +507,22 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.relational.model.Column#getUuid(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getUuid( final UnitOfWork transaction ) throws KException {
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.toString() );
+
+        if (option == null) {
+            return null;
+        }
+
+        return option.getOption( transaction );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.relational.model.Column#isAutoIncremented(org.komodo.spi.repository.Repository.UnitOfWork)
      */
     @Override
@@ -1032,6 +1048,17 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     public void setUpdatable( final UnitOfWork transaction,
                               final boolean newUpdatable ) throws KException {
         setStatementOption(transaction, StandardOptions.UPDATABLE.toString(), Boolean.toString(newUpdatable));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.Column#setUuid(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
+     */
+    @Override
+    public void setUuid( final UnitOfWork transaction,
+                         final String newUuid ) throws KException {
+        setStatementOption( transaction, StandardOptions.UUID.toString(), newUuid );
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/DataTypeResultSetImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/DataTypeResultSetImpl.java
@@ -72,7 +72,7 @@ public final class DataTypeResultSetImpl extends RelationalObjectImpl implements
          * @see org.komodo.relational.internal.TypeResolver#owningClass()
          */
         @Override
-        public Class< ? extends KomodoObject > owningClass() {
+        public Class< DataTypeResultSetImpl > owningClass() {
             return DataTypeResultSetImpl.class;
         }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
@@ -434,7 +434,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
             start += tables.length;
             System.arraycopy( views, 0, result, start, views.length );
 
-            start += sources.length;
+            start += views.length;
             System.arraycopy( sources, 0, result, start, sources.length );
 
             if (uow == null) {

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
@@ -1,0 +1,587 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.model.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
+import org.komodo.relational.RelationalConstants;
+import org.komodo.relational.RelationalConstants.Nullable;
+import org.komodo.relational.RelationalProperties;
+import org.komodo.relational.internal.AdapterFactory;
+import org.komodo.relational.internal.RelationalModelFactory;
+import org.komodo.relational.internal.RelationalObjectImpl;
+import org.komodo.relational.internal.TypeResolver;
+import org.komodo.relational.model.ResultSetColumn;
+import org.komodo.relational.model.StatementOption;
+import org.komodo.relational.model.TabularResultSet;
+import org.komodo.repository.ObjectImpl;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Property;
+import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.utils.ArgCheck;
+import org.komodo.utils.StringUtils;
+import org.modeshape.sequencer.ddl.StandardDdlLexicon;
+import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon.CreateProcedure;
+
+/**
+ * An implementation of a relational model tabular result set column.
+ */
+public final class ResultSetColumnImpl extends RelationalObjectImpl implements ResultSetColumn {
+
+    private enum StandardOptions {
+
+        ANNOTATION,
+        NAMEINSOURCE,
+        UUID
+
+    }
+
+    /**
+     * The resolver of a {@link ResultSetColumn}.
+     */
+    public static final TypeResolver RESOLVER = new TypeResolver() {
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.KomodoObject, java.lang.String, org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public ResultSetColumn create( final UnitOfWork transaction,
+                                       final KomodoObject parent,
+                                       final String id,
+                                       final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
+            final TabularResultSet parentResultSet = adapter.adapt( transaction, parent, TabularResultSet.class );
+            return RelationalModelFactory.createResultSetColumn( transaction, parent.getRepository(), parentResultSet, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
+        @Override
+        public KomodoType identifier() {
+            return IDENTIFIER;
+        }
+
+        @Override
+        public Class< ResultSetColumnImpl > owningClass() {
+            return ResultSetColumnImpl.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         */
+        @Override
+        public boolean resolvable( final UnitOfWork transaction,
+                                   final Repository repository,
+                                   final KomodoObject kobject ) {
+            try {
+                ObjectImpl.validateType( transaction, repository, kobject, CreateProcedure.RESULT_COLUMN );
+                return true;
+            } catch (final Exception e) {
+                // not resolvable
+            }
+
+            return false;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         */
+        @Override
+        public ResultSetColumn resolve( final UnitOfWork transaction,
+                                        final Repository repository,
+                                        final KomodoObject kobject ) throws KException {
+            return new ResultSetColumnImpl( transaction, repository, kobject.getAbsolutePath() );
+        }
+
+    };
+
+    /**
+     * @param uow
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param repository
+     *        the repository where the relational object exists (cannot be <code>null</code>)
+     * @param workspacePath
+     *        the workspace relative path (cannot be empty)
+     * @throws KException
+     *         if an error occurs or if node at specified path is not a column
+     */
+    public ResultSetColumnImpl( final UnitOfWork uow,
+                                final Repository repository,
+                                final String workspacePath ) throws KException {
+        super( uow, repository, workspacePath );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.OptionContainer#getCustomOptions(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public StatementOption[] getCustomOptions( final UnitOfWork uow ) throws KException {
+        UnitOfWork transaction = uow;
+
+        if (transaction == null) {
+            transaction = getRepository().createTransaction( "resultsetcolumnimpl-getCustomOptions", true, null ); //$NON-NLS-1$
+        }
+
+        assert ( transaction != null );
+
+        try {
+            StatementOption[] result = getStatementOptions( transaction );
+
+            if (result.length != 0) {
+                final List< StatementOption > temp = new ArrayList<>( result.length );
+
+                for (final StatementOption option : result) {
+                    if (StandardOptions.valueOf( option.getName( transaction ) ) == null) {
+                        temp.add( option );
+                    }
+                }
+
+                result = temp.toArray( new StatementOption[temp.size()] );
+            }
+
+            if (uow == null) {
+                transaction.commit();
+            }
+
+            return result;
+        } catch (final Exception e) {
+            throw handleError( uow, transaction, e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#getDatatypeName(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getDatatypeName( final UnitOfWork uow ) throws KException {
+        final String value = getObjectProperty( uow, Property.ValueType.STRING, "getDatatypeName", //$NON-NLS-1$
+                                                StandardDdlLexicon.DATATYPE_NAME );
+
+        if (StringUtils.isBlank( value )) {
+            return RelationalConstants.DEFAULT_DATATYPE_NAME;
+        }
+
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#getDefaultValue(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getDefaultValue( final UnitOfWork uow ) throws KException {
+        return getObjectProperty( uow, Property.ValueType.STRING, "getDefaultValue", StandardDdlLexicon.DEFAULT_VALUE ); //$NON-NLS-1$
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#getDescription(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getDescription( final UnitOfWork transaction ) throws KException {
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.ANNOTATION.toString() );
+
+        if (option == null) {
+            return null;
+        }
+
+        return option.getOption( transaction );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#getLength(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public long getLength( final UnitOfWork uow ) throws KException {
+        final Long value = getObjectProperty( uow, Property.ValueType.LONG, "getLength", StandardDdlLexicon.DATATYPE_LENGTH ); //$NON-NLS-1$
+
+        if (value == null) {
+            return RelationalConstants.DEFAULT_LENGTH;
+        }
+
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#getNameInSource(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getNameInSource( final UnitOfWork transaction ) throws KException {
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.NAMEINSOURCE.toString() );
+
+        if (option == null) {
+            return null;
+        }
+
+        return option.getOption( transaction );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#getNullable(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public Nullable getNullable( final UnitOfWork uow ) throws KException {
+        final String value = getObjectProperty( uow, Property.ValueType.STRING, "getNullable", //$NON-NLS-1$
+                                                StandardDdlLexicon.NULLABLE );
+
+        if (StringUtils.isBlank( value )) {
+            return Nullable.DEFAULT_VALUE;
+        }
+
+        return Nullable.fromValue( value );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#getPrecision(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public int getPrecision( final UnitOfWork uow ) throws KException {
+        final Integer value = getObjectProperty( uow, Property.ValueType.INTEGER, "getPrecision", //$NON-NLS-1$
+                                                 StandardDdlLexicon.DATATYPE_PRECISION );
+
+        if (value == null) {
+            return RelationalConstants.DEFAULT_PRECISION;
+        }
+
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#getScale(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public int getScale( final UnitOfWork uow ) throws KException {
+        final Integer value = getObjectProperty( uow, Property.ValueType.INTEGER, "getScale", //$NON-NLS-1$
+                                                 StandardDdlLexicon.DATATYPE_SCALE );
+
+        if (value == null) {
+            return RelationalConstants.DEFAULT_SCALE;
+        }
+
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.OptionContainer#getStatementOptions(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public StatementOption[] getStatementOptions( final UnitOfWork uow ) throws KException {
+        UnitOfWork transaction = uow;
+
+        if (transaction == null) {
+            transaction = getRepository().createTransaction( "resultsetcolumnimpl-getStatementOptions", true, null ); //$NON-NLS-1$
+        }
+
+        assert ( transaction != null );
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug( "getStatementOptions: transaction = {0}", transaction.getName() ); //$NON-NLS-1$
+        }
+
+        try {
+            final List< StatementOption > result = new ArrayList< StatementOption >();
+
+            for (final KomodoObject kobject : getChildrenOfType( transaction, StandardDdlLexicon.TYPE_STATEMENT_OPTION )) {
+                final StatementOption option = new StatementOptionImpl( transaction, getRepository(), kobject.getAbsolutePath() );
+
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug( "getStatementOptions: transaction = {0}, found statement option = {1}", //$NON-NLS-1$
+                                  transaction.getName(),
+                                  kobject.getAbsolutePath() );
+                }
+
+                result.add( option );
+            }
+
+            if (uow == null) {
+                transaction.commit();
+            }
+
+            if (result.isEmpty()) {
+                return StatementOption.NO_OPTIONS;
+            }
+
+            return result.toArray( new StatementOption[result.size()] );
+        } catch (final Exception e) {
+            throw handleError( uow, transaction, e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.repository.ObjectImpl#getTypeIdentifier(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public KomodoType getTypeIdentifier( final UnitOfWork uow ) {
+        return RESOLVER.identifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#getUuid(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getUuid( final UnitOfWork transaction ) throws KException {
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.toString() );
+
+        if (option == null) {
+            return null;
+        }
+
+        return option.getOption( transaction );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.OptionContainer#removeStatementOption(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public void removeStatementOption( final UnitOfWork uow,
+                                       final String optionToRemove ) throws KException {
+        ArgCheck.isNotEmpty( optionToRemove, "optionToRemove" ); //$NON-NLS-1$
+        UnitOfWork transaction = uow;
+
+        if (transaction == null) {
+            transaction = getRepository().createTransaction( "resultsetcolumnimpl-removeStatementOption", false, null ); //$NON-NLS-1$
+        }
+
+        assert ( transaction != null );
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug( "removeStatementOption: transaction = {0}, optionToRemove = {1}", //$NON-NLS-1$
+                          transaction.getName(),
+                          optionToRemove );
+        }
+
+        boolean found = false;
+
+        try {
+            final StatementOption[] options = getStatementOptions( transaction );
+
+            if (options.length != 0) {
+                for (final StatementOption option : options) {
+                    if (optionToRemove.equals( option.getName( transaction ) )) {
+                        removeChild( transaction, optionToRemove );
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!found) {
+                throw new KException( Messages.getString( Relational.STATEMENT_OPTION_NOT_FOUND_TO_REMOVE, optionToRemove ) );
+            }
+
+            if (uow == null) {
+                transaction.commit();
+            }
+        } catch (final Exception e) {
+            throw handleError( uow, transaction, e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#setDatatypeName(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public void setDatatypeName( final UnitOfWork uow,
+                                 final String newTypeName ) throws KException {
+        setObjectProperty( uow, "setDatatypeName", StandardDdlLexicon.DATATYPE_NAME, newTypeName ); //$NON-NLS-1$
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#setDefaultValue(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public void setDefaultValue( final UnitOfWork uow,
+                                 final String newDefaultValue ) throws KException {
+        setObjectProperty( uow, "setDefaultValue", StandardDdlLexicon.DEFAULT_VALUE, newDefaultValue ); //$NON-NLS-1$
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#setDescription(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public void setDescription( final UnitOfWork transaction,
+                                final String newDescription ) throws KException {
+        setStatementOption( transaction, StandardOptions.ANNOTATION.toString(), newDescription );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#setLength(org.komodo.spi.repository.Repository.UnitOfWork, long)
+     */
+    @Override
+    public void setLength( final UnitOfWork uow,
+                           final long newLength ) throws KException {
+        setObjectProperty( uow, "setLength", StandardDdlLexicon.DATATYPE_LENGTH, newLength ); //$NON-NLS-1$
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#setNameInSource(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public void setNameInSource( final UnitOfWork transaction,
+                                 final String newNameInSource ) throws KException {
+        setStatementOption( transaction, StandardOptions.NAMEINSOURCE.toString(), newNameInSource );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#setNullable(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      org.komodo.relational.RelationalConstants.Nullable)
+     */
+    @Override
+    public void setNullable( final UnitOfWork uow,
+                             final Nullable newNullable ) throws KException {
+        setObjectProperty( uow, "setNullable", //$NON-NLS-1$
+                           StandardDdlLexicon.NULLABLE,
+                           ( newNullable == null ) ? Nullable.DEFAULT_VALUE.toString() : newNullable.toString() );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#setPrecision(org.komodo.spi.repository.Repository.UnitOfWork, int)
+     */
+    @Override
+    public void setPrecision( final UnitOfWork uow,
+                              final int newPrecision ) throws KException {
+        setObjectProperty( uow, "setPrecision", StandardDdlLexicon.DATATYPE_PRECISION, newPrecision ); //$NON-NLS-1$
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#setScale(org.komodo.spi.repository.Repository.UnitOfWork, int)
+     */
+    @Override
+    public void setScale( final UnitOfWork uow,
+                          final int newScale ) throws KException {
+        setObjectProperty( uow, "setScale", StandardDdlLexicon.DATATYPE_SCALE, newScale ); //$NON-NLS-1$
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.OptionContainer#setStatementOption(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String, java.lang.String)
+     */
+    @Override
+    public StatementOption setStatementOption( final UnitOfWork uow,
+                                               final String optionName,
+                                               final String optionValue ) throws KException {
+        ArgCheck.isNotEmpty( optionName, "optionName" ); //$NON-NLS-1$
+        UnitOfWork transaction = uow;
+
+        if (transaction == null) {
+            transaction = getRepository().createTransaction( "resultsetcolumnimpl-setStatementOption", false, null ); //$NON-NLS-1$
+        }
+
+        assert ( transaction != null );
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug( "setStatementOption: transaction = {0}, optionName = {1}", //$NON-NLS-1$
+                          transaction.getName(),
+                          optionName );
+        }
+
+        try {
+            StatementOption result = null;
+
+            if (StringUtils.isBlank( optionValue )) {
+                removeStatementOption( transaction, optionName );
+            } else {
+                result = Utils.getOption( transaction, this, optionName );
+
+                if (result == null) {
+                    result = RelationalModelFactory.createStatementOption( transaction,
+                                                                           getRepository(),
+                                                                           this,
+                                                                           optionName,
+                                                                           optionValue );
+                } else {
+                    result.setOption( transaction, optionValue );
+                }
+            }
+
+            if (uow == null) {
+                transaction.commit();
+            }
+
+            return result;
+        } catch (final Exception e) {
+            throw handleError( uow, transaction, e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.ResultSetColumn#setUuid(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
+     */
+    @Override
+    public void setUuid( final UnitOfWork transaction,
+                         final String newUuid ) throws KException {
+        setStatementOption( transaction, StandardOptions.UUID.toString(), newUuid );
+    }
+
+}

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StoredProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StoredProcedureImpl.java
@@ -15,10 +15,12 @@ import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
+import org.komodo.relational.model.DataTypeResultSet;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.ProcedureResultSet;
 import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.model.StoredProcedure;
+import org.komodo.relational.model.TabularResultSet;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
@@ -326,11 +328,12 @@ public final class StoredProcedureImpl extends AbstractProcedureImpl implements 
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.relational.model.StoredProcedure#setResultSet(org.komodo.spi.repository.Repository.UnitOfWork, boolean)
+     * @see org.komodo.relational.model.StoredProcedure#setResultSet(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.Class)
      */
     @Override
-    public ProcedureResultSet setResultSet( final UnitOfWork uow,
-                                            final boolean tabularResultSet ) throws KException {
+    public < T extends ProcedureResultSet > T setResultSet( final UnitOfWork uow,
+                                                            final Class< T > resultSetType ) throws KException {
         UnitOfWork transaction = uow;
 
         if (transaction == null) {
@@ -340,7 +343,9 @@ public final class StoredProcedureImpl extends AbstractProcedureImpl implements 
         assert ( transaction != null );
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug( "setResultSet: transaction = {0}, tabularResultSet = {1}", transaction.getName(), tabularResultSet ); //$NON-NLS-1$
+            LOGGER.debug( "setResultSet: transaction = {0}, resultSetType = {1}", //$NON-NLS-1$
+                          transaction.getName(),
+                          resultSetType.getName() );
         }
 
         try {
@@ -351,12 +356,12 @@ public final class StoredProcedureImpl extends AbstractProcedureImpl implements 
                 removeChild( transaction, resultSet.getName( transaction ) );
             }
 
-            ProcedureResultSet result = null;
+            T result = null;
 
-            if (tabularResultSet) {
-                result = RelationalModelFactory.createTabularResultSet( transaction, getRepository(), this );
-            } else {
-                result = RelationalModelFactory.createDataTypeResultSet( transaction, getRepository(), this );
+            if (resultSetType == TabularResultSet.class) {
+                result = ( T )RelationalModelFactory.createTabularResultSet( transaction, getRepository(), this );
+            } else if (resultSetType == DataTypeResultSet.class) {
+                result = ( T )RelationalModelFactory.createDataTypeResultSet( transaction, getRepository(), this );
             }
 
             if (uow == null) {

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoType.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoType.java
@@ -146,6 +146,11 @@ public enum KomodoType {
     DATA_TYPE_RESULT_SET,
 
     /**
+     * Tabular Result Set Column
+     */
+    RESULT_SET_COLUMN,
+
+    /**
      * Tabular Result Set
      */
     TABULAR_RESULT_SET,

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
@@ -12,6 +12,7 @@ import org.komodo.relational.model.internal.IndexImplTest;
 import org.komodo.relational.model.internal.ModelImplTest;
 import org.komodo.relational.model.internal.ParameterImplTest;
 import org.komodo.relational.model.internal.PrimaryKeyImplTest;
+import org.komodo.relational.model.internal.ResultSetColumnImplTest;
 import org.komodo.relational.model.internal.StatementOptionImplTest;
 import org.komodo.relational.model.internal.TableConstraintTest;
 import org.komodo.relational.model.internal.TableImplTest;
@@ -46,6 +47,7 @@ import org.komodo.relational.workspace.WorkspaceManagerTest;
     ModelImplTest.class,
     ParameterImplTest.class,
     PrimaryKeyImplTest.class,
+    ResultSetColumnImplTest.class,
     StatementOptionImplTest.class,
     TableConstraintTest.class,
     TableImplTest.class,

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
@@ -126,6 +126,16 @@ public final class ColumnImplTest extends RelationalModelTest {
         }
     }
 
+    @Test( expected = KException.class )
+    public void shouldFailSettingEmptyUuidWhenNeverAdded() throws Exception {
+        this.column.setUuid( null, StringConstants.EMPTY_STRING );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailSettingNullUuidWhenNeverAdded() throws Exception {
+        this.column.setUuid( null, null );
+    }
+
     @Test
     public void shouldHaveCorrectName() throws Exception {
         assertThat(this.column.getName(null), is(NAME));
@@ -448,6 +458,13 @@ public final class ColumnImplTest extends RelationalModelTest {
         final boolean value = !Column.DEFAULT_UPDATABLE;
         this.column.setUpdatable(null, value);
         assertThat(this.column.isUpdatable(null), is(value));
+    }
+
+    @Test
+    public void shouldSetUuid() throws Exception {
+        final String value = "uuid";
+        this.column.setUuid( null, value );
+        assertThat( this.column.getUuid( null ), is( value ) );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ResultSetColumnImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ResultSetColumnImplTest.java
@@ -1,0 +1,234 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.model.internal;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import org.komodo.relational.RelationalConstants;
+import org.komodo.relational.RelationalConstants.Nullable;
+import org.komodo.relational.RelationalModelTest;
+import org.komodo.relational.internal.RelationalModelFactory;
+import org.komodo.relational.internal.RelationalObjectImpl;
+import org.komodo.relational.model.Model;
+import org.komodo.relational.model.ResultSetColumn;
+import org.komodo.relational.model.StoredProcedure;
+import org.komodo.relational.model.TabularResultSet;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.spi.KException;
+import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoObject;
+import org.modeshape.sequencer.ddl.StandardDdlLexicon;
+
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ResultSetColumnImplTest extends RelationalModelTest {
+
+    private static final String NAME = "column";
+
+    private ResultSetColumn column;
+    private TabularResultSet resultSet;
+
+    @Before
+    public void init() throws Exception {
+        final Vdb vdb = RelationalModelFactory.createVdb( null, _repo, null, "vdb", "path" );
+        final Model model = RelationalModelFactory.createModel( null, _repo, vdb, "model" );
+        final StoredProcedure procedure = RelationalModelFactory.createStoredProcedure( null, _repo, model, "procedure" );
+        this.resultSet = RelationalModelFactory.createTabularResultSet( null, _repo, procedure );
+        this.column = RelationalModelFactory.createResultSetColumn( null, _repo, this.resultSet, NAME );
+    }
+
+    @Test
+    public void shouldAllowEmptyDescription() throws Exception {
+        this.column.setDescription( null, "blah" );
+        this.column.setDescription( null, StringConstants.EMPTY_STRING );
+        assertThat( this.column.getDescription( null ), is( nullValue() ) );
+    }
+
+    @Test
+    public void shouldAllowEmptyNameInSource() throws Exception {
+        this.column.setNameInSource( null, "blah" );
+        this.column.setNameInSource( null, StringConstants.EMPTY_STRING );
+        assertThat( this.column.getNameInSource( null ), is( nullValue() ) );
+    }
+
+    @Test
+    public void shouldAllowNullDescription() throws Exception {
+        this.column.setDescription( null, "blah" );
+        this.column.setDescription( null, null );
+        assertThat( this.column.getDescription( null ), is( nullValue() ) );
+    }
+
+    @Test
+    public void shouldAllowNullNameInSource() throws Exception {
+        this.column.setNameInSource( null, "blah" );
+        this.column.setNameInSource( null, null );
+        assertThat( this.column.getNameInSource( null ), is( nullValue() ) );
+    }
+
+    @Test
+    public void shouldFailConstructionIfNotResultSetColumn() {
+        if (RelationalObjectImpl.VALIDATE_INITIAL_STATE) {
+            try {
+                new ColumnImpl( null, _repo, _repo.komodoLibrary( null ).getAbsolutePath() );
+                fail();
+            } catch (final KException e) {
+                // expected
+            }
+        }
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailSettingEmptyUuidWhenNeverAdded() throws Exception {
+        this.column.setUuid( null, StringConstants.EMPTY_STRING );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailSettingNullUuidWhenNeverAdded() throws Exception {
+        this.column.setUuid( null, null );
+    }
+
+    @Test
+    public void shouldHaveCorrectName() throws Exception {
+        assertThat( this.column.getName( null ), is( NAME ) );
+    }
+
+    @Test
+    public void shouldHaveDatatypeLengthPropertyDefaultValueAfterConstruction() throws Exception {
+        assertThat( this.column.getLength( null ), is( RelationalConstants.DEFAULT_LENGTH ) );
+        assertThat( this.column.hasProperty( null, StandardDdlLexicon.DATATYPE_LENGTH ), is( false ) );
+    }
+
+    @Test
+    public void shouldHaveDatatypeNamePropertyDefaultValueAfterConstruction() throws Exception {
+        assertThat( this.column.getDatatypeName( null ), is( RelationalConstants.DEFAULT_DATATYPE_NAME ) );
+        assertThat( this.column.hasProperty( null, StandardDdlLexicon.DATATYPE_NAME ), is( false ) );
+    }
+
+    @Test
+    public void shouldHaveDatatypePrecisionPropertyDefaultValueAfterConstruction() throws Exception {
+        assertThat( this.column.getPrecision( null ), is( RelationalConstants.DEFAULT_PRECISION ) );
+        assertThat( this.column.hasProperty( null, StandardDdlLexicon.DATATYPE_PRECISION ), is( false ) );
+    }
+
+    @Test
+    public void shouldHaveDatatypeScalePropertyDefaultValueAfterConstruction() throws Exception {
+        assertThat( this.column.getScale( null ), is( RelationalConstants.DEFAULT_SCALE ) );
+        assertThat( this.column.hasProperty( null, StandardDdlLexicon.DATATYPE_SCALE ), is( false ) );
+    }
+
+    @Test
+    public void shouldHaveNullablePropertyDefaultValueAfterConstruction() throws Exception {
+        assertThat( this.column.hasProperty( null, StandardDdlLexicon.NULLABLE ), is( true ) );
+        assertThat( this.column.getNullable( null ), is( RelationalConstants.Nullable.DEFAULT_VALUE ) );
+        assertThat( this.column.getProperty( null, StandardDdlLexicon.NULLABLE ).getStringValue( null ),
+                    is( RelationalConstants.Nullable.DEFAULT_VALUE.toString() ) );
+    }
+
+    @Test
+    public void shouldHaveParentResultSet() throws Exception {
+        assertThat( this.column.getParent( null ), is( instanceOf( TabularResultSet.class ) ) );
+        assertThat( this.column.getParent( null ), is( ( KomodoObject )this.resultSet ) );
+    }
+
+    @Test
+    public void shouldNotHaveDefaultValueAfterConstruction() throws Exception {
+        assertThat( this.column.getDefaultValue( null ), is( nullValue() ) );
+        assertThat( this.column.hasProperty( null, StandardDdlLexicon.DEFAULT_VALUE ), is( false ) );
+    }
+
+    @Test
+    public void shouldRemoveDefaultValueWithEmptyString() throws Exception {
+        this.column.setDefaultValue( null, "defaultValue" );
+        this.column.setDefaultValue( null, StringConstants.EMPTY_STRING );
+        assertThat( this.column.getDefaultValue( null ), is( nullValue() ) );
+        assertThat( this.column.hasProperty( null, StandardDdlLexicon.DEFAULT_VALUE ), is( false ) );
+    }
+
+    @Test
+    public void shouldRemoveDefaultValueWithNull() throws Exception {
+        this.column.setDefaultValue( null, "defaultValue" );
+        this.column.setDefaultValue( null, null );
+        assertThat( this.column.getDefaultValue( null ), is( nullValue() ) );
+        assertThat( this.column.hasProperty( null, StandardDdlLexicon.DEFAULT_VALUE ), is( false ) );
+    }
+
+    @Test
+    public void shouldSetDatatypeLengthProperty() throws Exception {
+        final long value = ( RelationalConstants.DEFAULT_LENGTH + 10 );
+        this.column.setLength( null, value );
+        assertThat( this.column.getLength( null ), is( value ) );
+        assertThat( this.column.getProperty( null, StandardDdlLexicon.DATATYPE_LENGTH ).getLongValue( null ), is( value ) );
+    }
+
+    @Test
+    public void shouldSetDatatypeNameProperty() throws Exception {
+        final String value = "datatypename";
+        this.column.setDatatypeName( null, value );
+        assertThat( this.column.getDatatypeName( null ), is( value ) );
+        assertThat( this.column.getProperty( null, StandardDdlLexicon.DATATYPE_NAME ).getStringValue( null ), is( value ) );
+    }
+
+    @Test
+    public void shouldSetDatatypePrecisionProperty() throws Exception {
+        final int value = 10;
+        this.column.setPrecision( null, value );
+        assertThat( this.column.getPrecision( null ), is( value ) );
+        assertThat( this.column.getProperty( null, StandardDdlLexicon.DATATYPE_PRECISION ).getLongValue( null ),
+                    is( ( long )value ) );
+    }
+
+    @Test
+    public void shouldSetDatatypeScaleProperty() throws Exception {
+        final int value = 10;
+        this.column.setScale( null, value );
+        assertThat( this.column.getScale( null ), is( value ) );
+        assertThat( this.column.getProperty( null, StandardDdlLexicon.DATATYPE_SCALE ).getLongValue( null ), is( ( long )value ) );
+    }
+
+    @Test
+    public void shouldSetDefaultValueProperty() throws Exception {
+        final String value = "defaultvalue";
+        this.column.setDefaultValue( null, value );
+        assertThat( this.column.getDefaultValue( null ), is( value ) );
+        assertThat( this.column.getProperty( null, StandardDdlLexicon.DEFAULT_VALUE ).getStringValue( null ), is( value ) );
+    }
+
+    @Test
+    public void shouldSetDescription() throws Exception {
+        final String value = "description";
+        this.column.setDescription( null, value );
+        assertThat( this.column.getDescription( null ), is( value ) );
+    }
+
+    @Test
+    public void shouldSetNameInSource() throws Exception {
+        final String value = "nameInSource";
+        this.column.setNameInSource( null, value );
+        assertThat( this.column.getNameInSource( null ), is( value ) );
+    }
+
+    @Test
+    public void shouldSetNullableProperty() throws Exception {
+        final Nullable value = Nullable.NO_NULLS;
+        this.column.setNullable( null, value );
+        assertThat( this.column.getNullable( null ), is( value ) );
+        assertThat( this.column.getProperty( null, StandardDdlLexicon.NULLABLE ).getStringValue( null ), is( value.toString() ) );
+    }
+
+    @Test
+    public void shouldSetUuid() throws Exception {
+        final String value = "uuid";
+        this.column.setUuid( null, value );
+        assertThat( this.column.getUuid( null ), is( value ) );
+    }
+
+}

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StoredProcedureImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StoredProcedureImplTest.java
@@ -85,7 +85,7 @@ public final class StoredProcedureImplTest extends RelationalModelTest {
     @Test
     public void shouldRemoveResultSet() throws Exception {
         final Repository.UnitOfWork uow = _repo.createTransaction( this.name.getMethodName(), false, null );
-        this.procedure.setResultSet( uow, true );
+        this.procedure.setResultSet( uow, TabularResultSet.class );
         this.procedure.removeResultSet( uow );
         uow.commit();
 
@@ -95,7 +95,7 @@ public final class StoredProcedureImplTest extends RelationalModelTest {
     @Test
     public void shouldSetDataTypeResultSet() throws Exception {
         final Repository.UnitOfWork uow = _repo.createTransaction( this.name.getMethodName(), false, null );
-        assertThat( this.procedure.setResultSet( uow, false ), is( notNullValue() ) );
+        assertThat( this.procedure.setResultSet( uow, DataTypeResultSet.class ), is( notNullValue() ) );
         assertThat( this.procedure.getResultSet( uow ), is( instanceOf( DataTypeResultSet.class ) ) );
         uow.commit();
     }
@@ -117,7 +117,7 @@ public final class StoredProcedureImplTest extends RelationalModelTest {
     @Test
     public void shouldSetTabularResultSet() throws Exception {
         final Repository.UnitOfWork uow = _repo.createTransaction( this.name.getMethodName(), false, null );
-        assertThat( this.procedure.setResultSet( uow, true ), is( notNullValue() ) );
+        assertThat( this.procedure.setResultSet( uow, TabularResultSet.class ), is( notNullValue() ) );
         assertThat( this.procedure.getResultSet( uow ), is( instanceOf( TabularResultSet.class ) ) );
         uow.commit();
     }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableImplTest.java
@@ -64,9 +64,10 @@ public final class TableImplTest extends RelationalModelTest {
     @Test
     public void shouldAddColumn() throws Exception {
         final String name = "column";
-        final Column column = this.table.addColumn(null, name);
-        assertThat(column, is(notNullValue()));
-        assertThat(column.getName(null), is(name));
+        final Column column = this.table.addColumn( null, name );
+        assertThat( column, is( notNullValue() ) );
+        assertThat( this.table.getColumns( null ).length, is( 1 ) );
+        assertThat( column.getName( null ), is( name ) );
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/workspace/WorkspaceManagerTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/workspace/WorkspaceManagerTest.java
@@ -31,6 +31,7 @@ import org.komodo.relational.model.PrimaryKey;
 import org.komodo.relational.model.Procedure;
 import org.komodo.relational.model.ProcedureResultSet;
 import org.komodo.relational.model.PushdownFunction;
+import org.komodo.relational.model.ResultSetColumn;
 import org.komodo.relational.model.StoredProcedure;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TabularResultSet;
@@ -290,7 +291,7 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
         final Vdb vdb = createVdb(uow, null, "vdb");
         final Model model = createModel(uow, vdb, "model");
         final StoredProcedure procedure = model.addStoredProcedure(uow, "procedure");
-        final ProcedureResultSet resultSet = procedure.setResultSet(uow, false);
+        final ProcedureResultSet resultSet = procedure.setResultSet(uow, DataTypeResultSet.class);
         final KomodoObject kobject = new ObjectImpl(_repo, resultSet.getAbsolutePath(), resultSet.getIndex());
         assertThat(this.wsMgr.resolve(uow, kobject, DataTypeResultSet.class), is(instanceOf(DataTypeResultSet.class)));
         uow.commit();
@@ -401,7 +402,7 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
         final Vdb vdb = createVdb(uow, null, "vdb");
         final Model model = createModel(uow, vdb, "model");
         final StoredProcedure procedure = model.addStoredProcedure(uow, "procedure");
-        final ProcedureResultSet resultSet = procedure.setResultSet(uow, true);
+        final ProcedureResultSet resultSet = procedure.setResultSet(uow, TabularResultSet.class);
         final KomodoObject kobject = new ObjectImpl(_repo, resultSet.getAbsolutePath(), resultSet.getIndex());
         assertThat(this.wsMgr.resolve(uow, kobject, TabularResultSet.class), is(instanceOf(TabularResultSet.class)));
         uow.commit();
@@ -532,6 +533,16 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
     }
 
     @Test
+    public void shouldCreateResultSetColumn() throws Exception {
+        final Vdb parent = createVdb(null, null, this.name.getMethodName() + "Vdb");
+        final Model model = createModel(null, parent, this.name.getMethodName() + "Model");
+        final AbstractProcedure procedure = RelationalModelFactory.createVirtualProcedure(null, _repo, model, "procedure");
+        final TabularResultSet resultSet = RelationalModelFactory.createTabularResultSet( null, _repo, procedure );
+        final KomodoObject result = wsMgr.create(null, resultSet, "resultSetColumn", KomodoType.RESULT_SET_COLUMN);
+        assertThat(result, is(instanceOf(ResultSetColumn.class)));
+    }
+
+    @Test
     public void shouldCreateAllRelationalObjects() throws Exception {
         KomodoObject workspace = _repo.komodoWorkspace(null);
         Vdb vdb = RelationalModelFactory.createVdb(null, _repo, workspace.getAbsolutePath(), "testControlVdb", "/test1");
@@ -634,6 +645,10 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
                     KomodoObject result = wsMgr.create(null, procedure, "test" + id, type);
                     assertNotNull(result);
                     assertThat(result, is(instanceOf(TabularResultSet.class)));
+                    break;
+                }
+                case RESULT_SET_COLUMN: {
+                    // see separate test
                     break;
                 }
                 case SCHEMA: {


### PR DESCRIPTION
Created ResultSetColumn. Reverting the change in ObjectImpl.getChildrenOfType so that it no longer uses ObjectSearcher (not sure why this doesn't work).