### PR TITLE
Issue 78 Need ability to rename a KomodoObject

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/Messages.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/Messages.java
@@ -68,6 +68,11 @@ public class Messages implements StringConstants {
         DUPLICATE_OBJECT_ERROR,
         ERROR_ADDING_ARTIFACT,
         ERROR_SESSION_IS_CLOSED,
+
+        /**
+         * Indicates a transaction that had already been run is being run again.
+         */
+        ERROR_TRANSACTION_FINISHED,
         ERROR_TRYING_TO_COMMIT,
         ERROR_TRYING_TO_ROLLBACK,
 

--- a/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
@@ -390,12 +390,13 @@ public class ObjectImpl implements KomodoObject, StringConstants {
 
         try {
             final Node node = node(transaction).addNode(name, type);
+            final KomodoObject result = new ObjectImpl(getRepository(), node.getPath(), node.getIndex());
 
             if (uow == null) {
                 transaction.commit();
             }
 
-            return new ObjectImpl(getRepository(), node.getPath(), node.getIndex());
+            return result;
         } catch (final Exception e) {
             throw handleError(uow, transaction, e);
         }

--- a/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
@@ -182,9 +182,9 @@ public class ObjectImpl implements KomodoObject, StringConstants {
         }
     }
 
-    final int index;
-    final String path;
-    final Repository repository;
+    protected int index;
+    protected String path;
+    final private Repository repository;
 
     /**
      * @param komodoRepository
@@ -1202,6 +1202,50 @@ public class ObjectImpl implements KomodoObject, StringConstants {
             }
         } catch (final Exception e) {
             throw handleError(uow, transaction, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.KomodoObject#rename(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
+     */
+    @Override
+    public void rename( final UnitOfWork uow,
+                        final String newName ) throws KException {
+        ArgCheck.isNotEmpty( newName, "newName" ); //$NON-NLS-1$
+        UnitOfWork transaction = uow;
+
+        if (uow == null) {
+            transaction = getRepository().createTransaction( "objectimpl-rename", false, null ); //$NON-NLS-1$
+        }
+
+        assert ( transaction != null );
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug( "kobject-rename: transaction = {0}, old path = {1}, new name = {1}", //$NON-NLS-1$
+                          transaction.getName(),
+                          getAbsolutePath(),
+                          newName );
+        }
+
+        try {
+            String newPath = getParent( transaction ).getAbsolutePath();
+
+            if (!newPath.endsWith( FORWARD_SLASH )) {
+                newPath += FORWARD_SLASH;
+            }
+
+            newPath += newName;
+            getSession( transaction ).move( getAbsolutePath(), newPath );
+            this.path = newPath;
+            // TODO seems like index could change also
+
+            if (uow == null) {
+                transaction.commit();
+            }
+        } catch (final Exception e) {
+            throw handleError( uow, transaction, e );
         }
     }
 

