### PR TITLE
Re-deployment of komodo on jboss issue

### DIFF
--- a/plugins/libs/org.komodo.modeshape.lib/.classpath
+++ b/plugins/libs/org.komodo.modeshape.lib/.classpath
@@ -13,7 +13,6 @@
 	<classpathentry exported="true" kind="lib" path="lib/jcr.jar" sourcepath="libsrc/jcr-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jgroups.jar" sourcepath="libsrc/jgroups-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/joda-time.jar" sourcepath="libsrc/time-sources.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jsr305.jar" sourcepath="libsrc/jsr305-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/leveldb-api.jar" sourcepath="libsrc/api-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/leveldb.jar" sourcepath="libsrc/leveldb-sources.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/leveldbjni-all.jar" sourcepath="libsrc/all-sources.jar"/>

--- a/plugins/libs/org.komodo.modeshape.lib/build.properties
+++ b/plugins/libs/org.komodo.modeshape.lib/build.properties
@@ -19,7 +19,6 @@ bin.includes = META-INF/,\
                lib/jcr.jar,\
                lib/jgroups.jar,\
                lib/joda-time.jar,\
-               lib/jsr305.jar,\
                lib/leveldb-api.jar,\
                lib/leveldb.jar,\
                lib/leveldbjni-all.jar,\

--- a/plugins/libs/org.komodo.modeshape.lib/pom.xml
+++ b/plugins/libs/org.komodo.modeshape.lib/pom.xml
@@ -190,6 +190,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!-- Force the upgrade to 13.0.1 to match komodo-web dependencies -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>13.0.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     

--- a/plugins/org.komodo.core/src/org/komodo/core/KEngine.java
+++ b/plugins/org.komodo.core/src/org/komodo/core/KEngine.java
@@ -170,7 +170,14 @@ public final class KEngine implements RepositoryClient, StringConstants {
      * @return the registered repositories (never <code>null</code> but can be empty)
      */
     public Set<Repository> getRepositories() {
-        return Collections.unmodifiableSet(this.repositories);
+        Set<Repository> allRepositories = new HashSet<Repository>();
+
+        if (defaultRepository != null)
+            allRepositories.add(defaultRepository);
+
+        allRepositories.addAll(this.repositories);
+
+        return Collections.unmodifiableSet(allRepositories);
     }
 
     private void notifyListeners(final KEvent event) {


### PR DESCRIPTION
* Redeploying the komodo-web war fails to shutdown modeshape correctly so
  the starting of modeshape causes an exception that the cache manager is
  already started

* KEngine
 * getRepositories() needs to include the default repository

* modeshape.lib
 * leveldb has a dependency on google.guava which is also used by the ui.
   By default, the ui depends on version 17 which is incompatible with the
   leveldb dependency.
 * Aligning both the engine and ui version dependency on guava to version
   13.0.1