### PR TITLE
Added the new KomodoObject.remove method

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
@@ -1094,6 +1094,37 @@ public class ObjectImpl implements KomodoObject, StringConstants {
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.spi.repository.KomodoObject#remove(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public void remove( final UnitOfWork uow ) throws KException {
+        UnitOfWork transaction = uow;
+
+        if (uow == null) {
+            transaction = getRepository().createTransaction( "objectimpl-remove", false, null ); //$NON-NLS-1$
+        }
+
+        assert ( transaction != null );
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug( "objectimpl-remove: transaction = {0}, path = {1}", transaction.getName(), getAbsolutePath() ); //$NON-NLS-1$
+        }
+
+        try {
+            final Node node = node( transaction );
+            node.remove();
+
+            if (uow == null) {
+                transaction.commit();
+            }
+        } catch (final Exception e) {
+            throw handleError( uow, transaction, e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.spi.repository.KomodoObject#removeChild(org.komodo.spi.repository.Repository.UnitOfWork,
      *      java.lang.String[])
      */

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AbstractProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AbstractProcedureImpl.java
@@ -418,7 +418,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
             if (parameters.length != 0) {
                 for (final Parameter parameter : parameters) {
                     if (parameterName.equals( parameter.getName( transaction ) )) {
-                        removeChild( transaction, parameterName );
+                        parameter.remove( transaction );
                         found = true;
                         break;
                     }
@@ -469,7 +469,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
             if (options.length != 0) {
                 for (final StatementOption option : options) {
                     if (optionToRemove.equals( option.getName( transaction ) )) {
-                        removeChild( transaction, optionToRemove );
+                        option.remove( transaction );
                         found = true;
                         break;
                     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ColumnImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ColumnImpl.java
@@ -731,7 +731,7 @@ public final class ColumnImpl extends RelationalObjectImpl implements Column {
             if (options.length != 0) {
                 for (final StatementOption option : options) {
                     if (optionToRemove.equals(option.getName(transaction))) {
-                        removeChild(transaction, optionToRemove);
+                        option.remove( transaction );
                         found = true;
                         break;
                     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
@@ -845,7 +845,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
             if (functions.length != 0) {
                 for (final Function function : functions) {
                     if (functionName.equals( function.getName( transaction ) )) {
-                        removeChild( transaction, functionName );
+                        function.remove( transaction );
                         found = true;
                         break;
                     }
@@ -895,7 +895,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
             if (procedures.length != 0) {
                 for (final Procedure procedure : procedures) {
                     if (procedureName.equals( procedure.getName( transaction ) )) {
-                        removeChild( transaction, procedureName );
+                        procedure.remove( transaction );
                         found = true;
                         break;
                     }
@@ -945,8 +945,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
             if (sources.length != 0) {
                 for (final ModelSource source : sources) {
                     if (sourceToRemove.equals( source.getName( transaction ) )) {
-                        final KomodoObject grouping = getChild( transaction, VdbLexicon.Vdb.SOURCES );
-                        grouping.removeChild( transaction, sourceToRemove );
+                        source.remove( transaction );
                         found = true;
                         break;
                     }
@@ -996,7 +995,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
             if (tables.length != 0) {
                 for (final Table table : tables) {
                     if (tableName.equals( table.getName( transaction ) )) {
-                        removeChild( transaction, tableName );
+                        table.remove( transaction );
                         found = true;
                         break;
                     }
@@ -1046,7 +1045,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
             if (views.length != 0) {
                 for (final View view : views) {
                     if (viewName.equals( view.getName( transaction ) )) {
-                        removeChild( transaction, viewName );
+                        view.remove( transaction );
                         found = true;
                         break;
                     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ParameterImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ParameterImpl.java
@@ -382,7 +382,7 @@ public final class ParameterImpl extends RelationalObjectImpl implements Paramet
             if (options.length != 0) {
                 for (final StatementOption option : options) {
                     if (optionToRemove.equals( option.getName( transaction ) )) {
-                        removeChild( transaction, optionToRemove );
+                        option.remove( transaction );
                         found = true;
                         break;
                     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/PushdownFunctionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/PushdownFunctionImpl.java
@@ -254,7 +254,7 @@ public final class PushdownFunctionImpl extends FunctionImpl implements Pushdown
                 throw new KException( Messages.getString( Relational.RESULT_SET_NOT_FOUND_TO_REMOVE, getAbsolutePath() ) );
             }
 
-            removeChild( transaction, resultSet.getName( transaction ) );
+            resultSet.remove( transaction );
 
             if (uow == null) {
                 transaction.commit();
@@ -287,11 +287,11 @@ public final class PushdownFunctionImpl extends FunctionImpl implements Pushdown
         }
 
         try {
-            // delete existing result set
+            // delete existing result set (don't call removeResultSet)
             final ProcedureResultSet resultSet = getResultSet( transaction );
 
             if (resultSet != null) {
-                removeChild( transaction, resultSet.getName( transaction ) );
+                resultSet.remove( transaction );
             }
 
             T result = null;

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
@@ -410,7 +410,7 @@ public final class ResultSetColumnImpl extends RelationalObjectImpl implements R
             if (options.length != 0) {
                 for (final StatementOption option : options) {
                     if (optionToRemove.equals( option.getName( transaction ) )) {
-                        removeChild( transaction, optionToRemove );
+                        option.remove( transaction );
                         found = true;
                         break;
                     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StoredProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StoredProcedureImpl.java
@@ -330,7 +330,7 @@ public final class StoredProcedureImpl extends AbstractProcedureImpl implements 
                 throw new KException( Messages.getString( Relational.RESULT_SET_NOT_FOUND_TO_REMOVE, getAbsolutePath() ) );
             }
 
-            removeChild( transaction, resultSet.getName( transaction ) );
+            resultSet.remove( transaction );
 
             if (uow == null) {
                 transaction.commit();
@@ -387,11 +387,11 @@ public final class StoredProcedureImpl extends AbstractProcedureImpl implements 
         }
 
         try {
-            // delete existing result set
+            // delete existing result set (don't call removeResultSet)
             final ProcedureResultSet resultSet = getResultSet( transaction );
 
             if (resultSet != null) {
-                removeChild( transaction, resultSet.getName( transaction ) );
+                resultSet.remove( transaction );
             }
 
             T result = null;

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TableImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TableImpl.java
@@ -1060,7 +1060,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
             if (accessPatterns.length != 0) {
                 for (final AccessPattern accessPattern : accessPatterns) {
                     if (accessPatternToRemove.equals(accessPattern.getName(transaction))) {
-                        removeChild(transaction, accessPatternToRemove);
+                        accessPattern.remove( transaction );
                         found = true;
                         break;
                     }
@@ -1112,7 +1112,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
             if (columns.length != 0) {
                 for (final Column column : columns) {
                     if (columnToRemove.equals(column.getName(transaction))) {
-                        removeChild(transaction, columnToRemove);
+                        column.remove( transaction );
                         found = true;
                         break;
                     }
@@ -1162,7 +1162,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
             if (foreignKeys.length != 0) {
                 for (final ForeignKey foreignKey : foreignKeys) {
                     if (foreignKeyToRemove.equals(foreignKey.getName(transaction))) {
-                        removeChild(transaction, foreignKeyToRemove);
+                        foreignKey.remove( transaction );
                         found = true;
                         break;
                     }
@@ -1214,7 +1214,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
             if (indexes.length != 0) {
                 for (final Index index : indexes) {
                     if (indexToRemove.equals(index.getName(transaction))) {
-                        removeChild(transaction, indexToRemove);
+                        index.remove( transaction );
                         found = true;
                         break;
                     }
@@ -1263,7 +1263,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
                                                         PrimaryKey.CONSTRAINT_TYPE.toString()));
             }
 
-            removeChild(transaction, primaryKey.getName(transaction));
+            primaryKey.remove( transaction );
 
             if (uow == null) {
                 transaction.commit();
@@ -1305,7 +1305,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
             if (options.length != 0) {
                 for (final StatementOption option : options) {
                     if (optionToRemove.equals(option.getName(transaction))) {
-                        removeChild(transaction, optionToRemove);
+                        option.remove( transaction );
                         found = true;
                         break;
                     }
@@ -1356,7 +1356,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
             if (uniqueConstraints.length != 0) {
                 for (final UniqueConstraint uniqueConstraint : uniqueConstraints) {
                     if (constraintToRemove.equals(uniqueConstraint.getName(transaction))) {
-                        removeChild(transaction, constraintToRemove);
+                        uniqueConstraint.remove( transaction );
                         found = true;
                         break;
                     }
@@ -1470,11 +1470,11 @@ public class TableImpl extends RelationalObjectImpl implements Table {
         }
 
         try {
-            // delete existing primary key
+            // delete existing primary key (dont' call removePrimaryKey)
             final PrimaryKey primaryKey = getPrimaryKey(transaction);
 
             if (primaryKey != null) {
-                removeChild(transaction, primaryKey.getName(transaction));
+                primaryKey.remove( transaction );
             }
 
             final PrimaryKey result = RelationalModelFactory.createPrimaryKey(transaction,

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TabularResultSetImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TabularResultSetImpl.java
@@ -259,7 +259,7 @@ public final class TabularResultSetImpl extends RelationalObjectImpl implements 
             if (columns.length != 0) {
                 for (final ResultSetColumn column : columns) {
                     if (columnToRemove.equals( column.getName( transaction ) )) {
-                        removeChild( transaction, columnToRemove );
+                        column.remove( transaction );
                         found = true;
                         break;
                     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/DataRoleImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/DataRoleImpl.java
@@ -541,17 +541,20 @@ public final class DataRoleImpl extends RelationalObjectImpl implements DataRole
         boolean found = false;
 
         try {
-            if (hasChild(transaction, VdbLexicon.DataRole.PERMISSIONS)) {
-                final KomodoObject grouping = getChild(transaction, VdbLexicon.DataRole.PERMISSIONS);
+            final Permission[] permissions = getPermissions( transaction );
 
-                if (grouping.hasChild(transaction, permissionToRemove)) {
-                    grouping.removeChild(transaction, permissionToRemove);
-                    found = true;
+            if (permissions.length != 0) {
+                for (final Permission permission : permissions) {
+                    if (permissionToRemove.equals( permission.getName( transaction ) )) {
+                        permission.remove( transaction );
+                        found = true;
+                        break;
+                    }
                 }
             }
 
             if (!found) {
-                throw new KException(Messages.getString(Relational.PERMISSION_NOT_FOUND_TO_REMOVE, permissionToRemove));
+                throw new KException( Messages.getString( Relational.PERMISSION_NOT_FOUND_TO_REMOVE, permissionToRemove ) );
             }
 
             if (uow == null) {

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/PermissionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/PermissionImpl.java
@@ -536,12 +536,15 @@ public final class PermissionImpl extends RelationalObjectImpl implements Permis
         boolean found = false;
 
         try {
-            if (hasChild(transaction, VdbLexicon.DataRole.Permission.CONDITIONS)) {
-                final KomodoObject grouping = getChild(transaction, VdbLexicon.DataRole.Permission.CONDITIONS);
+            final Condition[] conditions = getConditions(transaction);
 
-                if (grouping.hasChild(transaction, conditionToRemove)) {
-                    grouping.removeChild(transaction, conditionToRemove);
-                    found = true;
+            if (conditions.length != 0) {
+                for (final Condition condition : conditions) {
+                    if (conditionToRemove.equals( condition.getName( transaction ) )) {
+                        condition.remove( transaction );
+                        found = true;
+                        break;
+                    }
                 }
             }
 
@@ -583,17 +586,20 @@ public final class PermissionImpl extends RelationalObjectImpl implements Permis
         boolean found = false;
 
         try {
-            if (hasChild(transaction, VdbLexicon.DataRole.Permission.MASKS)) {
-                final KomodoObject grouping = getChild(transaction, VdbLexicon.DataRole.Permission.MASKS);
+            final Mask[] masks = getMasks( transaction );
 
-                if (grouping.hasChild(transaction, maskToRemove)) {
-                    grouping.removeChild(transaction, maskToRemove);
-                    found = true;
+            if (masks.length != 0) {
+                for (final Mask mask : masks) {
+                    if (maskToRemove.equals( mask.getName( transaction ) )) {
+                        mask.remove( transaction );
+                        found = true;
+                        break;
+                    }
                 }
             }
 
             if (!found) {
-                throw new KException(Messages.getString(Relational.MASK_NOT_FOUND_TO_REMOVE, maskToRemove));
+                throw new KException( Messages.getString( Relational.MASK_NOT_FOUND_TO_REMOVE, maskToRemove ) );
             }
 
             if (uow == null) {

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
@@ -910,8 +910,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
             if (dataRoles.length != 0) {
                 for (final DataRole dataRole : dataRoles) {
                     if (dataRoleToRemove.equals(dataRole.getName(transaction))) {
-                        final KomodoObject grouping = getChild(transaction, VdbLexicon.Vdb.DATA_ROLES);
-                        grouping.removeChild(transaction, dataRoleToRemove);
+                        dataRole.remove(transaction);
                         found = true;
                         break;
                     }
@@ -961,8 +960,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
             if (entries.length != 0) {
                 for (final Entry entry : entries) {
                     if (entryToRemove.equals(entry.getName(transaction))) {
-                        final KomodoObject grouping = getChild(transaction, VdbLexicon.Vdb.ENTRIES);
-                        grouping.removeChild(transaction, entryToRemove);
+                        entry.remove(transaction);
                         found = true;
                         break;
                     }
@@ -1012,8 +1010,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
             if (vdbImports.length != 0) {
                 for (final VdbImport vdbImport : vdbImports) {
                     if (importToRemove.equals(vdbImport.getName(transaction))) {
-                        final KomodoObject grouping = getChild(transaction, VdbLexicon.Vdb.IMPORT_VDBS);
-                        grouping.removeChild(transaction, importToRemove);
+                        vdbImport.remove(transaction);
                         found = true;
                         break;
                     }
@@ -1063,7 +1060,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
             if (models.length != 0) {
                 for (final Model model : models) {
                     if (modelToRemove.equals(model.getName(transaction))) {
-                        removeChild(transaction, modelToRemove);
+                        model.remove(transaction);
                         found = true;
                         break;
                     }
@@ -1113,8 +1110,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
             if (translators.length != 0) {
                 for (final Translator translator : translators) {
                     if (translatorToRemove.equals(translator.getName(transaction))) {
-                        final KomodoObject grouping = getChild(transaction, VdbLexicon.Vdb.TRANSLATORS);
-                        grouping.removeChild(transaction, translatorToRemove);
+                        translator.remove(transaction);
                         found = true;
                         break;
                     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
@@ -353,7 +353,7 @@ public class WorkspaceManager implements StringConstants {
             for (final KomodoObject kobject : kobjects) {
                 ArgCheck.isNotNull(kobject, "kobject"); //$NON-NLS-1$
                 validateWorkspaceMember(uow, kobject);
-                kobject.getParent(transaction).removeChild(transaction, kobject.getName(transaction));
+                kobject.remove(transaction);
             }
 
             if (uow == null) {

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
@@ -219,7 +219,18 @@ public interface KomodoObject extends KNode {
     void print( final UnitOfWork transaction ) throws KException;
 
     /**
-     * To remove children with same name, the same name must be passed in more than once.
+     * Removes this node.
+     *
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @throws KException
+     *         if an error occurs
+     */
+    void remove( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * To remove children with same name, the same name must be passed in more than once. It is recommended to use
+     * {@link #remove(UnitOfWork)} whenever the node being removed is available.
      *
      * @param transaction
      *        the transaction (can be <code>null</code> if update should be automatically committed)
@@ -227,6 +238,7 @@ public interface KomodoObject extends KNode {
      *        the name(s) of the child(ren) being removed from this object (cannot be empty)
      * @throws KException
      *         if an error occurs
+     * @see #remove(UnitOfWork)
      */
     void removeChild( final UnitOfWork transaction,
                       final String... names ) throws KException;

--- a/tests/org.komodo.core.test/src/org/komodo/repository/test/ObjectImplTest.java
+++ b/tests/org.komodo.core.test/src/org/komodo/repository/test/ObjectImplTest.java
@@ -1,0 +1,153 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.repository.test;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import org.junit.Before;
+import org.junit.Test;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.test.utils.AbstractLocalRepositoryTest;
+
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ObjectImplTest extends AbstractLocalRepositoryTest {
+
+    private static final String NAME = "blah";
+    KomodoObject kobject;
+
+    @Before
+    public void init() throws Exception {
+        this.kobject = _repo.add( null, null, NAME, null );
+    }
+
+    @Test
+    public void shouldAddChild() throws Exception {
+        final String name = "kid";
+        final String type = "nt:folder";
+        final KomodoObject child = this.kobject.addChild( null, name, type );
+        assertThat( _repo.getFromWorkspace( null, child.getAbsolutePath() ), is( notNullValue() ) );
+        assertThat( child.getPrimaryType( null ).getName(), is( type ) );
+    }
+
+    @Test
+    public void shouldAddDescriptor() throws Exception {
+        final String descriptorName = "mix:referenceable";
+        this.kobject.addDescriptor( null, descriptorName );
+        assertThat( this.kobject.hasDescriptor( null, descriptorName ), is( true ) );
+        assertThat( this.kobject.getDescriptors( null ).length, is( 1 ) );
+        assertThat( this.kobject.getDescriptors( null )[0].getName(), is( descriptorName ) );
+    }
+
+    @Test
+    public void shouldAddMultipleDescriptors() throws Exception {
+        final String descriptor1 = "mix:referenceable";
+        final String descriptor2 = "mix:lockable";
+        this.kobject.addDescriptor( null, descriptor1, descriptor2 );
+        assertThat( this.kobject.hasDescriptor( null, descriptor1 ), is( true ) );
+        assertThat( this.kobject.hasDescriptor( null, descriptor2 ), is( true ) );
+        assertThat( this.kobject.getDescriptors( null ).length, is( 2 ) );
+    }
+
+    @Test
+    public void shouldExist() throws Exception {
+        final KomodoObject obj = _repo.getFromWorkspace( null, NAME );
+        assertThat( obj, is( notNullValue() ) );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldFailAddingChildWithEmptyName() throws Exception {
+        this.kobject.addChild( null, EMPTY_STRING, null );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldFailAddingChildWithNullName() throws Exception {
+        this.kobject.addChild( null, null, null );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailAddingEmptyDescriptorName() throws Exception {
+        this.kobject.addDescriptor( null, EMPTY_STRING );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailAddingNullDescriptorName() throws Exception {
+        this.kobject.addDescriptor( null, ( String )null );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailToGetChildIfItDoesNotExist() throws Exception {
+        this.kobject.getChild( null, "blah" );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldFailToGetChildWithEmptyName() throws Exception {
+        this.kobject.getChild( null, EMPTY_STRING );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldFailToGetChildWithNullName() throws Exception {
+        this.kobject.getChild( null, null );
+    }
+
+    @Test
+    public void shouldGetChild() throws Exception {
+        final String name = "kid";
+        this.kobject.addChild( null, name, null );
+        assertThat( this.kobject.getChild( null, name ), is( notNullValue() ) );
+    }
+
+    @Test
+    public void shouldGetIndex() throws Exception {
+        assertThat( this.kobject.getIndex(), is( 0 ) );
+    }
+
+    @Test
+    public void shouldHaveUnknownTypeIdentifier() throws Exception {
+        assertThat( this.kobject.getTypeIdentifier( null ), is( KomodoType.UNKNOWN ) );
+    }
+
+    @Test
+    public void shouldRemove() throws Exception {
+        final KomodoObject obj = _repo.getFromWorkspace( null, NAME );
+        obj.remove( null );
+        assertThat( _repo.getFromWorkspace( null, NAME ), is( nullValue() ) );
+        assertThat( _repo.komodoWorkspace( null ).getChildren( null ).length, is( 0 ) );
+    }
+
+    @Test
+    public void shouldRemoveDescriptor() throws Exception {
+        final String descriptorName = "mix:referenceable";
+        this.kobject.addDescriptor( null, descriptorName );
+        this.kobject.removeDescriptor( null, descriptorName );
+        assertThat( this.kobject.hasDescriptor( null, descriptorName ), is( false ) );
+        assertThat( this.kobject.getDescriptors( null ).length, is( 0 ) );
+    }
+
+    @Test
+    public void shouldRemoveMultipleDescriptors() throws Exception {
+        final String descriptor1 = "mix:referenceable";
+        final String descriptor2 = "mix:lockable";
+        this.kobject.addDescriptor( null, descriptor1, descriptor2 );
+        this.kobject.removeDescriptor( null, descriptor1, descriptor2 );
+        assertThat( this.kobject.hasDescriptor( null, descriptor1 ), is( false ) );
+        assertThat( this.kobject.hasDescriptor( null, descriptor2 ), is( false ) );
+        assertThat( this.kobject.getDescriptors( null ).length, is( 0 ) );
+    }
+
+    @Test
+    public void shouldSetPrimaryType() throws Exception {
+        final String newType = "nt:folder";
+        this.kobject.setPrimaryType( null, newType );
+        assertThat( this.kobject.getPrimaryType( null ).getName(), is( newType ) );
+    }
+
+}


### PR DESCRIPTION
Changed all occurrences of `KomodoObject.removeChild` to use the new method when the node was available (which I believe was in every case). Added test cases.