--- a/plugins/org.komodo.core/src/org/komodo/repository/RepositoryImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/RepositoryImpl.java
@@ -542,7 +542,7 @@ public abstract class RepositoryImpl implements Repository, StringConstants {
 
     @Override
     public List<KomodoObject> searchByKeyword( UnitOfWork uow, String type, String property,
-                                                                             KeywordCriteria keywordCriteria, 
+                                                                             KeywordCriteria keywordCriteria,
                                                                              String... keywords) throws KException {
 
         UnitOfWork transaction = verifyTransaction(uow, "seachByKeyword", true); //$NON-NLS-1$
@@ -562,7 +562,7 @@ public abstract class RepositoryImpl implements Repository, StringConstants {
         searcher.addFromType(type, typeAlias);
         searcher.addWhereContainsClause(null, typeAlias, property, keywordCriteria, keywords);
         List<KomodoObject> searchObjects = searcher.searchObjects(transaction);
-        
+
         return searchObjects;
     }
 
@@ -685,11 +685,13 @@ public abstract class RepositoryImpl implements Repository, StringConstants {
 
         String nodePath = path.trim();
 
-        if (!nodePath.startsWith(WORKSPACE_ROOT)) {
-            if (REPO_ROOT.equals(path)) {
-                return WORKSPACE_ROOT;
-            }
+        // return workspace root if path is forward slash
+        if (REPO_ROOT.equals(nodePath)) {
+            return WORKSPACE_ROOT;
+        }
 
+        // if path does not start with workspace root assume a relative path so insert workspace root
+        if (!nodePath.startsWith(WORKSPACE_ROOT)) {
             if (nodePath.charAt(0) == File.separatorChar) {
                 nodePath = WORKSPACE_ROOT + FORWARD_SLASH + nodePath.substring(1); // remove leading slash
             } else {

--- a/plugins/org.komodo.core/src/org/komodo/repository/internal/ModeshapeEngineThread.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/internal/ModeshapeEngineThread.java
@@ -247,7 +247,7 @@ public class ModeshapeEngineThread extends Thread {
                 request.getCallback().errorOccurred(e);
             }
         } finally {
-            session.logout();
+            if (session.isLive()) session.logout();
         }
     }
 
@@ -293,7 +293,7 @@ public class ModeshapeEngineThread extends Thread {
         LOGGER.debug("rollback session for request {0}", rollbackRequest.getName()); //$NON-NLS-1$
 
         try {
-            session.refresh(false);
+            if (session.isLive()) session.refresh(false);
             LOGGER.debug("rollback session request {0} has been rolled back", rollbackRequest.getName()); //$NON-NLS-1$
 
             if (request.getCallback() != null) {

--- a/plugins/org.komodo.core/src/org/komodo/repository/messages.properties
+++ b/plugins/org.komodo.core/src/org/komodo/repository/messages.properties
@@ -20,6 +20,7 @@ Komodo.ARTIFACT_EXISTS_ERROR = Library artifact "{0}" already exists and overwri
 Komodo.DUPLICATE_OBJECT_ERROR = More than one object found for UUID "{0}"
 Komodo.ERROR_ADDING_ARTIFACT = Error adding artifact "{0}" at path "{1}"
 Komodo.ERROR_SESSION_IS_CLOSED = Error trying to use transaction "{0}" but the session has been closed
+Komodo.ERROR_TRANSACTION_FINISHED = Error trying to use old transaction "{0}" whose state is "{1}"
 Komodo.ERROR_TRYING_TO_COMMIT = Error committing transaction "{0}"
 Komodo.ERROR_TRYING_TO_ROLLBACK = Error rolling back transaction "{0}"
 Komodo.INCORRECT_TYPE = Object at "{0}" is not a "{1}"

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
@@ -1132,6 +1132,43 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.repository.ObjectImpl#rename(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
+     */
+    @Override
+    public void rename( final UnitOfWork uow,
+                        final String newName ) throws KException {
+        ArgCheck.isNotEmpty( newName, "newName" ); //$NON-NLS-1$
+        ArgCheck.doesNotContain( newName, "/", "newName" ); //$NON-NLS-1$ //$NON-NLS-2$
+        UnitOfWork transaction = uow;
+
+        if (uow == null) {
+            transaction = getRepository().createTransaction( "vdbimpl-rename", false, null ); //$NON-NLS-1$
+        }
+
+        assert ( transaction != null );
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug( "vdbimpl-rename: transaction = {0}, old path = {1}, new name = {1}", //$NON-NLS-1$
+                          transaction.getName(),
+                          getAbsolutePath(),
+                          newName );
+        }
+
+        try {
+            super.rename( transaction, newName );
+            setVdbName( transaction, newName );
+
+            if (uow == null) {
+                transaction.commit();
+            }
+        } catch (final Exception e) {
+            throw handleError( uow, transaction, e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.relational.vdb.Vdb#setConnectionType(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
      */
     @Override

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
@@ -257,6 +257,17 @@ public interface KomodoObject extends KNode {
     /**
      * @param transaction
      *        the transaction (can be <code>null</code> if update should be automatically committed)
+     * @param newName
+     *        the new name (cannot be empty or contain any slashes)
+     * @throws KException
+     *         if an error occurs
+     */
+    void rename( final UnitOfWork transaction,
+                 final String newName ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (can be <code>null</code> if update should be automatically committed)
      * @param typeName
      *        the new primary type name or <code>null</code> or empty if setting to <code>nt:unstructured</code>
      * @throws KException

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/Repository.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/Repository.java
@@ -122,6 +122,38 @@ public interface Repository {
     interface UnitOfWork {
 
         /**
+         * The transaction states.
+         */
+        public enum State {
+
+            /**
+             * The transaction has been committed.
+             */
+            COMMITTED,
+
+            /**
+             * There was an error running the transaction.
+             */
+            ERROR,
+
+            /**
+             * The transaction has not been run (neither commit or rollback has been called).
+             */
+            NOT_STARTED,
+
+            /**
+             * The transaction has been rolled back.
+             */
+            ROLLED_BACK,
+
+            /**
+             * The transaction is currently being committed or rolled back.
+             */
+            RUNNING;
+
+        }
+
+        /**
          * Saves all changes made during the transaction. If this is a roll back transaction then {@link #rollback()} is called.
          */
         void commit();
@@ -132,9 +164,20 @@ public interface Repository {
         UnitOfWorkListener getCallback();
 
         /**
+         * @return an error caught during the transaction (can be <code>null</code>)
+         * @see State#ERROR
+         */
+        KException getError();
+
+        /**
          * @return the name of the transaction (never <code>null</code>)
          */
         String getName();
+
+        /**
+         * @return the transaction state (never <code>null</code>)
+         */
+        State getState();
 
         /**
          * @return <code>true</code> if only rollback is allowed

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/Repository.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/Repository.java
@@ -151,7 +151,7 @@ public interface Repository {
     /**
      * A listener notified when a unit of work completes.
      */
-    interface UnitOfWorkListener {
+    public interface UnitOfWorkListener {
 
         /**
          * @param error

--- a/plugins/org.komodo.utils/src/org/komodo/utils/ArgCheck.java
+++ b/plugins/org.komodo.utils/src/org/komodo/utils/ArgCheck.java
@@ -440,6 +440,34 @@ public class ArgCheck {
 //
 
     /**
+     * @param arg
+     *        the argument being checked (cannot be empty)
+     * @param illegalCharacters
+     *        the characters the arg cannot contain (can be empty)
+     * @param message
+     *        the error message used when an illegal character is found (can be empty if a generic message should be used)
+     */
+    public static void doesNotContain( final String arg,
+                                       final String illegalCharacters,
+                                       final String message ) {
+        isNotEmpty( arg, message );
+
+        if (!StringUtils.isBlank( illegalCharacters )) {
+            for (final char c : illegalCharacters.toCharArray()) {
+                if (arg.indexOf( c ) != -1) {
+                    String msg = message;
+
+                    if (StringUtils.isBlank( message )) {
+                        msg = "Argument \"" + arg + "\" contains the illegal character \"c\""; //$NON-NLS-1$ //$NON-NLS-2$
+                    }
+
+                    throw new IllegalArgumentException( msg );
+                }
+            }
+        }
+    }
+
+    /**
      * Can't construct - utility class
      */
     private ArgCheck() {

--- a/plugins/org.komodo.utils/src/org/komodo/utils/StringUtils.java
+++ b/plugins/org.komodo.utils/src/org/komodo/utils/StringUtils.java
@@ -1335,7 +1335,19 @@ public final class StringUtils implements StringConstants {
 
         return sb.toString();
     }
-//
+
+    /**
+     * @param value the string whose leading spaces are being removed (can be empty)
+     * @return the input with leading spaces removed (can be <code>null</code> if input is <code>null</code>)
+     */
+    public static String trimLeft( final String value ) {
+        if (isEmpty(value)) {
+            return value;
+        }
+
+        return value.replaceAll("^\\s+", ""); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
     /**
      * Don't allow construction outside of this class.
      */

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/UnitOfWorkTestListener.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/UnitOfWorkTestListener.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.relational;
+
+import java.util.concurrent.CountDownLatch;
+import org.junit.Assert;
+import org.komodo.spi.repository.Repository.UnitOfWorkListener;
+
+@SuppressWarnings( {"javadoc"} )
+public class UnitOfWorkTestListener implements UnitOfWorkListener {
+
+    protected final CountDownLatch latch;
+
+    public UnitOfWorkTestListener(final CountDownLatch testLatch) {
+        this.latch = testLatch;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Repository.UnitOfWorkListener#errorOccurred(java.lang.Throwable)
+     */
+    @Override
+    public void errorOccurred( final Throwable error ) {
+        Assert.fail();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Repository.UnitOfWorkListener#respond(java.lang.Object)
+     */
+    @Override
+    public void respond( final Object results ) {
+        this.latch.countDown();
+    }
+
+}

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/VdbImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/VdbImplTest.java
@@ -13,12 +13,9 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
-import org.komodo.relational.UnitOfWorkTestListener;
 import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.model.Model;
@@ -30,9 +27,7 @@ import org.komodo.relational.vdb.Vdb.VdbManifest;
 import org.komodo.relational.vdb.VdbImport;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
-import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
-import org.komodo.spi.repository.Repository.UnitOfWorkListener;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 @SuppressWarnings( {"javadoc", "nls"} )
@@ -406,14 +401,7 @@ public final class VdbImplTest extends RelationalModelTest {
     @Test
     public void shouldRename() throws Exception {
         final String newName = "newVdbName";
-        final CountDownLatch latch = new CountDownLatch( 1 );
-        final UnitOfWorkListener callback = new UnitOfWorkTestListener( latch );
-        final Repository.UnitOfWork uow = _repo.createTransaction( this.name.getMethodName(), false, callback );
-
-        this.vdb.rename( uow, newName );
-        uow.commit();
-
-        assertThat( latch.await( 3, TimeUnit.SECONDS ), is( true ) ); // wait for the commit to finish
+        this.vdb.rename( null, newName );
         assertThat( this.vdb.getName( null ), is( newName ) );
         assertThat( this.vdb.getVdbName( null ), is( newName ) );
     }

--- a/tests/org.komodo.test.utils/src/org/komodo/test/utils/MultiUseAbstractTest.java
+++ b/tests/org.komodo.test.utils/src/org/komodo/test/utils/MultiUseAbstractTest.java
@@ -111,7 +111,7 @@ public abstract class MultiUseAbstractTest extends AbstractLoggingTest {
      * value is used instead.
      *
      * @see getTestConfiguration
-     * 
+     *
      * @return the location of modeshape's test configuration file
      */
     protected String getTestConfigurationPath() {
@@ -146,7 +146,7 @@ public abstract class MultiUseAbstractTest extends AbstractLoggingTest {
         repository = engine.deploy(config);
         problems = repository.getStartupProblems();
         if (problems.hasErrors() || problems.hasWarnings()) {
-            
+
             Iterator<Problem> iterator = problems.iterator();
             while(iterator.hasNext()) {
                 Problem problem = iterator.next();
@@ -176,7 +176,7 @@ public abstract class MultiUseAbstractTest extends AbstractLoggingTest {
      // log out of the session after each test ...
         try {
             clearRepository();
-            if (session != null)
+            if ((session != null) && session.isLive())
                 session.logout();
         } finally {
             session = null;
@@ -205,7 +205,7 @@ public abstract class MultiUseAbstractTest extends AbstractLoggingTest {
 
     /**
      * Utility method to get the resource on the classpath given by the supplied name
-     * 
+     *
      * @param name the name (or path) of the classpath resource
      * @return the input stream to the content; may be null if the resource does not exist
      */
@@ -215,7 +215,7 @@ public abstract class MultiUseAbstractTest extends AbstractLoggingTest {
 
     /**
      * Register the node types in the CND file at the given location on the classpath.
-     * 
+     *
      * @param resourceName the name of the CND file on the classpath
      * @throws RepositoryException if there is a problem registering the node types
      * @throws IOException if the CND file could not be read
@@ -230,7 +230,7 @@ public abstract class MultiUseAbstractTest extends AbstractLoggingTest {
 
     /**
      * Import under the supplied parent node the repository content in the XML file at the given location on the classpath.
-     * 
+     *
      * @param parent the node under which the content should be imported; may not be null
      * @param resourceName the name of the XML file on the classpath
      * @param uuidBehavior the UUID behavior; see {@link ImportUUIDBehavior} for values
@@ -245,7 +245,7 @@ public abstract class MultiUseAbstractTest extends AbstractLoggingTest {
 
     /**
      * Import under the supplied parent node the repository content in the XML file at the given location on the classpath.
-     * 
+     *
      * @param parentPath the path to the node under which the content should be imported; may not be null
      * @param resourceName the name of the XML file on the classpath
      * @param uuidBehavior the UUID behavior; see {@link ImportUUIDBehavior} for values

--- a/tests/org.komodo.test.utils/src/org/komodo/test/utils/UnitOfWorkTestListener.java
+++ b/tests/org.komodo.test.utils/src/org/komodo/test/utils/UnitOfWorkTestListener.java
@@ -1,13 +1,14 @@
 /*
  * JBoss, Home of Professional Open Source.
-*
-* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
-*
-* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
-*/
-package org.komodo.relational;
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.test.utils;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.komodo.spi.repository.Repository.UnitOfWorkListener;
 
@@ -15,9 +16,23 @@ import org.komodo.spi.repository.Repository.UnitOfWorkListener;
 public class UnitOfWorkTestListener implements UnitOfWorkListener {
 
     protected final CountDownLatch latch;
+    protected final long numUnits;
+    protected final TimeUnit unit;
 
-    public UnitOfWorkTestListener(final CountDownLatch testLatch) {
+    public UnitOfWorkTestListener() {
+        this( new CountDownLatch( 1 ), 3, TimeUnit.SECONDS );
+    }
+
+    public UnitOfWorkTestListener( final CountDownLatch testLatch,
+                                   final long testNumUnits,
+                                   final TimeUnit testUnit ) {
         this.latch = testLatch;
+        this.numUnits = testNumUnits;
+        this.unit = testUnit;
+    }
+
+    public boolean await() throws InterruptedException {
+        return this.latch.await( this.numUnits, this.unit );
     }
 
     /**


### PR DESCRIPTION
Added a rename method to KomodoObject that will keep the object in the same parent but change its name. VdbImpl overrides rename method so that it can also set the vdb:vdbName property. Added some tests.