### PR TITLE
Fix to TypeResolver.create To Allow Null Parent

### DIFF
--- a/plugins/org.komodo.relational/src/org/komodo/relational/RelationalConstants.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/RelationalConstants.java
@@ -56,12 +56,9 @@ public interface RelationalConstants {
         }
 
         /**
-         * {@inheritDoc}
-         *
-         * @see java.lang.Enum#toString()
+         * @return the Teiid nullable value (never empty)
          */
-        @Override
-        public String toString() {
+        public String toValue() {
             return this.value;
         }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/internal/AdapterFactory.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/internal/AdapterFactory.java
@@ -83,16 +83,16 @@ public class AdapterFactory {
             TypeResolverRegistry registry = TypeResolverRegistry.getInstance();
             TypeResolver resolver = registry.getResolver(type);
 
-            if (resolver != null && resolver.resolvable(transaction, repository, kObject))
-                result = resolver.resolve(transaction, repository, kObject);
+            if (resolver != null && resolver.resolvable(transaction, kObject))
+                result = resolver.resolve(transaction, kObject);
 
             if (result == null) {
                 // Failed with the type identifier so try to be safe than sorry
                 // and iterate through all resolvers to check this object is really
                 // not resolvable.
                 for (final TypeResolver aResolver : registry.getResolvers()) {
-                    if (aResolver.resolvable(transaction, repository, kObject)) {
-                        result = aResolver.resolve(transaction, repository, kObject);
+                    if (aResolver.resolvable(transaction, kObject)) {
+                        result = aResolver.resolve(transaction, kObject);
                         break;
                     }
                 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalModelFactory.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalModelFactory.java
@@ -121,7 +121,7 @@ public final class RelationalModelFactory {
         try {
             final KomodoObject kobject = repository.add(transaction, parentTable.getAbsolutePath(), accessPatternName, null);
             kobject.addDescriptor(transaction, Constraint.TABLE_ELEMENT);
-            kobject.setProperty(transaction, Constraint.TYPE, AccessPattern.CONSTRAINT_TYPE.toString());
+            kobject.setProperty(transaction, Constraint.TYPE, AccessPattern.CONSTRAINT_TYPE.toValue());
 
             final AccessPattern result = new AccessPatternImpl(transaction, repository, kobject.getAbsolutePath());
 
@@ -405,6 +405,7 @@ public final class RelationalModelFactory {
         try {
             final KomodoObject kobject = repository.add(transaction, parentTable.getAbsolutePath(), foreignKeyName, null);
             kobject.addDescriptor(transaction, Constraint.FOREIGN_KEY_CONSTRAINT);
+            kobject.setProperty(transaction, Constraint.TYPE, ForeignKey.CONSTRAINT_TYPE.toValue());
 
             final ForeignKey fk = new ForeignKeyImpl(transaction, repository, kobject.getAbsolutePath());
             fk.setReferencesTable(transaction, tableReference);
@@ -453,7 +454,7 @@ public final class RelationalModelFactory {
         try {
             final KomodoObject kobject = repository.add( transaction, parentModel.getAbsolutePath(), functionName, null );
             kobject.addDescriptor( transaction, CreateProcedure.FUNCTION_STATEMENT );
-            kobject.setProperty( transaction, SchemaElement.TYPE, SchemaElementType.FOREIGN.toString() );
+            kobject.setProperty( transaction, SchemaElement.TYPE, SchemaElementType.FOREIGN.name() );
             setCreateStatementProperties( transaction, kobject );
 
             final PushdownFunction result = new PushdownFunctionImpl( transaction, repository, kobject.getAbsolutePath() );
@@ -497,7 +498,8 @@ public final class RelationalModelFactory {
 
         try {
             final KomodoObject kobject = repository.add(transaction, parentTable.getAbsolutePath(), indexName, null);
-            kobject.addDescriptor(transaction, Constraint.INDEX_CONSTRAINT.toString());
+            kobject.addDescriptor(transaction, Constraint.INDEX_CONSTRAINT);
+            kobject.setProperty(transaction, Constraint.TYPE, Index.CONSTRAINT_TYPE.toValue());
 
             final Index index = new IndexImpl(transaction, repository, kobject.getAbsolutePath());
 
@@ -576,7 +578,6 @@ public final class RelationalModelFactory {
                                      final Vdb vdb,
                                      final String modelName ) throws KException {
         ArgCheck.isNotNull(repository, "repository"); //$NON-NLS-1$
-        ArgCheck.isNotNull(vdb, "vdb"); //$NON-NLS-1$
         ArgCheck.isNotEmpty(modelName, "modelName"); //$NON-NLS-1$
 
         UnitOfWork transaction = uow;
@@ -587,8 +588,16 @@ public final class RelationalModelFactory {
 
         assert (transaction != null);
 
+        KomodoObject kobject = null;
+
         try {
-            final KomodoObject kobject = vdb.addChild(transaction, modelName, VdbLexicon.Vdb.DECLARATIVE_MODEL);
+            if (vdb == null) {
+                final KomodoObject workspace = repository.komodoWorkspace( transaction );
+                kobject = workspace.addChild(transaction, modelName, VdbLexicon.Vdb.DECLARATIVE_MODEL);
+            } else {
+                kobject = vdb.addChild(transaction, modelName, VdbLexicon.Vdb.DECLARATIVE_MODEL);
+            }
+
             final Model result = new ModelImpl(transaction, repository, kobject.getAbsolutePath());
 
             if (uow == null) {
@@ -772,7 +781,7 @@ public final class RelationalModelFactory {
         try {
             final KomodoObject kobject = repository.add(transaction, parentTable.getAbsolutePath(), primaryKeyName, null);
             kobject.addDescriptor(transaction, Constraint.TABLE_ELEMENT);
-            kobject.setProperty(transaction, Constraint.TYPE, PrimaryKey.CONSTRAINT_TYPE.toString());
+            kobject.setProperty(transaction, Constraint.TYPE, PrimaryKey.CONSTRAINT_TYPE.toValue());
 
             final PrimaryKey result = new PrimaryKeyImpl(transaction, repository, kobject.getAbsolutePath());
 
@@ -820,7 +829,7 @@ public final class RelationalModelFactory {
         try {
             final KomodoObject kobject = repository.add( transaction, parentModel.getAbsolutePath(), procedureName, null );
             kobject.addDescriptor( transaction, CreateProcedure.PROCEDURE_STATEMENT );
-            kobject.setProperty( transaction, SchemaElement.TYPE, SchemaElementType.FOREIGN.toString() );
+            kobject.setProperty( transaction, SchemaElement.TYPE, SchemaElementType.FOREIGN.name() );
             setCreateStatementProperties( transaction, kobject );
 
             final StoredProcedure result = new StoredProcedureImpl( transaction, repository, kobject.getAbsolutePath() );
@@ -1205,7 +1214,7 @@ public final class RelationalModelFactory {
         try {
             final KomodoObject kobject = repository.add(transaction, parentTable.getAbsolutePath(), uniqueConstraintName, null);
             kobject.addDescriptor(transaction, Constraint.TABLE_ELEMENT);
-            kobject.setProperty(transaction, Constraint.TYPE, UniqueConstraint.CONSTRAINT_TYPE);
+            kobject.setProperty(transaction, Constraint.TYPE, UniqueConstraint.CONSTRAINT_TYPE.toValue());
 
             final UniqueConstraint result = new UniqueConstraintImpl(transaction, repository, kobject.getAbsolutePath());
 
@@ -1253,7 +1262,7 @@ public final class RelationalModelFactory {
         try {
             final KomodoObject kobject = repository.add( transaction, parentModel.getAbsolutePath(), functionName, null );
             kobject.addDescriptor( transaction, CreateProcedure.FUNCTION_STATEMENT );
-            kobject.setProperty( transaction, SchemaElement.TYPE, SchemaElementType.VIRTUAL.toString() );
+            kobject.setProperty( transaction, SchemaElement.TYPE, SchemaElementType.VIRTUAL.name() );
             setCreateStatementProperties( transaction, kobject );
 
             final UserDefinedFunction result = new UserDefinedFunctionImpl( transaction, repository, kobject.getAbsolutePath() );
@@ -1451,7 +1460,7 @@ public final class RelationalModelFactory {
         try {
             final KomodoObject kobject = repository.add( transaction, parentModel.getAbsolutePath(), procedureName, null );
             kobject.addDescriptor( transaction, CreateProcedure.PROCEDURE_STATEMENT );
-            kobject.setProperty( transaction, SchemaElement.TYPE, SchemaElementType.VIRTUAL.toString() );
+            kobject.setProperty( transaction, SchemaElement.TYPE, SchemaElementType.VIRTUAL.name() );
             setCreateStatementProperties( transaction, kobject );
 
             final VirtualProcedure result = new VirtualProcedureImpl( transaction, repository, kobject.getAbsolutePath() );

--- a/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalObjectImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalObjectImpl.java
@@ -197,18 +197,16 @@ public abstract class RelationalObjectImpl extends ObjectImpl implements Relatio
 
     protected KomodoObject resolveType( final UnitOfWork transaction,
                                         final KomodoObject kobject ) throws KException {
-        final Repository repository = getRepository();
-
         TypeResolver resolver = getResolverRegistry().getResolver(kobject.getTypeIdentifier(transaction));
-        if (resolver != null && resolver.resolvable(transaction, repository, kobject))
-            return resolver.resolve(transaction, repository, kobject);
+        if (resolver != null && resolver.resolvable(transaction, kobject))
+            return resolver.resolve(transaction, kobject);
 
         // Failed with the type identifier so try to be safe than sorry
         // and iterate through all resolvers to check this object is really
         // not resolvable.
         for (final TypeResolver aResolver : getResolverRegistry().getResolvers()) {
-            if (aResolver.resolvable(transaction, repository, kobject)) {
-                return aResolver.resolve(transaction, repository, kobject);
+            if (aResolver.resolvable(transaction, kobject)) {
+                return aResolver.resolve(transaction, kobject);
             }
         }
 
@@ -250,7 +248,7 @@ public abstract class RelationalObjectImpl extends ObjectImpl implements Relatio
                                          final KomodoObject kobject ) throws KException {
         final TypeResolver resolver = getResolverRegistry().getResolver(kobject.getClass());
 
-        if ((resolver != null) && !resolver.resolvable(transaction, getRepository(), kobject)) {
+        if ((resolver != null) && !resolver.resolvable(transaction, kobject)) {
             throw new KException(Messages.getString(Komodo.INCORRECT_TYPE,
                                                     kobject.getAbsolutePath(),
                                                     kobject.getClass().getSimpleName()));

--- a/plugins/org.komodo.relational/src/org/komodo/relational/internal/TypeResolver.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/internal/TypeResolver.java
@@ -1,10 +1,10 @@
 /*
  * JBoss, Home of Professional Open Source.
-*
-* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
-*
-* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
-*/
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
 package org.komodo.relational.internal;
 
 import org.komodo.relational.RelationalProperties;
@@ -24,60 +24,62 @@ import org.komodo.spi.repository.Repository.UnitOfWork;
 public interface TypeResolver< T extends RelationalObject > {
 
     /**
-     * @return the identifier associated with this resolver
+     * @param transaction
+     *        the transaction (can be <code>null</code> if the operation should be automatically committed)
+     * @param repository
+     *        the repository where the model object will be created (cannot be <code>null</code>)
+     * @param parent
+     *        the parent of the new object (can be <code>null</code>)
+     * @param id
+     *        the identifier/name of the object (cannot be <code>null</code>)
+     * @param type
+     *        the type of the object (cannot be <code>null</code>)
+     * @param properties
+     *        any additional properties required for construction (can be empty)
+     * @return new instance of the resolved object (never <code>null</code>)
+     * @throws KException
+     *         if error occurs
+     */
+    KomodoObject create( final UnitOfWork transaction,
+                         final Repository repository,
+                         final KomodoObject parent,
+                         final String id,
+                         final RelationalProperties properties ) throws KException;
+
+    /**
+     * @return the identifier associated with this resolver (never <code>null</code>)
      */
     KomodoType identifier();
 
     /**
-     * @return the class implementing this type resolver
+     * @return the class this type resolver pertains to (never <code>null</code>)
      */
-    Class<? extends KomodoObject>owningClass();
+    Class< ? extends KomodoObject > owningClass();
 
     /**
      * @param transaction
      *        the transaction (can be <code>null</code> if the operation should be automatically committed)
-     * @param repository
-     *        the repository where the model object will be created (cannot be <code>null</code>)
      * @param kobject
      *        the {@link KomodoObject} being resolved (cannot be <code>null</code>)
-     * @return <code>true</code> if object can be resolved to this resolvers type
+     * @return <code>true</code> if object can be resolved to this resolver's type
      */
     boolean resolvable( final UnitOfWork transaction,
-                        final Repository repository,
                         final KomodoObject kobject );
 
     /**
+     * Converts the specified {@link KomodoObject} to this resolver's strong typed relational object. It is assumed that the
+     * object has been {@link #resolvable(UnitOfWork, KomodoObject) resolved}.
+     *
      * @param transaction
      *        the transaction (can be <code>null</code> if the operation should be automatically committed)
-     * @param repository
-     *        the repository where the model object will be created (cannot be <code>null</code>)
      * @param kobject
      *        the {@link KomodoObject} being resolved (cannot be <code>null</code>)
      * @return the strong typed {@link RelationalObject} (never <code>null</code>)
      * @throws KException
-     *         if the object cannot be resolved or if an error occurs
-     * @see #resolvable(UnitOfWork, Repository, KomodoObject)
+     *         if an error occurs
+     * @see #resolvable(UnitOfWork, KomodoObject)
      */
     T resolve( final UnitOfWork transaction,
-               final Repository repository,
                final KomodoObject kobject ) throws KException;
 
-    /**
-     * @param transaction
-     *        the transaction (can be <code>null</code> if the operation should be automatically committed)
-     * @param parent
-     *        the parent of the new object (cannot be <code>null</code>)
-     * @param id
-     *        the identifier of the object (cannot be <code>null</code>)
-     * @param type
-     *        the type of the object (cannot be <code>null</code>)
-     * @param properties
-     *        any additional properties required for construction
-     * @return new instance of the resolved object
-     * @throws KException if error occurs
-     */
-    KomodoObject create(UnitOfWork transaction,
-                                      KomodoObject parent,
-                                      String id,
-                                      RelationalProperties properties) throws KException;
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/Model.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/Model.java
@@ -38,7 +38,7 @@ public interface Model extends RelationalObject {
         /**
          * The default model type. Value is {@value} .
          */
-        public static final Type DEFAULT = PHYSICAL;
+        public static final Type DEFAULT_VALUE = PHYSICAL;
 
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/Parameter.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/Parameter.java
@@ -30,7 +30,7 @@ public interface Parameter extends OptionContainer, RelationalObject {
     KomodoType IDENTIFIER = KomodoType.PARAMETER;
 
     /**
-     * Represents a
+     * Represents a parameter direction.
      */
     public enum Direction {
 
@@ -82,12 +82,9 @@ public interface Parameter extends OptionContainer, RelationalObject {
         }
 
         /**
-         * {@inheritDoc}
-         *
-         * @see java.lang.Enum#toString()
+         * @return the Teiid direction value (never empty)
          */
-        @Override
-        public String toString() {
+        public String toValue() {
             return this.value;
         }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/PushdownFunction.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/PushdownFunction.java
@@ -51,17 +51,19 @@ public interface PushdownFunction extends Function {
     /**
      * Deletes the current result set and returns a new one of the requested type.
      *
+     * @param <T>
+     *        the type of result set
      * @param transaction
      *        the transaction (can be <code>null</code> if update should be automatically committed)
-     * @param tabularResultSet
-     *        <code>true</code> if the result set should be tabular; <code>false</code> if the result set is a data type
+     * @param resultSetType
+     *        the type of result set being requested
      * @return the new result set (never <code>null</code>)
      * @throws KException
      *         if an error occurs
      * @see TabularResultSet
      * @see DataTypeResultSet
      */
-    ProcedureResultSet setResultSet( final UnitOfWork transaction,
-                                     final boolean tabularResultSet ) throws KException;
+    < T extends ProcedureResultSet > T setResultSet( final UnitOfWork transaction,
+                                                     final Class< T > resultSetType ) throws KException;
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/Table.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/Table.java
@@ -65,12 +65,9 @@ public interface Table extends OptionContainer, RelationalObject, SchemaElement 
         }
 
         /**
-         * {@inheritDoc}
-         *
-         * @see java.lang.Enum#toString()
+         * @return the Teiid value (cannot be empty)
          */
-        @Override
-        public String toString() {
+        public String toValue() {
             return this.value;
         }
 
@@ -314,6 +311,15 @@ public interface Table extends OptionContainer, RelationalObject, SchemaElement 
     /**
      * @param transaction
      *        the transaction (can be <code>null</code> if query should be automatically committed)
+     * @return the value of the <code>UUID</code> option (can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    String getUuid( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if query should be automatically committed)
      * @return <code>true</code> if this is a materialized table
      * @throws KException
      *         if an error occurs
@@ -507,5 +513,16 @@ public interface Table extends OptionContainer, RelationalObject, SchemaElement 
      */
     void setUpdatable( final UnitOfWork transaction,
                        final boolean newUpdatable ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newUuid
+     *        the new value of the <code>UUID</code> option (can only be empty when removing)
+     * @throws KException
+     *         if an error occurs
+     */
+    void setUuid( final UnitOfWork transaction,
+                  final String newUuid ) throws KException;
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/TableConstraint.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/TableConstraint.java
@@ -35,12 +35,9 @@ public interface TableConstraint extends RelationalObject {
         }
 
         /**
-         * {@inheritDoc}
-         *
-         * @see java.lang.Enum#toString()
+         * @return the Teiid value (never empty)
          */
-        @Override
-        public String toString() {
+        public String toValue() {
             return this.type;
         }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AbstractProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AbstractProcedureImpl.java
@@ -39,16 +39,15 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
 
     static Class< ? extends AbstractProcedure > getProcedureType( final UnitOfWork transaction,
                                                                   final KomodoObject kobject ) throws KException {
-        final Repository repo = kobject.getRepository();
         Class< ? extends AbstractProcedure > clazz = null;
 
-        if (PushdownFunctionImpl.RESOLVER.resolvable( transaction, repo, kobject )) {
+        if (PushdownFunctionImpl.RESOLVER.resolvable( transaction, kobject )) {
             clazz = PushdownFunction.class;
-        } else if (UserDefinedFunctionImpl.RESOLVER.resolvable( transaction, repo, kobject )) {
+        } else if (UserDefinedFunctionImpl.RESOLVER.resolvable( transaction, kobject )) {
             clazz = UserDefinedFunction.class;
-        } else if (StoredProcedureImpl.RESOLVER.resolvable( transaction, repo, kobject )) {
+        } else if (StoredProcedureImpl.RESOLVER.resolvable( transaction, kobject )) {
             clazz = StoredProcedure.class;
-        } else if (VirtualProcedureImpl.RESOLVER.resolvable( transaction, repo, kobject )) {
+        } else if (VirtualProcedureImpl.RESOLVER.resolvable( transaction, kobject )) {
             clazz = VirtualProcedure.class;
         } else {
             throw new KException( Messages.getString( Relational.UNEXPECTED_PROCEDURE_TYPE, kobject.getAbsolutePath() ) );
@@ -59,20 +58,10 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
 
     protected enum StandardOptions {
 
-        ANNOTATION( "ANNOTATION" ), //$NON-NLS-1$
-        NAMEINSOURCE( "NAMEINSOURCE" ), //$NON-NLS-1$
-        UPDATECOUNT( "UPDATECOUNT" ), //$NON-NLS-1$
-        UUID( "UUID" ); //$NON-NLS-1$
-
-        private final String name;
-
-        private StandardOptions( final String optionName ) {
-            this.name = optionName;
-        }
-
-        protected String getName() {
-            return this.name;
-        }
+        ANNOTATION,
+        NAMEINSOURCE,
+        UPDATECOUNT,
+        UUID;
 
     }
 
@@ -204,7 +193,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
      */
     @Override
     public String getDescription( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.ANNOTATION.getName() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.ANNOTATION.name() );
 
         if (option == null) {
             return null;
@@ -220,7 +209,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
      */
     @Override
     public String getNameInSource( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.NAMEINSOURCE.getName() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.NAMEINSOURCE.name() );
 
         if (option == null) {
             return null;
@@ -372,7 +361,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
      */
     @Override
     public int getUpdateCount( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UPDATECOUNT.getName() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UPDATECOUNT.name() );
 
         if (option == null) {
             return AbstractProcedure.DEFAULT_UPDATE_COUNT;
@@ -388,7 +377,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
      */
     @Override
     public String getUuid( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.getName() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.name() );
 
         if (option == null) {
             return null;
@@ -508,7 +497,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
     @Override
     public void setDescription( final UnitOfWork transaction,
                                 final String newDescription ) throws KException {
-        setStatementOption( transaction, StandardOptions.ANNOTATION.getName(), newDescription );
+        setStatementOption( transaction, StandardOptions.ANNOTATION.name(), newDescription );
     }
 
     /**
@@ -520,7 +509,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
     @Override
     public void setNameInSource( final UnitOfWork transaction,
                                  final String newNameInSource ) throws KException {
-        setStatementOption( transaction, StandardOptions.NAMEINSOURCE.getName(), newNameInSource );
+        setStatementOption( transaction, StandardOptions.NAMEINSOURCE.name(), newNameInSource );
     }
 
     /**
@@ -532,7 +521,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
     @Override
     public void setSchemaElementType( final UnitOfWork uow,
                                       final SchemaElementType newSchemaElementType ) throws KException {
-        final String newValue = ( ( newSchemaElementType == null ) ? SchemaElementType.DEFAULT_VALUE.toString() : newSchemaElementType.toString() );
+        final String newValue = ( ( newSchemaElementType == null ) ? SchemaElementType.DEFAULT_VALUE.name() : newSchemaElementType.toString() );
         setObjectProperty( uow, "setSchemaElementType", SchemaElement.TYPE, newValue ); //$NON-NLS-1$
     }
 
@@ -598,7 +587,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
     @Override
     public void setUpdateCount( final UnitOfWork transaction,
                                 final int newUpdateCount ) throws KException {
-        setStatementOption( transaction, StandardOptions.UPDATECOUNT.getName(), Integer.toString( newUpdateCount ) );
+        setStatementOption( transaction, StandardOptions.UPDATECOUNT.name(), Integer.toString( newUpdateCount ) );
     }
 
     /**
@@ -610,7 +599,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
     @Override
     public void setUuid( final UnitOfWork transaction,
                          final String newUuid ) throws KException {
-        setStatementOption( transaction, StandardOptions.UUID.getName(), newUuid );
+        setStatementOption( transaction, StandardOptions.UUID.name(), newUuid );
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AccessPatternImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AccessPatternImpl.java
@@ -31,13 +31,41 @@ public final class AccessPatternImpl extends TableConstraintImpl implements Acce
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public AccessPattern create( final UnitOfWork transaction,
+                                     final Repository repository,
+                                     final KomodoObject parent,
+                                     final String id,
+                                     final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Table parentTable = adapter.adapt( transaction, parent, Table.class );
+            return RelationalModelFactory.createAccessPattern( transaction, repository, parentTable, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< AccessPatternImpl > owningClass() {
             return AccessPatternImpl.class;
         }
 
@@ -45,19 +73,19 @@ public final class AccessPatternImpl extends TableConstraintImpl implements Acce
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, Constraint.TABLE_ELEMENT);
-                ObjectImpl.validatePropertyValue(transaction,
-                                                 repository,
-                                                 kobject,
-                                                 Constraint.TYPE,
-                                                 AccessPattern.CONSTRAINT_TYPE.toString());
+                final Repository repository = kobject.getRepository();
+                ObjectImpl.validateType( transaction, repository, kobject, Constraint.TABLE_ELEMENT );
+                ObjectImpl.validatePropertyValue( transaction,
+                                                  repository,
+                                                  kobject,
+                                                  Constraint.TYPE,
+                                                  AccessPattern.CONSTRAINT_TYPE.toValue() );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -70,23 +98,12 @@ public final class AccessPatternImpl extends TableConstraintImpl implements Acce
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public AccessPattern resolve( final UnitOfWork transaction,
-                                      final Repository repository,
                                       final KomodoObject kobject ) throws KException {
-            return new AccessPatternImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public AccessPattern create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Table parentTable = adapter.adapt(transaction, parent, Table.class);
-            return RelationalModelFactory.createAccessPattern(transaction, parent.getRepository(), parentTable, id);
+            return new AccessPatternImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
     };
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ColumnImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ColumnImpl.java
@@ -39,6 +39,7 @@ import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon.CreateTable;
 public final class ColumnImpl extends RelationalObjectImpl implements Column {
 
     private enum StandardOptions {
+
         ANNOTATION,
         CASE_SENSITIVE,
         CHAR_OCTET_LENGTH,
@@ -56,6 +57,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
         SIGNED,
         UPDATABLE,
         UUID
+
     }
 
     /**
@@ -63,13 +65,41 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Column create( UnitOfWork transaction,
+                              Repository repository,
+                              KomodoObject parent,
+                              String id,
+                              RelationalProperties properties ) throws KException {
+            AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
+            Table parentTable = adapter.adapt( transaction, parent, Table.class );
+            return RelationalModelFactory.createColumn( transaction, parent.getRepository(), parentTable, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< ColumnImpl > owningClass() {
             return ColumnImpl.class;
         }
 
@@ -77,14 +107,13 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, CreateTable.TABLE_ELEMENT);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, CreateTable.TABLE_ELEMENT );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -97,23 +126,12 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Column resolve( final UnitOfWork transaction,
-                               final Repository repository,
                                final KomodoObject kobject ) throws KException {
-            return new ColumnImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Column create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Table parentTable = adapter.adapt(transaction, parent, Table.class);
-            return RelationalModelFactory.createColumn(transaction, parent.getRepository(), parentTable, id);
+            return new ColumnImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };
@@ -146,7 +164,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public int getCharOctetLength( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.CHAR_OCTET_LENGTH.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.CHAR_OCTET_LENGTH.name());
 
         if (option == null) {
             return Column.DEFAULT_CHAR_OCTET_LENGTH;
@@ -241,7 +259,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public String getDescription( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.ANNOTATION.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.ANNOTATION.name());
 
         if (option == null) {
             return null;
@@ -257,7 +275,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public long getDistinctValues( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.DISTINCT_VALUES.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.DISTINCT_VALUES.name());
 
         if (option == null) {
             return Column.DEFAULT_DISTINCT_VALUES;
@@ -290,7 +308,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public String getMaxValue( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.MAX_VALUE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.MAX_VALUE.name());
 
         if (option == null) {
             return null;
@@ -306,7 +324,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public String getMinValue( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.MIN_VALUE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.MIN_VALUE.name());
 
         if (option == null) {
             return null;
@@ -322,7 +340,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public String getNameInSource( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.NAMEINSOURCE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.NAMEINSOURCE.name());
 
         if (option == null) {
             return null;
@@ -338,7 +356,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public String getNativeType( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.NATIVE_TYPE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.NATIVE_TYPE.name());
 
         if (option == null) {
             return null;
@@ -371,7 +389,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public long getNullValueCount( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.NULL_VALUE_COUNT.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.NULL_VALUE_COUNT.name());
 
         if (option == null) {
             return Column.DEFAULT_NULL_VALUE_COUNT;
@@ -404,7 +422,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public int getRadix( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.RADIX.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.RADIX.name());
 
         if (option == null) {
             return Column.DEFAULT_RADIX;
@@ -437,7 +455,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public Searchable getSearchable( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.SEARCHABLE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.SEARCHABLE.name());
 
         if (option == null) {
             return Searchable.DEFAULT_VALUE;
@@ -511,7 +529,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
      */
     @Override
     public String getUuid( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.toString() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.name() );
 
         if (option == null) {
             return null;
@@ -552,7 +570,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
 
         assert (transaction != null);
 
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.CASE_SENSITIVE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.CASE_SENSITIVE.name());
 
         if (option == null) {
             return Column.DEFAULT_CASE_SENSITIVE;
@@ -576,7 +594,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
 
         assert (transaction != null);
 
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.CURRENCY.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.CURRENCY.name());
 
         if (option == null) {
             return Column.DEFAULT_CURRENCY;
@@ -600,7 +618,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
 
         assert (transaction != null);
 
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.FIXED_LENGTH.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.FIXED_LENGTH.name());
 
         if (option == null) {
             return Column.DEFAULT_FIXED_LENGTH;
@@ -624,7 +642,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
 
         assert (transaction != null);
 
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.SELECTABLE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.SELECTABLE.name());
 
         if (option == null) {
             return Column.DEFAULT_SELECTABLE;
@@ -648,7 +666,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
 
         assert (transaction != null);
 
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.SIGNED.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.SIGNED.name());
 
         if (option == null) {
             return Column.DEFAULT_SIGNED;
@@ -672,7 +690,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
 
         assert (transaction != null);
 
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.UPDATABLE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.UPDATABLE.name());
 
         if (option == null) {
             return Column.DEFAULT_UPDATABLE;
@@ -751,7 +769,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setCaseSensitive( final UnitOfWork transaction,
                                   final boolean newCaseSensitive ) throws KException {
-        setStatementOption(transaction, StandardOptions.CASE_SENSITIVE.toString(), Boolean.toString(newCaseSensitive));
+        setStatementOption(transaction, StandardOptions.CASE_SENSITIVE.name(), Boolean.toString(newCaseSensitive));
     }
 
     /**
@@ -762,7 +780,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setCharOctetLength( final UnitOfWork transaction,
                                     final int newCharOctetLength ) throws KException {
-        setStatementOption(transaction, StandardOptions.CHAR_OCTET_LENGTH.toString(), Integer.toString(newCharOctetLength));
+        setStatementOption(transaction, StandardOptions.CHAR_OCTET_LENGTH.name(), Integer.toString(newCharOctetLength));
     }
 
     /**
@@ -784,7 +802,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setCurrency( final UnitOfWork transaction,
                              final boolean newCurrency ) throws KException {
-        setStatementOption(transaction, StandardOptions.CURRENCY.toString(), Boolean.toString(newCurrency));
+        setStatementOption(transaction, StandardOptions.CURRENCY.name(), Boolean.toString(newCurrency));
     }
 
     /**
@@ -817,13 +835,13 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setDescription( final UnitOfWork transaction,
                                 final String newDescription ) throws KException {
-        setStatementOption(transaction, StandardOptions.ANNOTATION.toString(), newDescription);
+        setStatementOption(transaction, StandardOptions.ANNOTATION.name(), newDescription);
     }
 
     @Override
     public void setDistinctValues( final UnitOfWork transaction,
                                    final long newDistinctValues ) throws KException {
-        setStatementOption(transaction, StandardOptions.DISTINCT_VALUES.toString(), Long.toString(newDistinctValues));
+        setStatementOption(transaction, StandardOptions.DISTINCT_VALUES.name(), Long.toString(newDistinctValues));
     }
 
     /**
@@ -834,7 +852,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setFixedLength( final UnitOfWork transaction,
                                 final boolean newFixedLength ) throws KException {
-        setStatementOption(transaction, StandardOptions.FIXED_LENGTH.toString(), Boolean.toString(newFixedLength));
+        setStatementOption(transaction, StandardOptions.FIXED_LENGTH.name(), Boolean.toString(newFixedLength));
     }
 
     /**
@@ -856,7 +874,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setMaxValue( final UnitOfWork transaction,
                              final String newMaxValue ) throws KException {
-        setStatementOption(transaction, StandardOptions.MAX_VALUE.toString(), newMaxValue);
+        setStatementOption(transaction, StandardOptions.MAX_VALUE.name(), newMaxValue);
     }
 
     /**
@@ -867,7 +885,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setMinValue( final UnitOfWork transaction,
                              final String newMinValue ) throws KException {
-        setStatementOption(transaction, StandardOptions.MIN_VALUE.toString(), newMinValue);
+        setStatementOption(transaction, StandardOptions.MIN_VALUE.name(), newMinValue);
     }
 
     /**
@@ -878,7 +896,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setNameInSource( final UnitOfWork transaction,
                                  final String newNameInSource ) throws KException {
-        setStatementOption(transaction, StandardOptions.NAMEINSOURCE.toString(), newNameInSource);
+        setStatementOption(transaction, StandardOptions.NAMEINSOURCE.name(), newNameInSource);
     }
 
     /**
@@ -889,7 +907,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setNativeType( final UnitOfWork transaction,
                                final String newNativeType ) throws KException {
-        setStatementOption(transaction, StandardOptions.NATIVE_TYPE.toString(), newNativeType);
+        setStatementOption(transaction, StandardOptions.NATIVE_TYPE.name(), newNativeType);
     }
 
     /**
@@ -903,7 +921,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
                              final Nullable newNullable ) throws KException {
         setObjectProperty(uow, "setNullable", //$NON-NLS-1$
                           StandardDdlLexicon.NULLABLE,
-                          (newNullable == null) ? Nullable.DEFAULT_VALUE.toString() : newNullable.toString());
+                          (newNullable == null) ? Nullable.DEFAULT_VALUE.toValue() : newNullable.toValue());
     }
 
     /**
@@ -914,7 +932,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setNullValueCount( final UnitOfWork transaction,
                                    final long newNullValueCount ) throws KException {
-        setStatementOption(transaction, StandardOptions.NULL_VALUE_COUNT.toString(), Long.toString(newNullValueCount));
+        setStatementOption(transaction, StandardOptions.NULL_VALUE_COUNT.name(), Long.toString(newNullValueCount));
     }
 
     /**
@@ -936,7 +954,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setRadix( final UnitOfWork transaction,
                           final int newRadix ) throws KException {
-        setStatementOption(transaction, StandardOptions.RADIX.toString(), Integer.toString(newRadix));
+        setStatementOption(transaction, StandardOptions.RADIX.name(), Integer.toString(newRadix));
     }
 
     /**
@@ -960,7 +978,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     public void setSearchable( final UnitOfWork transaction,
                                final Searchable newSearchable ) throws KException {
         final String value = ((newSearchable == null) ? Searchable.DEFAULT_VALUE.toString() : newSearchable.toString());
-        setStatementOption(transaction, StandardOptions.SEARCHABLE.toString(), value);
+        setStatementOption(transaction, StandardOptions.SEARCHABLE.name(), value);
     }
 
     /**
@@ -971,7 +989,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setSelectable( final UnitOfWork transaction,
                                final boolean newSelectable ) throws KException {
-        setStatementOption(transaction, StandardOptions.SELECTABLE.toString(), Boolean.toString(newSelectable));
+        setStatementOption(transaction, StandardOptions.SELECTABLE.name(), Boolean.toString(newSelectable));
     }
 
     /**
@@ -982,7 +1000,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setSigned( final UnitOfWork transaction,
                            final boolean newSigned ) throws KException {
-        setStatementOption(transaction, StandardOptions.SIGNED.toString(), Boolean.toString(newSigned));
+        setStatementOption(transaction, StandardOptions.SIGNED.name(), Boolean.toString(newSigned));
     }
 
     /**
@@ -1047,7 +1065,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setUpdatable( final UnitOfWork transaction,
                               final boolean newUpdatable ) throws KException {
-        setStatementOption(transaction, StandardOptions.UPDATABLE.toString(), Boolean.toString(newUpdatable));
+        setStatementOption(transaction, StandardOptions.UPDATABLE.name(), Boolean.toString(newUpdatable));
     }
 
     /**
@@ -1058,7 +1076,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
     @Override
     public void setUuid( final UnitOfWork transaction,
                          final String newUuid ) throws KException {
-        setStatementOption( transaction, StandardOptions.UUID.toString(), newUuid );
+        setStatementOption( transaction, StandardOptions.UUID.name(), newUuid );
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/DataTypeResultSetImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/DataTypeResultSetImpl.java
@@ -42,18 +42,19 @@ public final class DataTypeResultSetImpl extends RelationalObjectImpl implements
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.KomodoObject, java.lang.String, org.komodo.relational.RelationalProperties)
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
          */
         @Override
         public DataTypeResultSet create( final UnitOfWork transaction,
+                                         final Repository repository,
                                          final KomodoObject parent,
                                          final String id,
                                          final RelationalProperties properties ) throws KException {
-            final Repository repo = parent.getRepository();
             final Class< ? extends AbstractProcedure > clazz = AbstractProcedureImpl.getProcedureType( transaction, parent );
-            final AdapterFactory adapter = new AdapterFactory( repo );
+            final AdapterFactory adapter = new AdapterFactory( repository );
             final AbstractProcedure parentProc = adapter.adapt( transaction, parent, clazz );
-            return RelationalModelFactory.createDataTypeResultSet( transaction, repo, parentProc );
+            return RelationalModelFactory.createDataTypeResultSet( transaction, repository, parentProc );
         }
 
         /**
@@ -80,16 +81,15 @@ public final class DataTypeResultSetImpl extends RelationalObjectImpl implements
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
                 // must have the right name
                 if (CreateProcedure.RESULT_SET.equals( kobject.getName( transaction ) )) {
-                    ObjectImpl.validateType( transaction, repository, kobject, CreateProcedure.RESULT_DATA_TYPE );
+                    ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, CreateProcedure.RESULT_DATA_TYPE );
                     return true;
                 }
             } catch (final KException e) {
@@ -103,13 +103,12 @@ public final class DataTypeResultSetImpl extends RelationalObjectImpl implements
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public DataTypeResultSet resolve( final UnitOfWork transaction,
-                                          final Repository repository,
                                           final KomodoObject kobject ) throws KException {
-            return new DataTypeResultSetImpl( transaction, repository, kobject.getAbsolutePath() );
+            return new DataTypeResultSetImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };
@@ -253,7 +252,7 @@ public final class DataTypeResultSetImpl extends RelationalObjectImpl implements
         final String value = getObjectProperty( uow, Property.ValueType.STRING, "getDataType", StandardDdlLexicon.DATATYPE_NAME ); //$NON-NLS-1$
 
         if (StringUtils.isBlank( value )) {
-            setObjectProperty( uow, "setArray", StandardDdlLexicon.DATATYPE_NAME, ( Type.DEFAULT_VALUE.toString() + ARRAY_SUFFIX ) ); //$NON-NLS-1$
+            setObjectProperty( uow, "setArray", StandardDdlLexicon.DATATYPE_NAME, ( Type.DEFAULT_VALUE.name() + ARRAY_SUFFIX ) ); //$NON-NLS-1$
         } else if (!value.endsWith( ARRAY_SUFFIX )) {
             setObjectProperty( uow, "setArray", StandardDdlLexicon.DATATYPE_NAME, ( value + ARRAY_SUFFIX ) ); //$NON-NLS-1$
         }
@@ -282,9 +281,9 @@ public final class DataTypeResultSetImpl extends RelationalObjectImpl implements
         String newValue = null;
 
         if (newType == null) {
-            newValue = Type.DEFAULT_VALUE.toString();
+            newValue = Type.DEFAULT_VALUE.name();
         } else {
-            newValue = newType.toString();
+            newValue = newType.name();
         }
 
         if (isArray( uow )) {

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ForeignKeyImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ForeignKeyImpl.java
@@ -37,13 +37,43 @@ public final class ForeignKeyImpl extends TableConstraintImpl implements Foreign
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public ForeignKey create( final UnitOfWork transaction,
+                                  final Repository repository,
+                                  final KomodoObject parent,
+                                  final String id,
+                                  final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Table parentTable = adapter.adapt( transaction, parent, Table.class );
+            final Object keyRefValue = properties.getValue( Constraint.FOREIGN_KEY_CONSTRAINT );
+            final Table keyRef = adapter.adapt( transaction, keyRefValue, Table.class );
+            return RelationalModelFactory.createForeignKey( transaction, repository, parentTable, id, keyRef );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< ForeignKeyImpl > owningClass() {
             return ForeignKeyImpl.class;
         }
 
@@ -51,19 +81,18 @@ public final class ForeignKeyImpl extends TableConstraintImpl implements Foreign
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, Constraint.FOREIGN_KEY_CONSTRAINT);
-                ObjectImpl.validatePropertyValue(transaction,
-                                                 repository,
-                                                 kobject,
-                                                 Constraint.TYPE,
-                                                 ForeignKey.CONSTRAINT_TYPE.toString());
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, Constraint.FOREIGN_KEY_CONSTRAINT );
+                ObjectImpl.validatePropertyValue( transaction,
+                                                  kobject.getRepository(),
+                                                  kobject,
+                                                  Constraint.TYPE,
+                                                  ForeignKey.CONSTRAINT_TYPE.toValue() );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -76,25 +105,12 @@ public final class ForeignKeyImpl extends TableConstraintImpl implements Foreign
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public ForeignKey resolve( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) throws KException {
-            return new ForeignKeyImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public ForeignKey create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Object keyRefValue = properties.getValue(Constraint.FOREIGN_KEY_CONSTRAINT);
-            Table parentTable = adapter.adapt(transaction, parent, Table.class);
-            Table keyRef = adapter.adapt(transaction, keyRefValue, Table.class);
-            return RelationalModelFactory.createForeignKey(transaction, parent.getRepository(), parentTable, id, keyRef);
+            return new ForeignKeyImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/FunctionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/FunctionImpl.java
@@ -312,7 +312,7 @@ public abstract class FunctionImpl extends AbstractProcedureImpl implements Func
     @Override
     public void setDeterminism( final UnitOfWork transaction,
                                 final Determinism newDeterminism ) throws KException {
-        final String value = ( ( newDeterminism == null ) ? Determinism.DEFAULT_VALUE.toString() : newDeterminism.toString() );
+        final String value = ( ( newDeterminism == null ) ? Determinism.DEFAULT_VALUE.toString() : newDeterminism.name() );
         setStatementOption( transaction, StandardOptions.DETERMINISM.getName(), value );
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/IndexImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/IndexImpl.java
@@ -32,13 +32,41 @@ public final class IndexImpl extends TableConstraintImpl implements Index {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Index create( final UnitOfWork transaction,
+                             final Repository repository,
+                             final KomodoObject parent,
+                             final String id,
+                             final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Table parentTable = adapter.adapt( transaction, parent, Table.class );
+            return RelationalModelFactory.createIndex( transaction, repository, parentTable, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< IndexImpl > owningClass() {
             return IndexImpl.class;
         }
 
@@ -46,19 +74,18 @@ public final class IndexImpl extends TableConstraintImpl implements Index {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, Constraint.INDEX_CONSTRAINT);
-                ObjectImpl.validatePropertyValue(transaction,
-                                                 repository,
-                                                 kobject,
-                                                 Constraint.TYPE,
-                                                 Index.CONSTRAINT_TYPE.toString());
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, Constraint.INDEX_CONSTRAINT );
+                ObjectImpl.validatePropertyValue( transaction,
+                                                  kobject.getRepository(),
+                                                  kobject,
+                                                  Constraint.TYPE,
+                                                  Index.CONSTRAINT_TYPE.toValue() );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -71,23 +98,12 @@ public final class IndexImpl extends TableConstraintImpl implements Index {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Index resolve( final UnitOfWork transaction,
-                              final Repository repository,
                               final KomodoObject kobject ) throws KException {
-            return new IndexImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Index create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Table parentTable = adapter.adapt(transaction, parent, Table.class);
-            return RelationalModelFactory.createIndex(transaction, parent.getRepository(), parentTable, id);
+            return new IndexImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
@@ -54,13 +54,41 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Model create( final UnitOfWork transaction,
+                             final Repository repository,
+                             final KomodoObject parent,
+                             final String id,
+                             final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Vdb parentVdb = ( ( parent == null ) ? null : adapter.adapt( transaction, parent, Vdb.class ) );
+            return RelationalModelFactory.createModel( transaction, repository, parentVdb, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class< ? extends KomodoObject > owningClass() {
+        public Class< ModelImpl > owningClass() {
             return ModelImpl.class;
         }
 
@@ -68,14 +96,13 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType( transaction, repository, kobject, VdbLexicon.Vdb.DECLARATIVE_MODEL );
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, VdbLexicon.Vdb.DECLARATIVE_MODEL );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -88,23 +115,12 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Model resolve( final UnitOfWork transaction,
-                              final Repository repository,
                               final KomodoObject kobject ) throws KException {
-            return new ModelImpl( transaction, repository, kobject.getAbsolutePath() );
-        }
-
-        @Override
-        public Model create( UnitOfWork transaction,
-                             KomodoObject parent,
-                             String id,
-                             RelationalProperties properties ) throws KException {
-            AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
-            Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
-            return RelationalModelFactory.createModel( transaction, parent.getRepository(), parentVdb, id );
+            return new ModelImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };
@@ -577,7 +593,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
         final String value = getObjectProperty( uow, Property.ValueType.STRING, "getModelType", //$NON-NLS-1$
                                                 CoreLexicon.JcrId.MODEL_TYPE );
         final Type modelType = ( ( value == null ) ? null : Type.valueOf( value ) );
-        return ( ( modelType == null ) ? Type.DEFAULT : modelType );
+        return ( ( modelType == null ) ? Type.DEFAULT_VALUE : modelType );
     }
 
     /**
@@ -1075,8 +1091,8 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
     @Override
     public void setModelType( final UnitOfWork uow,
                               final Type newModelType ) throws KException {
-        final Type modelType = ( ( newModelType == null ) ? Type.DEFAULT : newModelType );
-        setObjectProperty( uow, "setModelType", CoreLexicon.JcrId.MODEL_TYPE, modelType.toString() ); //$NON-NLS-1$
+        final Type modelType = ( ( newModelType == null ) ? Type.DEFAULT_VALUE : newModelType );
+        setObjectProperty( uow, "setModelType", CoreLexicon.JcrId.MODEL_TYPE, modelType.name() ); //$NON-NLS-1$
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ParameterImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ParameterImpl.java
@@ -59,13 +59,42 @@ public final class ParameterImpl extends RelationalObjectImpl implements Paramet
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Parameter create( final UnitOfWork transaction,
+                                 final Repository repository,
+                                 final KomodoObject parent,
+                                 final String id,
+                                 final RelationalProperties properties ) throws KException {
+            final Class< ? extends AbstractProcedure > clazz = AbstractProcedureImpl.getProcedureType( transaction, parent );
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final AbstractProcedure parentProc = adapter.adapt( transaction, parent, clazz );
+            return RelationalModelFactory.createParameter( transaction, repository, parentProc, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class< ? extends KomodoObject > owningClass() {
+        public Class< ParameterImpl > owningClass() {
             return ParameterImpl.class;
         }
 
@@ -73,14 +102,13 @@ public final class ParameterImpl extends RelationalObjectImpl implements Paramet
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType( transaction, repository, kobject, CreateProcedure.PARAMETER );
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, CreateProcedure.PARAMETER );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -93,25 +121,12 @@ public final class ParameterImpl extends RelationalObjectImpl implements Paramet
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Parameter resolve( final UnitOfWork transaction,
-                                  final Repository repository,
                                   final KomodoObject kobject ) throws KException {
-            return new ParameterImpl( transaction, repository, kobject.getAbsolutePath() );
-        }
-
-        @Override
-        public Parameter create( UnitOfWork transaction,
-                                 KomodoObject parent,
-                                 String id,
-                                 RelationalProperties properties ) throws KException {
-            final Repository repo = parent.getRepository();
-            final Class< ? extends AbstractProcedure > clazz = AbstractProcedureImpl.getProcedureType( transaction, parent );
-            final AdapterFactory adapter = new AdapterFactory( repo );
-            final AbstractProcedure parentProc = adapter.adapt( transaction, parent, clazz );
-            return RelationalModelFactory.createParameter( transaction, repo, parentProc, id );
+            return new ParameterImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };
@@ -421,7 +436,7 @@ public final class ParameterImpl extends RelationalObjectImpl implements Paramet
                               final Direction newDirection ) throws KException {
         setObjectProperty( uow, "setDirection", //$NON-NLS-1$
                            CreateProcedure.PARAMETER_TYPE,
-                           ( newDirection == null ) ? Direction.DEFAULT_VALUE.toString() : newDirection.toString() );
+                           ( newDirection == null ) ? Direction.DEFAULT_VALUE.toValue() : newDirection.toValue() );
     }
 
     /**
@@ -446,7 +461,7 @@ public final class ParameterImpl extends RelationalObjectImpl implements Paramet
                              final Nullable newNullable ) throws KException {
         setObjectProperty( uow, "setNullable", //$NON-NLS-1$
                            StandardDdlLexicon.NULLABLE,
-                           ( newNullable == null ) ? Nullable.DEFAULT_VALUE.toString() : newNullable.toString() );
+                           ( newNullable == null ) ? Nullable.DEFAULT_VALUE.toValue() : newNullable.toValue() );
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/PrimaryKeyImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/PrimaryKeyImpl.java
@@ -31,13 +31,41 @@ public final class PrimaryKeyImpl extends TableConstraintImpl implements Primary
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public PrimaryKey create( final UnitOfWork transaction,
+                                  final Repository repository,
+                                  final KomodoObject parent,
+                                  final String id,
+                                  final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Table parentTable = adapter.adapt( transaction, parent, Table.class );
+            return RelationalModelFactory.createPrimaryKey( transaction, repository, parentTable, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< PrimaryKeyImpl > owningClass() {
             return PrimaryKeyImpl.class;
         }
 
@@ -45,19 +73,18 @@ public final class PrimaryKeyImpl extends TableConstraintImpl implements Primary
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, Constraint.TABLE_ELEMENT);
-                ObjectImpl.validatePropertyValue(transaction,
-                                                 repository,
-                                                 kobject,
-                                                 Constraint.TYPE,
-                                                 PrimaryKey.CONSTRAINT_TYPE.toString());
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, Constraint.TABLE_ELEMENT );
+                ObjectImpl.validatePropertyValue( transaction,
+                                                  kobject.getRepository(),
+                                                  kobject,
+                                                  Constraint.TYPE,
+                                                  PrimaryKey.CONSTRAINT_TYPE.toValue() );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -70,23 +97,12 @@ public final class PrimaryKeyImpl extends TableConstraintImpl implements Primary
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public PrimaryKey resolve( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) throws KException {
-            return new PrimaryKeyImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public PrimaryKey create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Table parentTable = adapter.adapt(transaction, parent, Table.class);
-            return RelationalModelFactory.createPrimaryKey(transaction, parent.getRepository(), parentTable, id);
+            return new PrimaryKeyImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
@@ -55,16 +55,18 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.KomodoObject, java.lang.String, org.komodo.relational.RelationalProperties)
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
          */
         @Override
         public ResultSetColumn create( final UnitOfWork transaction,
+                                       final Repository repository,
                                        final KomodoObject parent,
                                        final String id,
                                        final RelationalProperties properties ) throws KException {
-            final AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
+            final AdapterFactory adapter = new AdapterFactory( repository );
             final TabularResultSet parentResultSet = adapter.adapt( transaction, parent, TabularResultSet.class );
-            return RelationalModelFactory.createResultSetColumn( transaction, parent.getRepository(), parentResultSet, id );
+            return RelationalModelFactory.createResultSetColumn( transaction, repository, parentResultSet, id );
         }
 
         /**
@@ -77,6 +79,11 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
         public Class< ResultSetColumnImpl > owningClass() {
             return ResultSetColumnImpl.class;
@@ -86,14 +93,13 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType( transaction, repository, kobject, CreateProcedure.RESULT_COLUMN );
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, CreateProcedure.RESULT_COLUMN );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -106,13 +112,12 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public ResultSetColumn resolve( final UnitOfWork transaction,
-                                        final Repository repository,
                                         final KomodoObject kobject ) throws KException {
-            return new ResultSetColumnImpl( transaction, repository, kobject.getAbsolutePath() );
+            return new ResultSetColumnImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };
@@ -207,7 +212,7 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
      */
     @Override
     public String getDescription( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.ANNOTATION.toString() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.ANNOTATION.name() );
 
         if (option == null) {
             return null;
@@ -239,7 +244,7 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
      */
     @Override
     public String getNameInSource( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.NAMEINSOURCE.toString() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.NAMEINSOURCE.name() );
 
         if (option == null) {
             return null;
@@ -364,7 +369,7 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
      */
     @Override
     public String getUuid( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.toString() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.name() );
 
         if (option == null) {
             return null;
@@ -457,7 +462,7 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
     @Override
     public void setDescription( final UnitOfWork transaction,
                                 final String newDescription ) throws KException {
-        setStatementOption( transaction, StandardOptions.ANNOTATION.toString(), newDescription );
+        setStatementOption( transaction, StandardOptions.ANNOTATION.name(), newDescription );
     }
 
     /**
@@ -480,7 +485,7 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
     @Override
     public void setNameInSource( final UnitOfWork transaction,
                                  final String newNameInSource ) throws KException {
-        setStatementOption( transaction, StandardOptions.NAMEINSOURCE.toString(), newNameInSource );
+        setStatementOption( transaction, StandardOptions.NAMEINSOURCE.name(), newNameInSource );
     }
 
     /**
@@ -494,7 +499,7 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
                              final Nullable newNullable ) throws KException {
         setObjectProperty( uow, "setNullable", //$NON-NLS-1$
                            StandardDdlLexicon.NULLABLE,
-                           ( newNullable == null ) ? Nullable.DEFAULT_VALUE.toString() : newNullable.toString() );
+                           ( newNullable == null ) ? Nullable.DEFAULT_VALUE.toValue() : newNullable.toValue() );
     }
 
     /**
@@ -581,7 +586,7 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
     @Override
     public void setUuid( final UnitOfWork transaction,
                          final String newUuid ) throws KException {
-        setStatementOption( transaction, StandardOptions.UUID.toString(), newUuid );
+        setStatementOption( transaction, StandardOptions.UUID.name(), newUuid );
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/SchemaImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/SchemaImpl.java
@@ -48,13 +48,40 @@ public class SchemaImpl extends RelationalObjectImpl implements Schema {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Schema create( final UnitOfWork transaction,
+                              final Repository repository,
+                              final KomodoObject parent,
+                              final String id,
+                              final RelationalProperties properties ) throws KException {
+            final String parentPath = ( ( parent == null ) ? null : parent.getAbsolutePath() );
+            return RelationalModelFactory.createSchema( transaction, repository, parentPath, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< SchemaImpl > owningClass() {
             return SchemaImpl.class;
         }
 
@@ -62,14 +89,13 @@ public class SchemaImpl extends RelationalObjectImpl implements Schema {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, KomodoLexicon.Schema.NODE_TYPE);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, KomodoLexicon.Schema.NODE_TYPE );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -82,21 +108,12 @@ public class SchemaImpl extends RelationalObjectImpl implements Schema {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Schema resolve( final UnitOfWork transaction,
-                               final Repository repository,
                                final KomodoObject kobject ) throws KException {
-            return new SchemaImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Schema create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            return RelationalModelFactory.createSchema(transaction, parent.getRepository(), parent.getAbsolutePath(), id);
+            return new SchemaImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StatementOptionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StatementOptionImpl.java
@@ -34,13 +34,43 @@ public final class StatementOptionImpl extends RelationalObjectImpl implements S
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public StatementOption create( final UnitOfWork transaction,
+                                       final Repository repository,
+                                       final KomodoObject parent,
+                                       final String id,
+                                       final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Object optionValueValue = properties.getValue( StandardDdlLexicon.VALUE );
+            final String optionValue = optionValueValue == null ? null : optionValueValue.toString();
+            final Table parentTable = adapter.adapt( transaction, parent, Table.class );
+            return RelationalModelFactory.createStatementOption( transaction, repository, parentTable, id, optionValue );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< StatementOptionImpl > owningClass() {
             return StatementOptionImpl.class;
         }
 
@@ -48,14 +78,13 @@ public final class StatementOptionImpl extends RelationalObjectImpl implements S
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, StandardDdlLexicon.TYPE_STATEMENT_OPTION);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, StandardDdlLexicon.TYPE_STATEMENT_OPTION );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -68,25 +97,12 @@ public final class StatementOptionImpl extends RelationalObjectImpl implements S
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public StatementOption resolve( final UnitOfWork transaction,
-                                        final Repository repository,
                                         final KomodoObject kobject ) throws KException {
-            return new StatementOptionImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public StatementOption create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Object optionValueValue = properties.getValue(StandardDdlLexicon.VALUE);
-            String optionValue = optionValueValue == null ? null : optionValueValue.toString();
-            Table parentTable = adapter.adapt(transaction, parent, Table.class);
-            return RelationalModelFactory.createStatementOption(transaction, parent.getRepository(), parentTable, id, optionValue);
+            return new StatementOptionImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TableImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TableImpl.java
@@ -46,6 +46,7 @@ import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon.SchemaElement;
 public class TableImpl extends RelationalObjectImpl implements Table {
 
     private enum StandardOptions {
+
         ANNOTATION,
         CARDINALITY,
         MATERIALIZED,
@@ -53,6 +54,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
         NAMEINSOURCE,
         UPDATABLE,
         UUID
+
     }
 
     /*
@@ -73,13 +75,41 @@ public class TableImpl extends RelationalObjectImpl implements Table {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Table create( final UnitOfWork transaction,
+                             final Repository repository,
+                             final KomodoObject parent,
+                             final String id,
+                             final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Model parentModel = adapter.adapt( transaction, parent, Model.class );
+            return RelationalModelFactory.createTable( transaction, repository, parentModel, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< TableImpl > owningClass() {
             return TableImpl.class;
         }
 
@@ -87,14 +117,13 @@ public class TableImpl extends RelationalObjectImpl implements Table {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, CreateTable.TABLE_STATEMENT);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, CreateTable.TABLE_STATEMENT );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -107,23 +136,12 @@ public class TableImpl extends RelationalObjectImpl implements Table {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Table resolve( final UnitOfWork transaction,
-                              final Repository repository,
                               final KomodoObject kobject ) throws KException {
-            return new TableImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Table create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Model parentModel = adapter.adapt(transaction, parent, Model.class);
-            return RelationalModelFactory.createTable(transaction, parent.getRepository(), parentModel, id);
+            return new TableImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };
@@ -371,7 +389,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
             for (final KomodoObject kobject : super.getChildrenOfType(transaction, Constraint.TABLE_ELEMENT)) {
                 final Property prop = kobject.getProperty(transaction, Constraint.TYPE);
 
-                if (AccessPattern.CONSTRAINT_TYPE.toString().equals(prop.getStringValue(transaction))) {
+                if (AccessPattern.CONSTRAINT_TYPE.toValue().equals(prop.getStringValue(transaction))) {
                     final AccessPattern constraint = new AccessPatternImpl(transaction,
                                                                            getRepository(),
                                                                            kobject.getAbsolutePath());
@@ -407,7 +425,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
      */
     @Override
     public int getCardinality( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.CARDINALITY.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.CARDINALITY.name());
 
         if (option == null) {
             return Table.DEFAULT_CARDINALITY;
@@ -604,7 +622,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
      */
     @Override
     public String getDescription( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.ANNOTATION.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.ANNOTATION.name());
 
         if (option == null) {
             return null;
@@ -716,7 +734,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
      */
     @Override
     public String getMaterializedTable( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.MATERIALIZED_TABLE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.MATERIALIZED_TABLE.name());
 
         if (option == null) {
             return null;
@@ -732,7 +750,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
      */
     @Override
     public String getNameInSource( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.NAMEINSOURCE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.NAMEINSOURCE.name());
 
         if (option == null) {
             return null;
@@ -783,7 +801,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
             for (final KomodoObject kobject : super.getChildrenOfType(transaction, Constraint.TABLE_ELEMENT)) {
                 final Property prop = kobject.getProperty(transaction, Constraint.TYPE);
 
-                if (PrimaryKey.CONSTRAINT_TYPE.toString().equals(prop.getStringValue(transaction))) {
+                if (PrimaryKey.CONSTRAINT_TYPE.toValue().equals(prop.getStringValue(transaction))) {
                     result = new PrimaryKeyImpl(transaction, getRepository(), kobject.getAbsolutePath());
 
                     if (LOGGER.isDebugEnabled()) {
@@ -933,7 +951,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
             for (final KomodoObject kobject : super.getChildrenOfType(transaction, Constraint.TABLE_ELEMENT)) {
                 final Property prop = kobject.getProperty(transaction, Constraint.TYPE);
 
-                if (UniqueConstraint.CONSTRAINT_TYPE.toString().equals(prop.getStringValue(transaction))) {
+                if (UniqueConstraint.CONSTRAINT_TYPE.toValue().equals(prop.getStringValue(transaction))) {
                     final UniqueConstraint constraint = new UniqueConstraintImpl(transaction,
                                                                                  getRepository(),
                                                                                  kobject.getAbsolutePath());
@@ -965,11 +983,27 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.relational.model.Table#getUuid(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getUuid( final UnitOfWork transaction ) throws KException {
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.name() );
+
+        if (option == null) {
+            return null;
+        }
+
+        return option.getOption( transaction );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.relational.model.Table#isMaterialized(org.komodo.spi.repository.Repository.UnitOfWork)
      */
     @Override
     public boolean isMaterialized( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.MATERIALIZED.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.MATERIALIZED.name());
 
         if (option == null) {
             return Table.DEFAULT_MATERIALIZED;
@@ -985,7 +1019,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
      */
     @Override
     public boolean isUpdatable( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.UPDATABLE.toString());
+        final StatementOption option = Utils.getOption(transaction, this, StandardOptions.UPDATABLE.name());
 
         if (option == null) {
             return Table.DEFAULT_UPDATABLE;
@@ -1351,7 +1385,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public void setCardinality( final UnitOfWork transaction,
                                 final int newCardinality ) throws KException {
-        setStatementOption(transaction, StandardOptions.CARDINALITY.toString(), Integer.toString(newCardinality));
+        setStatementOption(transaction, StandardOptions.CARDINALITY.name(), Integer.toString(newCardinality));
     }
 
     /**
@@ -1362,7 +1396,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public void setDescription( final UnitOfWork transaction,
                                 final String newDescription ) throws KException {
-        setStatementOption(transaction, StandardOptions.ANNOTATION.toString(), newDescription);
+        setStatementOption(transaction, StandardOptions.ANNOTATION.name(), newDescription);
     }
 
     /**
@@ -1373,7 +1407,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public void setMaterialized( final UnitOfWork transaction,
                                  final boolean newMaterialized ) throws KException {
-        setStatementOption(transaction, StandardOptions.MATERIALIZED.toString(), Boolean.toString(newMaterialized));
+        setStatementOption(transaction, StandardOptions.MATERIALIZED.name(), Boolean.toString(newMaterialized));
     }
 
     /**
@@ -1385,7 +1419,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public void setMaterializedTable( final UnitOfWork transaction,
                                       final String newMaterializedTable ) throws KException {
-        setStatementOption(transaction, StandardOptions.MATERIALIZED_TABLE.toString(), newMaterializedTable);
+        setStatementOption(transaction, StandardOptions.MATERIALIZED_TABLE.name(), newMaterializedTable);
     }
 
     /**
@@ -1396,7 +1430,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public void setNameInSource( final UnitOfWork transaction,
                                  final String newNameInSource ) throws KException {
-        setStatementOption(transaction, StandardOptions.NAMEINSOURCE.toString(), newNameInSource);
+        setStatementOption(transaction, StandardOptions.NAMEINSOURCE.name(), newNameInSource);
     }
 
     /**
@@ -1408,7 +1442,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public void setOnCommitValue( final UnitOfWork uow,
                                   final OnCommit newOnCommit ) throws KException {
-        final String newValue = (newOnCommit == null) ? null : newOnCommit.toString();
+        final String newValue = (newOnCommit == null) ? null : newOnCommit.toValue();
         setObjectProperty(uow, "setOnCommitValue", StandardDdlLexicon.ON_COMMIT_VALUE, newValue); //$NON-NLS-1$
     }
 
@@ -1479,7 +1513,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public void setSchemaElementType( final UnitOfWork uow,
                                       final SchemaElementType newSchemaElementType ) throws KException {
-        final String newValue = ((newSchemaElementType == null) ? SchemaElementType.DEFAULT_VALUE.toString() : newSchemaElementType.toString());
+        final String newValue = ((newSchemaElementType == null) ? SchemaElementType.DEFAULT_VALUE.name() : newSchemaElementType.name());
         setObjectProperty(uow, "setSchemaElementType", SchemaElement.TYPE, newValue); //$NON-NLS-1$
     }
 
@@ -1546,7 +1580,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public void setTemporaryTableType( final UnitOfWork uow,
                                        final TemporaryType newTempType ) throws KException {
-        final String newValue = ((newTempType == null) ? null : newTempType.toString());
+        final String newValue = ((newTempType == null) ? null : newTempType.name());
         setObjectProperty(uow, "setTemporaryTableType", StandardDdlLexicon.TEMPORARY, newValue); //$NON-NLS-1$
     }
 
@@ -1558,7 +1592,18 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public void setUpdatable( final UnitOfWork transaction,
                               final boolean newUpdatable ) throws KException {
-        setStatementOption(transaction, StandardOptions.UPDATABLE.toString(), Boolean.toString(newUpdatable));
+        setStatementOption(transaction, StandardOptions.UPDATABLE.name(), Boolean.toString(newUpdatable));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.Table#setUuid(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
+     */
+    @Override
+    public void setUuid( final UnitOfWork transaction,
+                         final String newUuid ) throws KException {
+        setStatementOption( transaction, StandardOptions.UUID.name(), newUuid );
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TabularResultSetImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TabularResultSetImpl.java
@@ -42,18 +42,19 @@ public final class TabularResultSetImpl extends RelationalObjectImpl implements 
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.KomodoObject, java.lang.String, org.komodo.relational.RelationalProperties)
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
          */
         @Override
         public TabularResultSet create( final UnitOfWork transaction,
+                                        final Repository repository,
                                         final KomodoObject parent,
                                         final String id,
                                         final RelationalProperties properties ) throws KException {
-            final Repository repo = parent.getRepository();
             final Class< ? extends AbstractProcedure > clazz = AbstractProcedureImpl.getProcedureType( transaction, parent );
-            final AdapterFactory adapter = new AdapterFactory( repo );
+            final AdapterFactory adapter = new AdapterFactory( repository );
             final AbstractProcedure parentProc = adapter.adapt( transaction, parent, clazz );
-            return RelationalModelFactory.createTabularResultSet( transaction, repo, parentProc );
+            return RelationalModelFactory.createTabularResultSet( transaction, repository, parentProc );
         }
 
         /**
@@ -80,16 +81,15 @@ public final class TabularResultSetImpl extends RelationalObjectImpl implements 
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
                 // must have the right name
                 if (CreateProcedure.RESULT_SET.equals( kobject.getName( transaction ) )) {
-                    ObjectImpl.validateType( transaction, repository, kobject, CreateProcedure.RESULT_COLUMNS );
+                    ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, CreateProcedure.RESULT_COLUMNS );
                     return true;
                 }
             } catch (final KException e) {
@@ -103,13 +103,12 @@ public final class TabularResultSetImpl extends RelationalObjectImpl implements 
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public TabularResultSet resolve( final UnitOfWork transaction,
-                                         final Repository repository,
                                          final KomodoObject kobject ) throws KException {
-            return new TabularResultSetImpl( transaction, repository, kobject.getAbsolutePath() );
+            return new TabularResultSetImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/UniqueConstraintImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/UniqueConstraintImpl.java
@@ -31,13 +31,41 @@ public final class UniqueConstraintImpl extends TableConstraintImpl implements U
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public UniqueConstraint create( final UnitOfWork transaction,
+                                        final Repository repository,
+                                        final KomodoObject parent,
+                                        final String id,
+                                        final RelationalProperties properties ) throws KException {
+            AdapterFactory adapter = new AdapterFactory( repository );
+            Table parentTable = adapter.adapt( transaction, parent, Table.class );
+            return RelationalModelFactory.createUniqueConstraint( transaction, repository, parentTable, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< UniqueConstraintImpl > owningClass() {
             return UniqueConstraintImpl.class;
         }
 
@@ -45,19 +73,18 @@ public final class UniqueConstraintImpl extends TableConstraintImpl implements U
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, Constraint.TABLE_ELEMENT);
-                ObjectImpl.validatePropertyValue(transaction,
-                                                 repository,
-                                                 kobject,
-                                                 Constraint.TYPE,
-                                                 UniqueConstraint.CONSTRAINT_TYPE.toString());
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, Constraint.TABLE_ELEMENT );
+                ObjectImpl.validatePropertyValue( transaction,
+                                                  kobject.getRepository(),
+                                                  kobject,
+                                                  Constraint.TYPE,
+                                                  UniqueConstraint.CONSTRAINT_TYPE.toValue() );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -70,23 +97,12 @@ public final class UniqueConstraintImpl extends TableConstraintImpl implements U
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public UniqueConstraint resolve( final UnitOfWork transaction,
-                                         final Repository repository,
                                          final KomodoObject kobject ) throws KException {
-            return new UniqueConstraintImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public UniqueConstraint create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Table parentTable = adapter.adapt(transaction, parent, Table.class);
-            return RelationalModelFactory.createUniqueConstraint(transaction, parent.getRepository(), parentTable, id);
+            return new UniqueConstraintImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/UserDefinedFunctionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/UserDefinedFunctionImpl.java
@@ -32,19 +32,9 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
 
     private enum StandardOptions {
 
-        CATEGORY( "CATEGORY" ), //$NON-NLS-1$
-        JAVA_CLASS( "JAVA_CLASS" ), //$NON-NLS-1$
-        JAVA_METHOD( "JAVA_METHOD" ); //$NON-NLS-1$
-
-        private final String name;
-
-        private StandardOptions( final String optionName ) {
-            this.name = optionName;
-        }
-
-        public String getName() {
-            return this.name;
-        }
+        CATEGORY,
+        JAVA_CLASS,
+        JAVA_METHOD;
 
     }
 
@@ -57,16 +47,18 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.KomodoObject, java.lang.String, org.komodo.relational.RelationalProperties)
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
          */
         @Override
         public UserDefinedFunction create( final UnitOfWork transaction,
+                                           final Repository repository,
                                            final KomodoObject parent,
                                            final String id,
                                            final RelationalProperties properties ) throws KException {
-            final AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
+            final AdapterFactory adapter = new AdapterFactory( repository );
             final Model parentModel = adapter.adapt( transaction, parent, Model.class );
-            return RelationalModelFactory.createUserDefinedFunction( transaction, parent.getRepository(), parentModel, id );
+            return RelationalModelFactory.createUserDefinedFunction( transaction, repository, parentModel, id );
         }
 
         /**
@@ -93,19 +85,18 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType( transaction, repository, kobject, CreateProcedure.FUNCTION_STATEMENT );
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, CreateProcedure.FUNCTION_STATEMENT );
                 ObjectImpl.validatePropertyValue( transaction,
-                                                  repository,
+                                                  kobject.getRepository(),
                                                   kobject,
                                                   SchemaElement.TYPE,
-                                                  SchemaElementType.VIRTUAL.toString() );
+                                                  SchemaElementType.VIRTUAL.name() );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -118,13 +109,12 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public UserDefinedFunction resolve( final UnitOfWork transaction,
-                                            final Repository repository,
                                             final KomodoObject kobject ) throws KException {
-            return new UserDefinedFunctionImpl( transaction, repository, kobject.getAbsolutePath() );
+            return new UserDefinedFunctionImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };
@@ -152,7 +142,7 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
      */
     @Override
     public String getCategory( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.CATEGORY.getName() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.CATEGORY.name() );
 
         if (option == null) {
             return null;
@@ -212,7 +202,7 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
      */
     @Override
     public String getJavaClass( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.JAVA_CLASS.getName() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.JAVA_CLASS.name() );
 
         if (option == null) {
             return null;
@@ -228,7 +218,7 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
      */
     @Override
     public String getJavaMethod( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.JAVA_METHOD.getName() );
+        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.JAVA_METHOD.name() );
 
         if (option == null) {
             return null;
@@ -266,7 +256,7 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
     @Override
     public void setCategory( final UnitOfWork transaction,
                              final String newCategory ) throws KException {
-        setStatementOption( transaction, StandardOptions.CATEGORY.getName(), newCategory );
+        setStatementOption( transaction, StandardOptions.CATEGORY.name(), newCategory );
     }
 
     /**
@@ -278,7 +268,7 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
     @Override
     public void setJavaClass( final UnitOfWork transaction,
                               final String newJavaClass ) throws KException {
-        setStatementOption( transaction, StandardOptions.JAVA_CLASS.getName(), newJavaClass );
+        setStatementOption( transaction, StandardOptions.JAVA_CLASS.name(), newJavaClass );
     }
 
     /**
@@ -290,7 +280,7 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
     @Override
     public void setJavaMethod( final UnitOfWork transaction,
                                final String newJavaMethod ) throws KException {
-        setStatementOption( transaction, StandardOptions.JAVA_METHOD.getName(), newJavaMethod );
+        setStatementOption( transaction, StandardOptions.JAVA_METHOD.name(), newJavaMethod );
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ViewImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ViewImpl.java
@@ -35,13 +35,41 @@ public final class ViewImpl extends TableImpl implements View {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public View create( final UnitOfWork transaction,
+                            final Repository repository,
+                            final KomodoObject parent,
+                            final String id,
+                            final RelationalProperties properties ) throws KException {
+            AdapterFactory adapter = new AdapterFactory( repository );
+            Model parentModel = adapter.adapt( transaction, parent, Model.class );
+            return RelationalModelFactory.createView( transaction, repository, parentModel, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return View.IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< ViewImpl > owningClass() {
             return ViewImpl.class;
         }
 
@@ -49,14 +77,13 @@ public final class ViewImpl extends TableImpl implements View {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, CreateTable.VIEW_STATEMENT);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, CreateTable.VIEW_STATEMENT );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -69,23 +96,12 @@ public final class ViewImpl extends TableImpl implements View {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public View resolve( final UnitOfWork transaction,
-                             final Repository repository,
                              final KomodoObject kobject ) throws KException {
-            return new ViewImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public View create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Model parentModel = adapter.adapt(transaction, parent, Model.class);
-            return RelationalModelFactory.createView(transaction, parent.getRepository(), parentModel, id);
+            return new ViewImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/VirtualProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/VirtualProcedureImpl.java
@@ -37,16 +37,18 @@ public final class VirtualProcedureImpl extends AbstractProcedureImpl implements
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.KomodoObject, java.lang.String, org.komodo.relational.RelationalProperties)
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
          */
         @Override
         public VirtualProcedure create( final UnitOfWork transaction,
+                                        final Repository repository,
                                         final KomodoObject parent,
                                         final String id,
                                         final RelationalProperties properties ) throws KException {
-            final AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
+            final AdapterFactory adapter = new AdapterFactory( repository );
             final Model parentModel = adapter.adapt( transaction, parent, Model.class );
-            return RelationalModelFactory.createVirtualProcedure( transaction, parent.getRepository(), parentModel, id );
+            return RelationalModelFactory.createVirtualProcedure( transaction, repository, parentModel, id );
         }
 
         /**
@@ -73,19 +75,18 @@ public final class VirtualProcedureImpl extends AbstractProcedureImpl implements
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType( transaction, repository, kobject, CreateProcedure.PROCEDURE_STATEMENT );
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, CreateProcedure.PROCEDURE_STATEMENT );
                 ObjectImpl.validatePropertyValue( transaction,
-                                                  repository,
+                                                  kobject.getRepository(),
                                                   kobject,
                                                   SchemaElement.TYPE,
-                                                  SchemaElementType.VIRTUAL.toString() );
+                                                  SchemaElementType.VIRTUAL.name() );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -98,13 +99,12 @@ public final class VirtualProcedureImpl extends AbstractProcedureImpl implements
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public VirtualProcedure resolve( final UnitOfWork transaction,
-                                         final Repository repository,
                                          final KomodoObject kobject ) throws KException {
-            return new VirtualProcedureImpl( transaction, repository, kobject.getAbsolutePath() );
+            return new VirtualProcedureImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/teiid/internal/TeiidImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/teiid/internal/TeiidImpl.java
@@ -57,13 +57,40 @@ public class TeiidImpl extends RelationalObjectImpl implements Teiid, EventManag
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Teiid create( final UnitOfWork transaction,
+                             final Repository repository,
+                             final KomodoObject parent,
+                             final String id,
+                             final RelationalProperties properties ) throws KException {
+            final String workspacePath = ( ( parent == null ) ? null : parent.getAbsolutePath() );
+            return RelationalModelFactory.createTeiid( transaction, repository, workspacePath, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< TeiidImpl > owningClass() {
             return TeiidImpl.class;
         }
 
@@ -71,14 +98,13 @@ public class TeiidImpl extends RelationalObjectImpl implements Teiid, EventManag
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, KomodoLexicon.Teiid.NODE_TYPE);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, KomodoLexicon.Teiid.NODE_TYPE );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -91,21 +117,12 @@ public class TeiidImpl extends RelationalObjectImpl implements Teiid, EventManag
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Teiid resolve( final UnitOfWork transaction,
-                              final Repository repository,
                               final KomodoObject kobject ) throws KException {
-            return new TeiidImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Teiid create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            return RelationalModelFactory.createTeiid(transaction, parent.getRepository(), parent.getAbsolutePath(), id);
+            return new TeiidImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ConditionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ConditionImpl.java
@@ -33,13 +33,41 @@ public final class ConditionImpl extends RelationalObjectImpl implements Conditi
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Condition create( final UnitOfWork transaction,
+                                 final Repository repository,
+                                 final KomodoObject parent,
+                                 final String id,
+                                 final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Permission parentPerm = adapter.adapt( transaction, parent, Permission.class );
+            return RelationalModelFactory.createCondition( transaction, repository, parentPerm, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< ConditionImpl > owningClass() {
             return ConditionImpl.class;
         }
 
@@ -47,14 +75,16 @@ public final class ConditionImpl extends RelationalObjectImpl implements Conditi
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, VdbLexicon.DataRole.Permission.Condition.CONDITION);
+                ObjectImpl.validateType( transaction,
+                                         kobject.getRepository(),
+                                         kobject,
+                                         VdbLexicon.DataRole.Permission.Condition.CONDITION );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -67,23 +97,12 @@ public final class ConditionImpl extends RelationalObjectImpl implements Conditi
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Condition resolve( final UnitOfWork transaction,
-                                  final Repository repository,
                                   final KomodoObject kobject ) throws KException {
-            return new ConditionImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Condition create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Permission parentPerm = adapter.adapt(transaction, parent, Permission.class);
-            return RelationalModelFactory.createCondition(transaction, parent.getRepository(), parentPerm, id);
+            return new ConditionImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/DataRoleImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/DataRoleImpl.java
@@ -40,13 +40,41 @@ public final class DataRoleImpl extends RelationalObjectImpl implements DataRole
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public DataRole create( final UnitOfWork transaction,
+                                final Repository repository,
+                                final KomodoObject parent,
+                                final String id,
+                                final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
+            return RelationalModelFactory.createDataRole( transaction, repository, parentVdb, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< DataRoleImpl > owningClass() {
             return DataRoleImpl.class;
         }
 
@@ -54,14 +82,13 @@ public final class DataRoleImpl extends RelationalObjectImpl implements DataRole
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, VdbLexicon.DataRole.DATA_ROLE);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, VdbLexicon.DataRole.DATA_ROLE );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -74,23 +101,12 @@ public final class DataRoleImpl extends RelationalObjectImpl implements DataRole
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public DataRole resolve( final UnitOfWork transaction,
-                                 final Repository repository,
                                  final KomodoObject kobject ) throws KException {
-            return new DataRoleImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public DataRole create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Vdb parentVdb = adapter.adapt(transaction, parent, Vdb.class);
-            return RelationalModelFactory.createDataRole(transaction, parent.getRepository(), parentVdb, id);
+            return new DataRoleImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/EntryImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/EntryImpl.java
@@ -34,13 +34,43 @@ public final class EntryImpl extends RelationalObjectImpl implements Entry {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Entry create( final UnitOfWork transaction,
+                             final Repository repository,
+                             final KomodoObject parent,
+                             final String id,
+                             final RelationalProperties properties ) throws KException {
+            final Object entryPathValue = properties.getValue( VdbLexicon.Entry.PATH );
+            final String entryPath = entryPathValue == null ? null : entryPathValue.toString();
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
+            return RelationalModelFactory.createEntry( transaction, repository, parentVdb, id, entryPath );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< EntryImpl > owningClass() {
             return EntryImpl.class;
         }
 
@@ -48,14 +78,13 @@ public final class EntryImpl extends RelationalObjectImpl implements Entry {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, VdbLexicon.Entry.ENTRY);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, VdbLexicon.Entry.ENTRY );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -68,25 +97,12 @@ public final class EntryImpl extends RelationalObjectImpl implements Entry {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Entry resolve( final UnitOfWork transaction,
-                              final Repository repository,
                               final KomodoObject kobject ) throws KException {
-            return new EntryImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Entry create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Object entryPathValue = properties.getValue(VdbLexicon.Entry.PATH);
-            String entryPath = entryPathValue == null ? null : entryPathValue.toString();
-            Vdb parentVdb = adapter.adapt(transaction, parent, Vdb.class);
-            return RelationalModelFactory.createEntry(transaction, parent.getRepository(), parentVdb, id, entryPath);
+            return new EntryImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/MaskImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/MaskImpl.java
@@ -33,13 +33,41 @@ public final class MaskImpl extends RelationalObjectImpl implements Mask {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Mask create( final UnitOfWork transaction,
+                            final Repository repository,
+                            final KomodoObject parent,
+                            final String id,
+                            final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
+            final Permission parentPerm = adapter.adapt( transaction, parent, Permission.class );
+            return RelationalModelFactory.createMask( transaction, parent.getRepository(), parentPerm, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< MaskImpl > owningClass() {
             return MaskImpl.class;
         }
 
@@ -47,14 +75,13 @@ public final class MaskImpl extends RelationalObjectImpl implements Mask {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, VdbLexicon.DataRole.Permission.Mask.MASK);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, VdbLexicon.DataRole.Permission.Mask.MASK );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -67,23 +94,12 @@ public final class MaskImpl extends RelationalObjectImpl implements Mask {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Mask resolve( final UnitOfWork transaction,
-                             final Repository repository,
                              final KomodoObject kobject ) throws KException {
-            return new MaskImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Mask create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Permission parentPerm = adapter.adapt(transaction, parent, Permission.class);
-            return RelationalModelFactory.createMask(transaction, parent.getRepository(), parentPerm, id);
+            return new MaskImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ModelSourceImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ModelSourceImpl.java
@@ -33,13 +33,41 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public ModelSource create( final UnitOfWork transaction,
+                                   final Repository repository,
+                                   final KomodoObject parent,
+                                   final String id,
+                                   final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Model parentModel = adapter.adapt( transaction, parent, Model.class );
+            return RelationalModelFactory.createModelSource( transaction, repository, parentModel, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< ModelSourceImpl > owningClass() {
             return ModelSourceImpl.class;
         }
 
@@ -47,14 +75,13 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, VdbLexicon.Source.SOURCE);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, VdbLexicon.Source.SOURCE );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -67,23 +94,12 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public ModelSource resolve( final UnitOfWork transaction,
-                                    final Repository repository,
                                     final KomodoObject kobject ) throws KException {
-            return new ModelSourceImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public ModelSource create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Model parentModel = adapter.adapt(transaction, parent, Model.class);
-            return RelationalModelFactory.createModelSource(transaction, parent.getRepository(), parentModel, id);
+            return new ModelSourceImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };
@@ -101,11 +117,11 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
     public ModelSourceImpl( final UnitOfWork uow,
                             final Repository repository,
                             final String workspacePath ) throws KException {
-        super(uow, repository, workspacePath);
+        super( uow, repository, workspacePath );
     }
 
     @Override
-    public KomodoType getTypeIdentifier(UnitOfWork uow) {
+    public KomodoType getTypeIdentifier( UnitOfWork uow ) {
         return KomodoType.VDB_MODEL_SOURCE;
     }
 
@@ -116,7 +132,7 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
      */
     @Override
     public String getJndiName( final UnitOfWork uow ) throws KException {
-        return getObjectProperty(uow, Property.ValueType.STRING, "getJndiName", VdbLexicon.Source.JNDI_NAME); //$NON-NLS-1$
+        return getObjectProperty( uow, Property.ValueType.STRING, "getJndiName", VdbLexicon.Source.JNDI_NAME ); //$NON-NLS-1$
     }
 
     /**
@@ -129,14 +145,14 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
         UnitOfWork transaction = uow;
 
         if (transaction == null) {
-            transaction = getRepository().createTransaction("modelsourceimpl-getParent", true, null); //$NON-NLS-1$
+            transaction = getRepository().createTransaction( "modelsourceimpl-getParent", true, null ); //$NON-NLS-1$
         }
 
-        assert (transaction != null);
+        assert ( transaction != null );
 
         try {
-            final KomodoObject grouping = super.getParent(transaction);
-            final KomodoObject result = resolveType(transaction, grouping.getParent(transaction));
+            final KomodoObject grouping = super.getParent( transaction );
+            final KomodoObject result = resolveType( transaction, grouping.getParent( transaction ) );
 
             if (uow == null) {
                 transaction.commit();
@@ -144,7 +160,7 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
 
             return result;
         } catch (final Exception e) {
-            throw handleError(uow, transaction, e);
+            throw handleError( uow, transaction, e );
         }
     }
 
@@ -155,7 +171,7 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
      */
     @Override
     public String getTranslatorName( final UnitOfWork uow ) throws KException {
-        return getObjectProperty(uow, Property.ValueType.STRING, "getTranslatorName", VdbLexicon.Source.TRANSLATOR); //$NON-NLS-1$
+        return getObjectProperty( uow, Property.ValueType.STRING, "getTranslatorName", VdbLexicon.Source.TRANSLATOR ); //$NON-NLS-1$
     }
 
     /**
@@ -176,7 +192,7 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
     @Override
     public void setJndiName( final UnitOfWork uow,
                              final String newJndiName ) throws KException {
-        setObjectProperty(uow, "setJndiName", VdbLexicon.Source.JNDI_NAME, newJndiName); //$NON-NLS-1$
+        setObjectProperty( uow, "setJndiName", VdbLexicon.Source.JNDI_NAME, newJndiName ); //$NON-NLS-1$
     }
 
     /**
@@ -188,7 +204,7 @@ public final class ModelSourceImpl extends RelationalObjectImpl implements Model
     @Override
     public void setTranslatorName( final UnitOfWork uow,
                                    final String newTranslatorName ) throws KException {
-        setObjectProperty(uow, "setTranslatorName", VdbLexicon.Source.TRANSLATOR, newTranslatorName); //$NON-NLS-1$
+        setObjectProperty( uow, "setTranslatorName", VdbLexicon.Source.TRANSLATOR, newTranslatorName ); //$NON-NLS-1$
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/PermissionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/PermissionImpl.java
@@ -40,13 +40,41 @@ public final class PermissionImpl extends RelationalObjectImpl implements Permis
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Permission create( final UnitOfWork transaction,
+                                  final Repository repository,
+                                  final KomodoObject parent,
+                                  final String id,
+                                  final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final DataRole parentDataRole = adapter.adapt( transaction, parent, DataRole.class );
+            return RelationalModelFactory.createPermission( transaction, repository, parentDataRole, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< PermissionImpl > owningClass() {
             return PermissionImpl.class;
         }
 
@@ -54,14 +82,13 @@ public final class PermissionImpl extends RelationalObjectImpl implements Permis
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, VdbLexicon.DataRole.Permission.PERMISSION);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, VdbLexicon.DataRole.Permission.PERMISSION );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -74,23 +101,12 @@ public final class PermissionImpl extends RelationalObjectImpl implements Permis
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Permission resolve( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) throws KException {
-            return new PermissionImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Permission create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            DataRole parentDataRole = adapter.adapt(transaction, parent, DataRole.class);
-            return RelationalModelFactory.createPermission(transaction, parent.getRepository(), parentDataRole, id);
+            return new PermissionImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/TranslatorImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/TranslatorImpl.java
@@ -34,13 +34,43 @@ public final class TranslatorImpl extends RelationalObjectImpl implements Transl
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Translator create( final UnitOfWork transaction,
+                                  final Repository repository,
+                                  final KomodoObject parent,
+                                  final String id,
+                                  final RelationalProperties properties ) throws KException {
+            final Object transTypeValue = properties.getValue( VdbLexicon.Translator.TYPE );
+            final String transType = transTypeValue == null ? null : transTypeValue.toString();
+            final AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
+            final Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
+            return RelationalModelFactory.createTranslator( transaction, parent.getRepository(), parentVdb, id, transType );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< TranslatorImpl > owningClass() {
             return TranslatorImpl.class;
         }
 
@@ -48,14 +78,13 @@ public final class TranslatorImpl extends RelationalObjectImpl implements Transl
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, VdbLexicon.Translator.TRANSLATOR);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, VdbLexicon.Translator.TRANSLATOR );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -68,25 +97,12 @@ public final class TranslatorImpl extends RelationalObjectImpl implements Transl
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Translator resolve( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) throws KException {
-            return new TranslatorImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Translator create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Object transTypeValue = properties.getValue(VdbLexicon.Translator.TYPE);
-            String transType = transTypeValue == null ? null : transTypeValue.toString();
-            Vdb parentVdb = adapter.adapt(transaction, parent, Vdb.class);
-            return RelationalModelFactory.createTranslator(transaction, parent.getRepository(), parentVdb, id, transType);
+            return new TranslatorImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
@@ -121,13 +121,42 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Vdb create( final UnitOfWork transaction,
+                           final Repository repository,
+                           final KomodoObject parent,
+                           final String id,
+                           final RelationalProperties properties ) throws KException {
+            final Object origFilePathValue = properties.getValue( VdbLexicon.Vdb.ORIGINAL_FILE );
+            final String origFilePath = origFilePathValue == null ? null : origFilePathValue.toString();
+            final String workspacePath = ( ( parent == null ) ? null : parent.getAbsolutePath() );
+            return RelationalModelFactory.createVdb( transaction, repository, workspacePath, id, origFilePath );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< VdbImpl > owningClass() {
             return VdbImpl.class;
         }
 
@@ -135,14 +164,13 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, VdbLexicon.Vdb.VIRTUAL_DATABASE);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, VdbLexicon.Vdb.VIRTUAL_DATABASE );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -155,23 +183,12 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public Vdb resolve( final UnitOfWork transaction,
-                            final Repository repository,
                             final KomodoObject kobject ) throws KException {
-            return new VdbImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public Vdb create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            Object origFilePathValue = properties.getValue(VdbLexicon.Vdb.ORIGINAL_FILE);
-            String origFilePath = origFilePathValue == null ? null : origFilePathValue.toString();
-            return RelationalModelFactory.createVdb(transaction, parent.getRepository(), parent.getAbsolutePath(), id, origFilePath);
+            return new VdbImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImportImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImportImpl.java
@@ -33,13 +33,41 @@ public class VdbImportImpl extends RelationalObjectImpl implements VdbImport {
      */
     public static final TypeResolver RESOLVER = new TypeResolver() {
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public VdbImport create( final UnitOfWork transaction,
+                                 final Repository repository,
+                                 final KomodoObject parent,
+                                 final String id,
+                                 final RelationalProperties properties ) throws KException {
+            final AdapterFactory adapter = new AdapterFactory( repository );
+            final Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
+            return RelationalModelFactory.createVdbImport( transaction, repository, parentVdb, id );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#identifier()
+         */
         @Override
         public KomodoType identifier() {
             return IDENTIFIER;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.internal.TypeResolver#owningClass()
+         */
         @Override
-        public Class<? extends KomodoObject> owningClass() {
+        public Class< VdbImportImpl > owningClass() {
             return VdbImportImpl.class;
         }
 
@@ -47,14 +75,13 @@ public class VdbImportImpl extends RelationalObjectImpl implements VdbImport {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public boolean resolvable( final UnitOfWork transaction,
-                                   final Repository repository,
                                    final KomodoObject kobject ) {
             try {
-                ObjectImpl.validateType(transaction, repository, kobject, VdbLexicon.ImportVdb.IMPORT_VDB);
+                ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, VdbLexicon.ImportVdb.IMPORT_VDB );
                 return true;
             } catch (final Exception e) {
                 // not resolvable
@@ -67,23 +94,12 @@ public class VdbImportImpl extends RelationalObjectImpl implements VdbImport {
          * {@inheritDoc}
          *
          * @see org.komodo.relational.internal.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
-         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject)
+         *      org.komodo.spi.repository.KomodoObject)
          */
         @Override
         public VdbImport resolve( final UnitOfWork transaction,
-                                  final Repository repository,
                                   final KomodoObject kobject ) throws KException {
-            return new VdbImportImpl(transaction, repository, kobject.getAbsolutePath());
-        }
-
-        @Override
-        public VdbImport create(UnitOfWork transaction,
-                                                      KomodoObject parent,
-                                                      String id,
-                                                      RelationalProperties properties) throws KException {
-            AdapterFactory adapter = new AdapterFactory(parent.getRepository());
-            Vdb parentVdb = adapter.adapt(transaction, parent, Vdb.class);
-            return RelationalModelFactory.createVdbImport(transaction, parent.getRepository(), parentVdb, id);
+            return new VdbImportImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
         }
 
     };

--- a/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
@@ -287,7 +287,6 @@ public class WorkspaceManager implements StringConstants {
                                                   KomodoType type,
                                                   RelationalProperty... properties) throws KException {
 
-        ArgCheck.isNotNull(parent, "parent"); //$NON-NLS-1$
         ArgCheck.isNotEmpty(id, "id"); //$NON-NLS-1$
         ArgCheck.isNotNull(type);
 
@@ -310,10 +309,15 @@ public class WorkspaceManager implements StringConstants {
         try {
             TypeResolverRegistry registry = TypeResolverRegistry.getInstance();
             TypeResolver resolver = registry.getResolver(type);
-            if (resolver == null)
-                return parent.addChild(transaction, id, JcrConstants.NT_UNSTRUCTURED);
+            if (resolver == null) {
+                if (parent == null) {
+                    return getRepository().komodoWorkspace( transaction ).addChild(transaction, id, JcrConstants.NT_UNSTRUCTURED);
+                }
 
-            result = resolver.create(transaction, parent, id, relProperties);
+                return parent.addChild(transaction, id, JcrConstants.NT_UNSTRUCTURED);
+            }
+
+            result = resolver.create(transaction, getRepository(), parent, id, relProperties);
 
             if (uow == null) {
                 transaction.commit();

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
@@ -12,13 +12,17 @@ import org.komodo.relational.model.internal.IndexImplTest;
 import org.komodo.relational.model.internal.ModelImplTest;
 import org.komodo.relational.model.internal.ParameterImplTest;
 import org.komodo.relational.model.internal.PrimaryKeyImplTest;
+import org.komodo.relational.model.internal.PushdownFunctionImplTest;
 import org.komodo.relational.model.internal.ResultSetColumnImplTest;
 import org.komodo.relational.model.internal.StatementOptionImplTest;
+import org.komodo.relational.model.internal.StoredProcedureImplTest;
 import org.komodo.relational.model.internal.TableConstraintTest;
 import org.komodo.relational.model.internal.TableImplTest;
 import org.komodo.relational.model.internal.TabularResultSetImplTest;
 import org.komodo.relational.model.internal.UniqueConstraintImplTest;
+import org.komodo.relational.model.internal.UserDefinedFunctionImplTest;
 import org.komodo.relational.model.internal.ViewImplTest;
+import org.komodo.relational.model.internal.VirtualProcedureImplTest;
 import org.komodo.relational.vdb.internal.ConditionImplTest;
 import org.komodo.relational.vdb.internal.DataRoleImplTest;
 import org.komodo.relational.vdb.internal.EntryImplTest;
@@ -47,13 +51,17 @@ import org.komodo.relational.workspace.WorkspaceManagerTest;
     ModelImplTest.class,
     ParameterImplTest.class,
     PrimaryKeyImplTest.class,
+    PushdownFunctionImplTest.class,
     ResultSetColumnImplTest.class,
     StatementOptionImplTest.class,
+    StoredProcedureImplTest.class,
     TableConstraintTest.class,
     TableImplTest.class,
     TabularResultSetImplTest.class,
     UniqueConstraintImplTest.class,
+    UserDefinedFunctionImplTest.class,
     ViewImplTest.class,
+    VirtualProcedureImplTest.class,
 
     // VDB
     ConditionImplTest.class,

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AbstractProcedureImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AbstractProcedureImplTest.java
@@ -219,7 +219,7 @@ public final class AbstractProcedureImplTest extends RelationalModelTest {
         this.procedure.setSchemaElementType( null, value );
         assertThat( this.procedure.getSchemaElementType( null ), is( value ) );
         assertThat( this.procedure.getProperty( null, TeiidDdlLexicon.SchemaElement.TYPE ).getStringValue( null ),
-                    is( value.toString() ) );
+                    is( value.name() ) );
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AccessPatternImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AccessPatternImplTest.java
@@ -54,7 +54,7 @@ public class AccessPatternImplTest extends RelationalModelTest {
     public void shouldHaveCorrectConstraintType() throws Exception {
         assertThat(this.accessPattern.getConstraintType(), is(TableConstraint.ConstraintType.ACCESS_PATTERN));
         assertThat(this.accessPattern.getProperty(null, TeiidDdlLexicon.Constraint.TYPE).getStringValue(null),
-                   is(TableConstraint.ConstraintType.ACCESS_PATTERN.toString()));
+                   is(TableConstraint.ConstraintType.ACCESS_PATTERN.toValue()));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
@@ -231,7 +231,7 @@ public final class ColumnImplTest extends RelationalModelTest {
         assertThat(this.column.hasProperty(null, StandardDdlLexicon.NULLABLE), is(true));
         assertThat(this.column.getNullable(null), is(RelationalConstants.Nullable.DEFAULT_VALUE));
         assertThat(this.column.getProperty(null, StandardDdlLexicon.NULLABLE).getStringValue(null),
-                   is(RelationalConstants.Nullable.DEFAULT_VALUE.toString()));
+                   is(RelationalConstants.Nullable.DEFAULT_VALUE.toValue()));
     }
 
     @Test
@@ -415,7 +415,7 @@ public final class ColumnImplTest extends RelationalModelTest {
         final Nullable value = Nullable.NO_NULLS;
         this.column.setNullable(null, value);
         assertThat(this.column.getNullable(null), is(value));
-        assertThat(this.column.getProperty(null, StandardDdlLexicon.NULLABLE).getStringValue(null), is(value.toString()));
+        assertThat(this.column.getProperty(null, StandardDdlLexicon.NULLABLE).getStringValue(null), is(value.toValue()));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ForeignKeyImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ForeignKeyImplTest.java
@@ -83,7 +83,7 @@ public class ForeignKeyImplTest extends RelationalModelTest {
     public void shouldHaveCorrectConstraintType() throws Exception {
         assertThat(this.foreignKey.getConstraintType(), is(TableConstraint.ConstraintType.FOREIGN_KEY));
         assertThat(this.foreignKey.getProperty(null, TeiidDdlLexicon.Constraint.TYPE).getStringValue(null),
-                   is(TableConstraint.ConstraintType.FOREIGN_KEY.toString()));
+                   is(TableConstraint.ConstraintType.FOREIGN_KEY.toValue()));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/IndexImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/IndexImplTest.java
@@ -83,7 +83,7 @@ public class IndexImplTest extends RelationalModelTest {
     public void shouldHaveCorrectConstraintType() throws Exception {
         assertThat(this.index.getConstraintType(), is(TableConstraint.ConstraintType.INDEX));
         assertThat(this.index.getProperty(null, TeiidDdlLexicon.Constraint.TYPE).getStringValue(null),
-                   is(TableConstraint.ConstraintType.INDEX.toString()));
+                   is(TableConstraint.ConstraintType.INDEX.toValue()));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ModelImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ModelImplTest.java
@@ -132,7 +132,7 @@ public final class ModelImplTest extends RelationalModelTest {
     public void shouldAllowNullModelTypeWhenSettingToDefaultValue() throws Exception {
         this.model.setModelType( null, Type.VIRTUAL );
         this.model.setModelType( null, null );
-        assertThat( this.model.getModelType( null ), is( Type.DEFAULT ) );
+        assertThat( this.model.getModelType( null ), is( Type.DEFAULT_VALUE ) );
     }
 
     @Test( expected = IllegalArgumentException.class )

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ParameterImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ParameterImplTest.java
@@ -183,7 +183,7 @@ public final class ParameterImplTest extends RelationalModelTest {
         assertThat(this.parameter.getDirection(null), is(Direction.DEFAULT_VALUE));
         assertThat(this.parameter.hasProperty(null, TeiidDdlLexicon.CreateProcedure.PARAMETER_TYPE), is(true));
         assertThat(this.parameter.getProperty(null, TeiidDdlLexicon.CreateProcedure.PARAMETER_TYPE).getStringValue(null),
-                   is(Direction.DEFAULT_VALUE.toString()));
+                   is(Direction.DEFAULT_VALUE.toValue()));
     }
 
     @Test
@@ -191,7 +191,7 @@ public final class ParameterImplTest extends RelationalModelTest {
         assertThat(this.parameter.getNullable(null), is(Nullable.DEFAULT_VALUE));
         assertThat(this.parameter.hasProperty(null, StandardDdlLexicon.NULLABLE), is(true));
         assertThat(this.parameter.getProperty(null, StandardDdlLexicon.NULLABLE).getStringValue(null),
-                   is(RelationalConstants.Nullable.DEFAULT_VALUE.toString()));
+                   is(RelationalConstants.Nullable.DEFAULT_VALUE.toValue()));
     }
 
     @Test
@@ -273,7 +273,7 @@ public final class ParameterImplTest extends RelationalModelTest {
         this.parameter.setDirection(null, value);
         assertThat(this.parameter.getDirection(null), is(value));
         assertThat(this.parameter.getProperty(null, TeiidDdlLexicon.CreateProcedure.PARAMETER_TYPE).getStringValue(null),
-                   is(value.toString()));
+                   is(value.toValue()));
     }
 
     @Test
@@ -281,7 +281,7 @@ public final class ParameterImplTest extends RelationalModelTest {
         final Nullable value = Nullable.NO_NULLS;
         this.parameter.setNullable(null, value);
         assertThat(this.parameter.getNullable(null), is(value));
-        assertThat(this.parameter.getProperty(null, StandardDdlLexicon.NULLABLE).getStringValue(null), is(value.toString()));
+        assertThat(this.parameter.getProperty(null, StandardDdlLexicon.NULLABLE).getStringValue(null), is(value.toValue()));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PrimaryKeyImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PrimaryKeyImplTest.java
@@ -54,7 +54,7 @@ public class PrimaryKeyImplTest extends RelationalModelTest {
     public void shouldHaveCorrectConstraintType() throws Exception {
         assertThat(this.primaryKey.getConstraintType(), is(TableConstraint.ConstraintType.PRIMARY_KEY));
         assertThat(this.primaryKey.getProperty(null, TeiidDdlLexicon.Constraint.TYPE).getStringValue(null),
-                   is(TableConstraint.ConstraintType.PRIMARY_KEY.toString()));
+                   is(TableConstraint.ConstraintType.PRIMARY_KEY.toValue()));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PushdownFunctionImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PushdownFunctionImplTest.java
@@ -25,6 +25,7 @@ import org.komodo.relational.model.PushdownFunction;
 import org.komodo.relational.model.SchemaElement.SchemaElementType;
 import org.komodo.relational.model.TabularResultSet;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
 
 @SuppressWarnings( {"javadoc", "nls"} )
@@ -55,6 +56,20 @@ public final class PushdownFunctionImplTest extends RelationalModelTest {
     }
 
     @Test
+    public void shouldGetOnlyResultSetWhenGettingChildren() throws Exception {
+        final TabularResultSet resultSet = this.function.setResultSet( null, TabularResultSet.class );
+        assertThat(this.function.getChildren( null ).length, is(1));
+        assertThat(this.function.getChildren( null )[0], is((KomodoObject)resultSet));
+    }
+
+    @Test
+    public void shouldGetChildren() throws Exception {
+        this.function.addParameter( null, "param" );
+        this.function.setResultSet( null, DataTypeResultSet.class );
+        assertThat(this.function.getChildren( null ).length, is(2));
+    }
+
+    @Test
     public void shouldHaveCorrectSchemaElementType() throws Exception {
         assertThat( this.function.getSchemaElementType( null ), is( SchemaElementType.FOREIGN ) );
     }
@@ -67,7 +82,7 @@ public final class PushdownFunctionImplTest extends RelationalModelTest {
     @Test
     public void shouldRemoveResultSet() throws Exception {
         final Repository.UnitOfWork uow = _repo.createTransaction( this.name.getMethodName(), false, null );
-        this.function.setResultSet( uow, true );
+        this.function.setResultSet( uow, TabularResultSet.class );
         this.function.removeResultSet( uow );
         uow.commit();
 
@@ -77,7 +92,7 @@ public final class PushdownFunctionImplTest extends RelationalModelTest {
     @Test
     public void shouldSetDataTypeResultSet() throws Exception {
         final Repository.UnitOfWork uow = _repo.createTransaction( this.name.getMethodName(), false, null );
-        assertThat( this.function.setResultSet( uow, false ), is( notNullValue() ) );
+        assertThat( this.function.setResultSet( uow, DataTypeResultSet.class ), is( notNullValue() ) );
         assertThat( this.function.getResultSet( uow ), is( instanceOf( DataTypeResultSet.class ) ) );
         uow.commit();
     }
@@ -85,7 +100,7 @@ public final class PushdownFunctionImplTest extends RelationalModelTest {
     @Test
     public void shouldSetTabularResultSet() throws Exception {
         final Repository.UnitOfWork uow = _repo.createTransaction( this.name.getMethodName(), false, null );
-        assertThat( this.function.setResultSet( uow, true ), is( notNullValue() ) );
+        assertThat( this.function.setResultSet( uow, TabularResultSet.class ), is( notNullValue() ) );
         assertThat( this.function.getResultSet( uow ), is( instanceOf( TabularResultSet.class ) ) );
         uow.commit();
     }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ResultSetColumnImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ResultSetColumnImplTest.java
@@ -130,7 +130,7 @@ public final class ResultSetColumnImplTest extends RelationalModelTest {
         assertThat( this.column.hasProperty( null, StandardDdlLexicon.NULLABLE ), is( true ) );
         assertThat( this.column.getNullable( null ), is( RelationalConstants.Nullable.DEFAULT_VALUE ) );
         assertThat( this.column.getProperty( null, StandardDdlLexicon.NULLABLE ).getStringValue( null ),
-                    is( RelationalConstants.Nullable.DEFAULT_VALUE.toString() ) );
+                    is( RelationalConstants.Nullable.DEFAULT_VALUE.toValue() ) );
     }
 
     @Test
@@ -221,7 +221,7 @@ public final class ResultSetColumnImplTest extends RelationalModelTest {
         final Nullable value = Nullable.NO_NULLS;
         this.column.setNullable( null, value );
         assertThat( this.column.getNullable( null ), is( value ) );
-        assertThat( this.column.getProperty( null, StandardDdlLexicon.NULLABLE ).getStringValue( null ), is( value.toString() ) );
+        assertThat( this.column.getProperty( null, StandardDdlLexicon.NULLABLE ).getStringValue( null ), is( value.toValue() ) );
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StoredProcedureImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StoredProcedureImplTest.java
@@ -26,6 +26,7 @@ import org.komodo.relational.model.TabularResultSet;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
 
 @SuppressWarnings( {"javadoc", "nls"} )
@@ -65,6 +66,20 @@ public final class StoredProcedureImplTest extends RelationalModelTest {
     @Test( expected = KException.class )
     public void shouldFailSettingNullNativeQueryWhenNeverAdded() throws Exception {
         this.procedure.setNativeQuery( null, null );
+    }
+
+    @Test
+    public void shouldGetOnlyResultSetWhenGettingChildren() throws Exception {
+        final TabularResultSet resultSet = this.procedure.setResultSet( null, TabularResultSet.class );
+        assertThat(this.procedure.getChildren( null ).length, is(1));
+        assertThat(this.procedure.getChildren( null )[0], is((KomodoObject)resultSet));
+    }
+
+    @Test
+    public void shouldGetChildren() throws Exception {
+        this.procedure.addParameter( null, "param" );
+        this.procedure.setResultSet( null, DataTypeResultSet.class );
+        assertThat(this.procedure.getChildren( null ).length, is(2));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableImplTest.java
@@ -231,6 +231,11 @@ public final class TableImplTest extends RelationalModelTest {
     }
 
     @Test( expected = KException.class )
+    public void shouldFailSettingEmptyUuidWhenNeverAdded() throws Exception {
+        this.table.setUuid( null, StringConstants.EMPTY_STRING );
+    }
+
+    @Test( expected = KException.class )
     public void shouldFailSettingNullDescriptionWhenNeverAdded() throws Exception {
         this.table.setDescription(null, null);
     }
@@ -248,6 +253,11 @@ public final class TableImplTest extends RelationalModelTest {
     @Test( expected = KException.class )
     public void shouldFailSettingNullStatementOptionValueWhenNeverAdded() throws Exception {
         this.table.setStatementOption(null, "blah", null);
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailSettingNullUuidWhenNeverAdded() throws Exception {
+        this.table.setUuid( null, null );
     }
 
     @Test( expected = IllegalArgumentException.class )
@@ -574,7 +584,7 @@ public final class TableImplTest extends RelationalModelTest {
         final OnCommit value = OnCommit.DELETE_ROWS;
         this.table.setOnCommitValue(null, value);
         assertThat(this.table.getOnCommitValue(null), is(value));
-        assertThat(this.table.getProperty(null, StandardDdlLexicon.ON_COMMIT_VALUE).getStringValue(null), is(value.toString()));
+        assertThat(this.table.getProperty(null, StandardDdlLexicon.ON_COMMIT_VALUE).getStringValue(null), is(value.toValue()));
     }
 
     @Test
@@ -598,7 +608,7 @@ public final class TableImplTest extends RelationalModelTest {
         final SchemaElementType value = SchemaElementType.VIRTUAL;
         this.table.setSchemaElementType(null, value);
         assertThat(this.table.getSchemaElementType(null), is(value));
-        assertThat(this.table.getProperty(null, TeiidDdlLexicon.SchemaElement.TYPE).getStringValue(null), is(value.toString()));
+        assertThat(this.table.getProperty(null, TeiidDdlLexicon.SchemaElement.TYPE).getStringValue(null), is(value.name()));
     }
 
     @Test
@@ -606,7 +616,7 @@ public final class TableImplTest extends RelationalModelTest {
         final TemporaryType value = TemporaryType.GLOBAL;
         this.table.setTemporaryTableType(null, value);
         assertThat(this.table.getTemporaryTableType(null), is(value));
-        assertThat(this.table.getProperty(null, StandardDdlLexicon.TEMPORARY).getStringValue(null), is(value.toString()));
+        assertThat(this.table.getProperty(null, StandardDdlLexicon.TEMPORARY).getStringValue(null), is(value.name()));
     }
 
     @Test
@@ -614,6 +624,13 @@ public final class TableImplTest extends RelationalModelTest {
         final boolean value = !Table.DEFAULT_UPDATABLE;
         this.table.setUpdatable(null, value);
         assertThat(this.table.isUpdatable(null), is(value));
+    }
+
+    @Test
+    public void shouldSetUuid() throws Exception {
+        final String value = "uuid";
+        this.table.setUuid( null, value );
+        assertThat( this.table.getUuid( null ), is( value ) );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UniqueConstraintImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UniqueConstraintImplTest.java
@@ -54,7 +54,7 @@ public class UniqueConstraintImplTest extends RelationalModelTest {
     public void shouldHaveCorrectConstraintType() throws Exception {
         assertThat(this.uniqueConstraint.getConstraintType(), is(TableConstraint.ConstraintType.UNIQUE));
         assertThat(this.uniqueConstraint.getProperty(null, TeiidDdlLexicon.Constraint.TYPE).getStringValue(null),
-                   is(TableConstraint.ConstraintType.UNIQUE.toString()));
+                   is(TableConstraint.ConstraintType.UNIQUE.toValue()));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/workspace/WorkspaceManagerTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/workspace/WorkspaceManagerTest.java
@@ -138,6 +138,15 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
     }
 
     @Test
+    public void shouldCreateModelAtWorkspaceRoot() throws Exception {
+        final String modelName = "model";
+        final Model model = this.wsMgr.createModel( null, null, modelName );
+        assertThat(model, is(notNullValue()));
+        assertThat(this.wsMgr.findModels( null ).length, is(1));
+        assertThat(this.wsMgr.findModels( null )[0].getName( null ), is(modelName));
+    }
+
+    @Test
     public void shouldCreateVdb() throws Exception {
         final KomodoObject parent = _repo.add(null, _repo.komodoWorkspace(null).getAbsolutePath(), "parent", null);
         final Vdb vdb = createVdb(null, parent, this.name.getMethodName());


### PR DESCRIPTION
When creating a model, the parent can now be null or not null. Changed enums `toString` method to `toValue` so that the `toString` can be used for localization if needed. Modified the `TypeResolver.create` method to take a `Repository` argument. This allows the parent arg to be `null` if needed (like for models). Removed the `Repository` arg from `TypeResolver.resolvable` and `TypeResolvable.resolve` methods as the repository can be obtained from the `KomodoObject` being resolved. `ProcedureResultSet` objects are now being returned in the `StoredProcedure.getChildren` and the `PushdownFunction.getChildren` methods.