### PR TITLE
Issue 140 Standard Statement Options Should Appear As If They Were Properties

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
@@ -649,7 +649,7 @@ public class ObjectImpl implements KomodoObject, StringConstants {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.spi.repository.KomodoObject#getIndex()
+     * @see org.komodo.spi.repository.KNode#getIndex()
      */
     @Override
     public int getIndex() {

--- a/plugins/org.komodo.relational/src/org/komodo/relational/Messages.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/Messages.java
@@ -78,6 +78,12 @@ public class Messages implements StringConstants {
         FUNCTION_NOT_FOUND_TO_REMOVE,
 
         /**
+         * An error message indicating the proposed statement option value is invalid. Most likely this is a multi-valued value
+         * which is not supported.
+         */
+        INVALID_STATEMENT_OPTION_VALUE,
+
+        /**
          * An error message indicating a mapped role name could not be removed.
          */
         MAPPED_ROLE_NOT_FOUND_TO_REMOVE,

--- a/plugins/org.komodo.relational/src/org/komodo/relational/messages.properties
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/messages.properties
@@ -26,6 +26,7 @@ Relational.DATA_ROLE_NOT_FOUND_TO_REMOVE = VDB data role name "{0}" could not be
 Relational.DUPLICATE_ROLE_NAME = Mapped role name "{0}" could not be added because it already exists
 Relational.ENTRY_NOT_FOUND_TO_REMOVE = VDB data role name "{0}" could not be removed because it was not found
 Relational.FUNCTION_NOT_FOUND_TO_REMOVE = Function with name of "{0}" could not be removed because it was not found
+Relational.INVALID_STATEMENT_OPTION_VALUE = Statement options cannot contain or be set to multiple values 
 Relational.MAPPED_ROLE_NOT_FOUND_TO_REMOVE = Mapped role name "{0}" could not be removed because it was not found
 Relational.MASK_NOT_FOUND_TO_REMOVE = Permission mask with name "{0}" could not be removed because it was not found
 Relational.MODEL_NOT_FOUND_TO_REMOVE = Model with name of "{0}" could not be removed from the VDB because it was not found

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/OptionContainer.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/OptionContainer.java
@@ -8,74 +8,69 @@
 package org.komodo.relational.model;
 
 import org.komodo.spi.KException;
-import org.komodo.spi.repository.KNode;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.spi.repository.Repository.UnitOfWork.State;
-import org.komodo.utils.ArgCheck;
 
 /**
  * Indicates the implementing class may have {@link StatementOption options}.
  */
-public interface OptionContainer extends KNode {
-
-    /**
-     * Common utilities for {@link OptionContainer}s.
-     */
-    class Utils {
-
-        /**
-         * @param transaction
-         *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
-         * @param container
-         *        the option container whose statement option is being requested (cannot be <code>null</code>)
-         * @param name
-         *        the name of the statement option being requested (cannot be empty)
-         * @return the statement option or <code>null</code> if not found
-         * @throws KException
-         *         if an error occurs
-         */
-        public static StatementOption getOption( final UnitOfWork transaction,
-                                                 final OptionContainer container,
-                                                 final String name ) throws KException {
-            ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-            ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-            ArgCheck.isNotNull( container, "container" ); //$NON-NLS-1$
-            ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
-
-            StatementOption result = null;
-            final StatementOption[] options = container.getStatementOptions( transaction );
-
-            if ( options.length != 0 ) {
-                for ( final StatementOption option : options ) {
-                    if ( name.equals( option.getName( transaction ) ) ) {
-                        result = option;
-                        break;
-                    }
-                }
-            }
-
-            return result;
-        }
-
-    }
+public interface OptionContainer extends KomodoObject {
 
     /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
-     * @return the user-defined, built-in, and any other non-standard statement options (never <code>null</code> but can be empty)
+     * @return the user-defined and any other non-standard statement options (never <code>null</code> but can be empty)
      * @throws KException
      *         if an error occurs
      */
     StatementOption[] getCustomOptions( final UnitOfWork transaction ) throws KException;
 
     /**
+     * @return the names of the standard options that this object may have (never <code>null</code> but can be empty)
+     */
+    String[] getStandardOptionNames();
+
+    /**
+     * This result includes both the standard statement options and any custom options that have been set.
+     *
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
+     * @return the statement option names for this object (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    String[] getStatementOptionNames( final UnitOfWork transaction ) throws KException;
+
+    /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
-     * @return the statement options (never <code>null</code> but can be empty)
+     * @return the statement options that have been set (never <code>null</code> but can be empty)
      * @throws KException
      *         if an error occurs
      */
     StatementOption[] getStatementOptions( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param name
+     *        the name of the option being checked (cannot be empty)
+     * @return <code>true</code> if the custom option exists
+     * @throws KException
+     *         if an error occurs
+     */
+    boolean isCustomOption( final UnitOfWork transaction,
+                            final String name ) throws KException;
+
+    /**
+     * A standard option is a statement option that is built-in/well known.
+     *
+     * @param name
+     *        the name of the option being checked (cannot be empty)
+     * @return <code>true</code> if a standard option
+     */
+    boolean isStandardOption( final String name );
 
     /**
      * @param transaction

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/StatementOption.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/StatementOption.java
@@ -10,13 +10,14 @@ package org.komodo.relational.model;
 import org.komodo.relational.RelationalObject;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Property;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.spi.repository.Repository.UnitOfWork.State;
 
 /**
  * Represents a DDL statement option from a relational model.
  */
-public interface StatementOption extends RelationalObject {
+public interface StatementOption extends Property, RelationalObject {
 
     /**
      * Identifier of this object

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/OptionContainerUtils.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/OptionContainerUtils.java
@@ -1,0 +1,607 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.model.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
+import org.komodo.relational.internal.RelationalModelFactory;
+import org.komodo.relational.model.OptionContainer;
+import org.komodo.relational.model.StatementOption;
+import org.komodo.repository.DescriptorImpl;
+import org.komodo.repository.ObjectImpl;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.Descriptor;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.Property;
+import org.komodo.spi.repository.PropertyDescriptor;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.repository.Repository.UnitOfWork.State;
+import org.komodo.utils.ArgCheck;
+import org.komodo.utils.StringUtils;
+import org.modeshape.sequencer.ddl.StandardDdlLexicon;
+
+/**
+ * Utilities for retrieving and updating standard and custom statement options.
+ */
+public final class OptionContainerUtils {
+
+    private static class PrimaryTypeDescriptor extends DescriptorImpl {
+
+        private final OptionContainer container;
+        private final Descriptor primaryType;
+
+        /**
+         * @param transaction
+         *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+         * @param optionContainer
+         *        the option container (cannot be <code>null</code>)
+         * @param descriptor
+         *        the primary type descriptor (cannot be <code>null</code>)
+         * @throws KException
+         *         if an error occurs
+         */
+        PrimaryTypeDescriptor( final UnitOfWork transaction,
+                               final OptionContainer optionContainer,
+                               final Descriptor descriptor ) throws KException {
+            super( optionContainer.getRepository(), optionContainer.getName( transaction ) );
+            ArgCheck.isNotNull( descriptor, "descriptor" ); //$NON-NLS-1$
+
+            this.container = optionContainer;
+            this.primaryType = descriptor;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.repository.DescriptorImpl#getPropertyDescriptors(org.komodo.spi.repository.Repository.UnitOfWork)
+         */
+        @Override
+        public PropertyDescriptor[] getPropertyDescriptors( final UnitOfWork transaction ) throws KException {
+            final PropertyDescriptor[] propDescriptors = this.primaryType.getPropertyDescriptors( transaction );
+            PropertyDescriptor[] standardDescriptors = PropertyDescriptor.NO_DESCRIPTORS;
+            PropertyDescriptor[] customDescriptors = PropertyDescriptor.NO_DESCRIPTORS;
+
+            { // standard statement options
+                final String[] standardNames = this.container.getStandardOptionNames();
+
+                if ( standardNames.length > 0 ) {
+                    standardDescriptors = new PropertyDescriptor[ standardNames.length ];
+                    int i = 0;
+
+                    for ( final String name : standardNames ) {
+                        standardDescriptors[i++] = new StatementOptionImpl.OptionDescriptor( name );
+                    }
+                }
+            }
+
+            { // custom statement options
+                final StatementOption[] customOptions = this.container.getCustomOptions( transaction );
+
+                if ( customOptions.length > 0 ) {
+                    customDescriptors = new PropertyDescriptor[ customOptions.length ];
+                    int i = 0;
+
+                    for ( final StatementOption option : customOptions ) {
+                        customDescriptors[i++] = new StatementOptionImpl.OptionDescriptor( option.getName( transaction ) );
+                    }
+                }
+            }
+
+            // combine all descriptors
+            final PropertyDescriptor[] result = new PropertyDescriptor[ propDescriptors.length + standardDescriptors.length
+                                                                        + customDescriptors.length ];
+            System.arraycopy( propDescriptors, 0, result, 0, propDescriptors.length );
+            System.arraycopy( standardDescriptors, 0, result, propDescriptors.length, standardDescriptors.length );
+            System.arraycopy( customDescriptors,
+                              0,
+                              result,
+                              ( propDescriptors.length + standardDescriptors.length ),
+                              customDescriptors.length );
+
+            return result;
+        }
+
+    }
+
+    /**
+     * Supplements the given descriptor with all the each standard and custom statement options.
+     *
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container (cannot be <code>null</code>)
+     * @param primaryType
+     *        the primary type descriptor (cannot be <code>null</code>)
+     * @return the primary type descriptor (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static Descriptor createPrimaryType( final UnitOfWork transaction,
+                                                final OptionContainer container,
+                                                final Descriptor primaryType ) throws KException {
+        return new PrimaryTypeDescriptor( transaction, container, primaryType );
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose custom options are being requested (cannot be <code>null</code>)
+     * @return the user-defined and any other non-standard statement options (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static StatementOption[] getCustomOptions( final UnitOfWork transaction,
+                                                      final OptionContainer container ) throws KException {
+        final StatementOption[] options = getOptions( transaction, container );
+
+        if ( options.length == 0 ) {
+            return options;
+        }
+
+        final List< StatementOption > custom = new ArrayList<>( options.length );
+
+        for ( final StatementOption option : options ) {
+            if ( !container.isStandardOption( option.getName( transaction ) ) ) {
+                custom.add( option );
+            }
+        }
+
+        return custom.toArray( new StatementOption[ custom.size() ] );
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose statement option value is being requested (cannot be <code>null</code>)
+     * @param name
+     *        the name of the statement option whose value is being requested (cannot be empty)
+     * @return the option value or <code>null</code> if not found
+     * @throws KException
+     *         if an error occurs
+     */
+    public static String getOption( final UnitOfWork transaction,
+                                    final OptionContainer container,
+                                    final String name ) throws KException {
+        final StatementOption option = getStatementOption( transaction, container, name );
+
+        if ( option == null ) {
+            return null;
+        }
+
+        return option.getOption( transaction );
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
+     * @param container
+     *        the option container whose option descriptor is being requested (cannot be <code>null</code>)
+     * @param propName
+     *        the name of the statement option whose descriptor is being requested (cannot be empty)
+     * @return the option's property descriptor (can be <code>null</code> if not found)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static PropertyDescriptor getOptionDescriptor( final UnitOfWork transaction,
+                                                          final OptionContainer container,
+                                                          final String propName ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotNull( container, "container" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( propName, "propName" ); //$NON-NLS-1$
+
+        PropertyDescriptor result = null;
+
+        // see if standard statement option
+        if ( container.isStandardOption( propName ) ) {
+            result = new StatementOptionImpl.OptionDescriptor( propName );
+        } else {
+            // see if there is a custom statement option persisted
+            final StatementOption[] customOptions = getCustomOptions( transaction, container );
+
+            if ( customOptions.length > 0 ) {
+                for ( final StatementOption option : customOptions ) {
+                    if ( propName.equals( option.getName( transaction ) ) ) {
+                        result = option.getDescriptor( transaction );
+                        break;
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose custom option names are being requested (cannot be <code>null</code>)
+     * @return the names of the statement options that have been set (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static String[] getOptionNames( final UnitOfWork transaction,
+                                           final OptionContainer container ) throws KException {
+        final StatementOption[] options = getOptions( transaction, container );
+        final String[] names = new String[ options.length ];
+        int i = 0;
+
+        for ( final StatementOption option : options ) {
+            names[i++] = option.getName( transaction );
+        }
+
+        return names;
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose options are being requested (cannot be <code>null</code>)
+     * @return the statement options (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static StatementOption[] getOptions( final UnitOfWork transaction,
+                                                final OptionContainer container ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotNull( container, "container" ); //$NON-NLS-1$
+
+        // must create a generic KomodoObject here so that we can get to the getChildrenOfType that does not filter result
+        final KomodoObject same = new ObjectImpl( container.getRepository(), container.getAbsolutePath(), container.getIndex() );
+        final List< StatementOption > result = new ArrayList< StatementOption >();
+
+        for ( final KomodoObject kobject : same.getChildrenOfType( transaction, StandardDdlLexicon.TYPE_STATEMENT_OPTION ) ) {
+            final StatementOption option = new StatementOptionImpl( transaction,
+                                                                    container.getRepository(),
+                                                                    kobject.getAbsolutePath() );
+            result.add( option );
+        }
+
+        if ( result.isEmpty() ) {
+            return StatementOption.NO_OPTIONS;
+        }
+
+        return result.toArray( new StatementOption[ result.size() ] );
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose property or statement option is being requested (cannot be <code>null</code>)
+     * @param name
+     *        the name of the property or statement option being requested (cannot be empty)
+     * @param property
+     *        the property with the given name or <code>null</code> if it does not exist
+     * @return the property, statement option or <code>null</code> if not found
+     * @throws KException
+     *         if an error occurs
+     */
+    public static Property getProperty( final UnitOfWork transaction,
+                                        final OptionContainer container,
+                                        final String name,
+                                        final Property property ) throws KException {
+        // if a property was not passed in see if a statement option has been set with that name
+        if ( property == null ) {
+            return getStatementOption( transaction, container, name );
+        }
+
+        return property;
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose property or statement option descriptor is being requested (cannot be <code>null</code>)
+     * @param name
+     *        the name of the property or statement option whose descriptor is being requested (cannot be empty)
+     * @param descriptor
+     *        the property descriptor with the given name or <code>null</code> if it does not exist
+     * @return the property or statement option descriptor or <code>null</code> if not found
+     * @throws KException
+     *         if an error occurs
+     */
+    public static PropertyDescriptor getPropertyDescriptor( final UnitOfWork transaction,
+                                                            final OptionContainer container,
+                                                            final String name,
+                                                            final PropertyDescriptor descriptor ) throws KException {
+        // if a descriptor was not passed in see if a statement option descriptor with that name is available
+        if ( descriptor == null ) {
+            return getOptionDescriptor( transaction, container, name );
+        }
+
+        return descriptor;
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose property or statement option descriptor is being requested (cannot be <code>null</code>)
+     * @param propNames
+     *        the names of the properties that have values (cannot be <code>null</code>)
+     * @return the names of the properties and statement options that have values (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static String[] getPropertyNames( final UnitOfWork transaction,
+                                             final OptionContainer container,
+                                             final String[] propNames ) throws KException {
+        final String[] optionNames = getOptionNames( transaction, container );
+
+        // combine
+        final String[] result = new String[ propNames.length + optionNames.length ];
+        System.arraycopy( propNames, 0, result, 0, propNames.length );
+        System.arraycopy( optionNames, 0, result, propNames.length, optionNames.length );
+
+        return result;
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose statement option is being requested (cannot be <code>null</code>)
+     * @param name
+     *        the name of the statement option being requested (cannot be empty)
+     * @return the statement option or <code>null</code> if not found
+     * @throws KException
+     *         if an error occurs
+     */
+    public static StatementOption getStatementOption( final UnitOfWork transaction,
+                                                      final OptionContainer container,
+                                                      final String name ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
+
+        StatementOption result = null;
+        final StatementOption[] options = getOptions( transaction, container );
+
+        if ( options.length != 0 ) {
+            for ( final StatementOption option : options ) {
+                if ( name.equals( option.getName( transaction ) ) ) {
+                    result = option;
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
+     * @param container
+     *        the option container being checked (cannot be <code>null</code>)
+     * @param name
+     *        the name the custom statement option whose existence is being checked (cannot be empty)
+     * @return <code>true</code> if the custom statement option exists
+     * @throws KException
+     *         if an error occurs
+     */
+    public static boolean hasCustomOption( final UnitOfWork transaction,
+                                           final OptionContainer container,
+                                           final String name ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotNull( container, "container" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
+
+        if ( container.isStandardOption( name ) ) {
+            return false;
+        }
+
+        return ( getOption( transaction, container, name ) != null );
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
+     * @param container
+     *        the option container being checked (cannot be <code>null</code>)
+     * @param name
+     *        the name the property or statement option whose existence is being checked (cannot be empty)
+     * @return <code>true</code> if a property or statement option with the supplied name exists
+     * @throws KException
+     *         if an error occurs
+     */
+    public static boolean hasOption( final UnitOfWork transaction,
+                                     final OptionContainer container,
+                                     final String name ) throws KException {
+        return ( getStatementOption( transaction, container, name ) != null );
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
+     * @param container
+     *        the option container being checked (cannot be <code>null</code>)
+     * @return <code>true</code> if statement options exist
+     * @throws KException
+     *         if an error occurs
+     */
+    public static boolean hasOptions( final UnitOfWork transaction,
+                                      final OptionContainer container ) throws KException {
+        return ( getOptions( transaction, container ).length > 0 );
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
+     * @param container
+     *        the option container being checked (cannot be <code>null</code>)
+     * @param propertiesExist
+     *        <code>true</code> if container has properties
+     * @return <code>true</code> if properties or statement options exist
+     * @throws KException
+     *         if an error occurs
+     */
+    public static boolean hasProperties( final UnitOfWork transaction,
+                                         final OptionContainer container,
+                                         final boolean propertiesExist ) throws KException {
+        return ( propertiesExist || hasOptions( transaction, container ) );
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
+     * @param container
+     *        the option container being checked (cannot be <code>null</code>)
+     * @param name
+     *        the name of the property or statement option (cannot be empty)
+     * @param propertyExists
+     *        <code>true</code> if container has the specified property
+     * @return <code>true</code> if a property or statement options with the specified name exists
+     * @throws KException
+     *         if an error occurs
+     */
+    public static boolean hasProperty( final UnitOfWork transaction,
+                                       final OptionContainer container,
+                                       final String name,
+                                       final boolean propertyExists ) throws KException {
+        return ( propertyExists || hasOption( transaction, container, name ) );
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose option is being removed (cannot be <code>null</code>)
+     * @param optionToRemove
+     *        the name of the statement option being removed (cannot be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static void removeOption( final UnitOfWork transaction,
+                                     final OptionContainer container,
+                                     final String optionToRemove ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotNull( container, "container" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( optionToRemove, "optionToRemove" ); //$NON-NLS-1$
+
+        boolean found = false;
+        final StatementOption[] options = getOptions( transaction, container );
+
+        if ( options.length != 0 ) {
+            for ( final StatementOption option : options ) {
+                if ( optionToRemove.equals( option.getName( transaction ) ) ) {
+                    option.remove( transaction );
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if ( !found ) {
+            throw new KException( Messages.getString( Relational.STATEMENT_OPTION_NOT_FOUND_TO_REMOVE, optionToRemove ) );
+        }
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose option is being set (cannot be <code>null</code>)
+     * @param optionName
+     *        the name of the statement option being added (cannot be empty)
+     * @param optionValue
+     *        the statement option value (can be empty if removing the option)
+     * @return the statement option (<code>null</code> if removed)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static StatementOption setOption( final UnitOfWork transaction,
+                                             final OptionContainer container,
+                                             final String optionName,
+                                             final String optionValue ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotNull( container, "container" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( optionName, "optionName" ); //$NON-NLS-1$
+
+        if ( StringUtils.isBlank( optionValue ) ) {
+            removeOption( transaction, container, optionName );
+            return null;
+        }
+
+        StatementOption result = getStatementOption( transaction, container, optionName );
+
+        if ( result == null ) {
+            result = RelationalModelFactory.createStatementOption( transaction,
+                                                                   container.getRepository(),
+                                                                   container,
+                                                                   optionName,
+                                                                   optionValue );
+        } else {
+            result.setOption( transaction, optionValue );
+        }
+
+        return result;
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param container
+     *        the option container whose option is being set (cannot be <code>null</code>)
+     * @param propertyName
+     *        the name of the option (cannot be empty)
+     * @param values
+     *        the new values (can be <code>null</code>)
+     * @return <code>true</code> if an option was set
+     * @throws KException
+     *         if an error occurs
+     */
+    public static boolean setProperty( final UnitOfWork transaction,
+                                       final OptionContainer container,
+                                       final String propertyName,
+                                       final Object... values ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( propertyName, "propertyName" ); //$NON-NLS-1$
+
+        if ( container.isStandardOption( propertyName ) || hasCustomOption( transaction, container, propertyName ) ) {
+            // must be a single-valued string, null, or empty
+            String newValue = null;
+
+            if ( values != null ) {
+                if ( ( values.length == 1 ) && ( values[0] != null ) ) {
+                    newValue = values[0].toString();
+                } else if ( values.length > 1 ) {
+                    Messages.getString( org.komodo.repository.Messages.Komodo.UNABLE_TO_SET_SINGLE_VALUE_PROPERTY_WITH_MULTIPLE_VALUES,
+                                        propertyName,
+                                        container.getAbsolutePath() );
+                }
+            }
+
+            setOption( transaction, container, propertyName, newValue );
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Don't allow construction outside of this class.
+     */
+    private OptionContainerUtils() {
+        // nothing to do
+    }
+
+}

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
@@ -7,10 +7,6 @@
  */
 package org.komodo.relational.model.internal;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.komodo.relational.Messages;
-import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalConstants;
 import org.komodo.relational.RelationalConstants.Nullable;
 import org.komodo.relational.RelationalProperties;
@@ -23,13 +19,15 @@ import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.model.TabularResultSet;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.Descriptor;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Property;
+import org.komodo.spi.repository.PropertyDescriptor;
 import org.komodo.spi.repository.PropertyValueType;
 import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.spi.repository.Repository.UnitOfWork.State;
-import org.komodo.utils.ArgCheck;
 import org.komodo.utils.StringUtils;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon.CreateProcedure;
@@ -39,11 +37,41 @@ import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon.CreateProcedure
  */
 public final class ResultSetColumnImpl extends RelationalChildRestrictedObject implements ResultSetColumn {
 
-    private enum StandardOptions {
+    private enum StandardOption {
 
         ANNOTATION,
         NAMEINSOURCE,
-        UUID
+        UUID;
+
+        /**
+         * @param name
+         *        the name being checked (can be <code>null</code>)
+         * @return <code>true</code> if the name is the name of a standard option
+         */
+        static boolean isValid( final String name ) {
+            for ( final StandardOption option : values() ) {
+                if ( option.name().equals( name ) ) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * @return the names of all the options (never <code>null</code> or empty)
+         */
+        static String[] names() {
+            final StandardOption[] options = values();
+            final String[] result = new String[ options.length ];
+            int i = 0;
+
+            for ( final StandardOption option : options ) {
+                result[i++] = option.name();
+            }
+
+            return result;
+        }
 
     }
 
@@ -139,24 +167,7 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
      */
     @Override
     public StatementOption[] getCustomOptions( final UnitOfWork transaction ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
-        StatementOption[] result = getStatementOptions( transaction );
-
-        if ( result.length != 0 ) {
-            final List< StatementOption > temp = new ArrayList<>( result.length );
-
-            for ( final StatementOption option : result ) {
-                if ( StandardOptions.valueOf( option.getName( transaction ) ) == null ) {
-                    temp.add( option );
-                }
-            }
-
-            result = temp.toArray( new StatementOption[ temp.size() ] );
-        }
-
-        return result;
+        return OptionContainerUtils.getCustomOptions( transaction, this );
     }
 
     /**
@@ -193,13 +204,7 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
      */
     @Override
     public String getDescription( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.ANNOTATION.name() );
-
-        if ( option == null ) {
-            return null;
-        }
-
-        return option.getOption( transaction );
+        return OptionContainerUtils.getOption( transaction, this, StandardOption.ANNOTATION.name() );
     }
 
     /**
@@ -225,13 +230,7 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
      */
     @Override
     public String getNameInSource( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.NAMEINSOURCE.name() );
-
-        if ( option == null ) {
-            return null;
-        }
-
-        return option.getOption( transaction );
+        return OptionContainerUtils.getOption( transaction, this, StandardOption.NAMEINSOURCE.name() );
     }
 
     /**
@@ -271,6 +270,53 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.repository.ObjectImpl#getPrimaryType(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public Descriptor getPrimaryType( final UnitOfWork transaction ) throws KException {
+        return OptionContainerUtils.createPrimaryType(transaction, this, super.getPrimaryType( transaction ));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#getProperty(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public Property getProperty( final UnitOfWork transaction,
+                                 final String name ) throws KException {
+        return OptionContainerUtils.getProperty( transaction, this, name, super.getProperty( transaction, name ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#getPropertyDescriptor(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public PropertyDescriptor getPropertyDescriptor( final UnitOfWork transaction,
+                                                     final String propName ) throws KException {
+        return OptionContainerUtils.getPropertyDescriptor( transaction,
+                                                           this,
+                                                           propName,
+                                                           super.getPropertyDescriptor( transaction, propName ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#getPropertyNames(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String[] getPropertyNames( final UnitOfWork transaction ) throws KException {
+        return OptionContainerUtils.getPropertyNames( transaction, this, super.getPropertyNames( transaction ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.relational.model.ResultSetColumn#getScale(org.komodo.spi.repository.Repository.UnitOfWork)
      */
     @Override
@@ -288,26 +334,31 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.relational.model.OptionContainer#getStandardOptionNames()
+     */
+    @Override
+    public String[] getStandardOptionNames() {
+        return StandardOption.names();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.OptionContainer#getStatementOptionNames(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String[] getStatementOptionNames( final UnitOfWork transaction ) throws KException {
+        return OptionContainerUtils.getOptionNames( transaction, this );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.relational.model.OptionContainer#getStatementOptions(org.komodo.spi.repository.Repository.UnitOfWork)
      */
     @Override
     public StatementOption[] getStatementOptions( final UnitOfWork transaction ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
-        final KomodoObject same = new ObjectImpl( getRepository(), getAbsolutePath(), getIndex() );
-        final List< StatementOption > result = new ArrayList< StatementOption >();
-
-        for ( final KomodoObject kobject : same.getChildrenOfType( transaction, StandardDdlLexicon.TYPE_STATEMENT_OPTION ) ) {
-            final StatementOption option = new StatementOptionImpl( transaction, getRepository(), kobject.getAbsolutePath() );
-            result.add( option );
-        }
-
-        if ( result.isEmpty() ) {
-            return StatementOption.NO_OPTIONS;
-        }
-
-        return result.toArray( new StatementOption[ result.size() ] );
+        return OptionContainerUtils.getOptions( transaction, this );
     }
 
     /**
@@ -327,13 +378,51 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
      */
     @Override
     public String getUuid( final UnitOfWork transaction ) throws KException {
-        final StatementOption option = Utils.getOption( transaction, this, StandardOptions.UUID.name() );
+        return OptionContainerUtils.getOption( transaction, this, StandardOption.UUID.name() );
+    }
 
-        if ( option == null ) {
-            return null;
-        }
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.repository.ObjectImpl#hasProperties(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public boolean hasProperties( final UnitOfWork transaction ) throws KException {
+        return OptionContainerUtils.hasProperties( transaction, this, super.hasProperties( transaction ) );
+    }
 
-        return option.getOption( transaction );
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#hasProperty(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public boolean hasProperty( final UnitOfWork transaction,
+                                final String name ) throws KException {
+        return OptionContainerUtils.hasProperty( transaction, this, name, super.hasProperty( transaction, name ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.OptionContainer#isCustomOption(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public boolean isCustomOption( final UnitOfWork transaction,
+                                   final String name ) throws KException {
+        return OptionContainerUtils.hasCustomOption( transaction, this, name );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.model.OptionContainer#isStandardOption(java.lang.String)
+     */
+    @Override
+    public boolean isStandardOption( final String name ) {
+        return StandardOption.isValid( name );
     }
 
     /**
@@ -345,26 +434,7 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
     @Override
     public void removeStatementOption( final UnitOfWork transaction,
                                        final String optionToRemove ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( optionToRemove, "optionToRemove" ); //$NON-NLS-1$
-
-        boolean found = false;
-        final StatementOption[] options = getStatementOptions( transaction );
-
-        if ( options.length != 0 ) {
-            for ( final StatementOption option : options ) {
-                if ( optionToRemove.equals( option.getName( transaction ) ) ) {
-                    option.remove( transaction );
-                    found = true;
-                    break;
-                }
-            }
-        }
-
-        if ( !found ) {
-            throw new KException( Messages.getString( Relational.STATEMENT_OPTION_NOT_FOUND_TO_REMOVE, optionToRemove ) );
-        }
+        OptionContainerUtils.removeOption( transaction, this, optionToRemove );
     }
 
     /**
@@ -400,7 +470,7 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
     @Override
     public void setDescription( final UnitOfWork transaction,
                                 final String newDescription ) throws KException {
-        setStatementOption( transaction, StandardOptions.ANNOTATION.name(), newDescription );
+        setStatementOption( transaction, StandardOption.ANNOTATION.name(), newDescription );
     }
 
     /**
@@ -423,7 +493,7 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
     @Override
     public void setNameInSource( final UnitOfWork transaction,
                                  final String newNameInSource ) throws KException {
-        setStatementOption( transaction, StandardOptions.NAMEINSOURCE.name(), newNameInSource );
+        setStatementOption( transaction, StandardOption.NAMEINSOURCE.name(), newNameInSource );
     }
 
     /**
@@ -454,6 +524,22 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.repository.ObjectImpl#setProperty(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String,
+     *      java.lang.Object[])
+     */
+    @Override
+    public void setProperty( final UnitOfWork transaction,
+                             final String propertyName,
+                             final Object... values ) throws KException {
+        // if an option was not set then set a property
+        if ( !OptionContainerUtils.setProperty( transaction, this, propertyName, values ) ) {
+            super.setProperty( transaction, propertyName, values );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.relational.model.ResultSetColumn#setScale(org.komodo.spi.repository.Repository.UnitOfWork, int)
      */
     @Override
@@ -472,29 +558,7 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
     public StatementOption setStatementOption( final UnitOfWork transaction,
                                                final String optionName,
                                                final String optionValue ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( optionName, "optionName" ); //$NON-NLS-1$
-
-        StatementOption result = null;
-
-        if ( StringUtils.isBlank( optionValue ) ) {
-            removeStatementOption( transaction, optionName );
-        } else {
-            result = Utils.getOption( transaction, this, optionName );
-
-            if ( result == null ) {
-                result = RelationalModelFactory.createStatementOption( transaction,
-                                                                       getRepository(),
-                                                                       this,
-                                                                       optionName,
-                                                                       optionValue );
-            } else {
-                result.setOption( transaction, optionValue );
-            }
-        }
-
-        return result;
+        return OptionContainerUtils.setOption( transaction, this, optionName, optionValue );
     }
 
     /**
@@ -505,7 +569,7 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
     @Override
     public void setUuid( final UnitOfWork transaction,
                          final String newUuid ) throws KException {
-        setStatementOption( transaction, StandardOptions.UUID.name(), newUuid );
+        setStatementOption( transaction, StandardOption.UUID.name(), newUuid );
     }
 
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StatementOptionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StatementOptionImpl.java
@@ -7,6 +7,11 @@
  */
 package org.komodo.relational.model.internal;
 
+import java.math.BigDecimal;
+import java.text.DateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import org.komodo.relational.Messages;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
@@ -16,19 +21,92 @@ import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.model.Table;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.spi.KException;
+import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.PropertyDescriptor;
 import org.komodo.spi.repository.PropertyValueType;
 import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.spi.repository.Repository.UnitOfWork.State;
 import org.komodo.utils.ArgCheck;
+import org.komodo.utils.StringUtils;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 
 /**
  * An implementation of a relational model DDL statement option.
  */
 public final class StatementOptionImpl extends RelationalChildRestrictedObject implements StatementOption {
+
+    static class OptionDescriptor implements PropertyDescriptor {
+
+        private final String name;
+
+        OptionDescriptor( final String optionName ) {
+            this.name = optionName;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.spi.repository.PropertyDescriptor#getDefaultValues()
+         */
+        @Override
+        public Object[] getDefaultValues() {
+            return StringConstants.EMPTY_ARRAY;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.spi.repository.PropertyDescriptor#getName()
+         */
+        @Override
+        public String getName() {
+            return this.name;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.spi.repository.PropertyDescriptor#getType()
+         */
+        @Override
+        public Type getType() {
+            return Type.STRING;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.spi.repository.PropertyDescriptor#isMandatory()
+         */
+        @Override
+        public boolean isMandatory() {
+            return false;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.spi.repository.PropertyDescriptor#isModifiable()
+         */
+        @Override
+        public boolean isModifiable() {
+            return true;
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.spi.repository.PropertyDescriptor#isMultiple()
+         */
+        @Override
+        public boolean isMultiple() {
+            return false;
+        }
+
+    }
 
     /**
      * The resolver of a {@link StatementOption}.
@@ -104,8 +182,10 @@ public final class StatementOptionImpl extends RelationalChildRestrictedObject i
 
     };
 
+    private PropertyDescriptor descriptor;
+
     /**
-     * @param uow
+     * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
      * @param repository
      *        the repository where the relational object exists (cannot be <code>null</code>)
@@ -114,15 +194,147 @@ public final class StatementOptionImpl extends RelationalChildRestrictedObject i
      * @throws KException
      *         if an error occurs or if node at specified path is not a statement option
      */
-    public StatementOptionImpl( final UnitOfWork uow,
+    public StatementOptionImpl( final UnitOfWork transaction,
                                 final Repository repository,
                                 final String workspacePath ) throws KException {
-        super(uow, repository, workspacePath);
+        super( transaction, repository, workspacePath );
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getBooleanValue(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
     @Override
-    public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return RESOLVER.identifier();
+    public boolean getBooleanValue( final UnitOfWork transaction ) throws KException {
+        final String value = getOption( transaction );
+        return Boolean.parseBoolean( value );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getBooleanValues(org.komodo.spi.repository.Repository.UnitOfWork)
+     * @throws UnsupportedOperationException
+     *         if called
+     */
+    @Override
+    public boolean[] getBooleanValues( final UnitOfWork transaction ) {
+        throw new UnsupportedOperationException( Messages.getString( Messages.Relational.INVALID_STATEMENT_OPTION_VALUE ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getDateValue(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public Calendar getDateValue( final UnitOfWork transaction ) throws KException {
+        final String value = getOption( transaction );
+
+        try {
+            final Date date = DateFormat.getInstance().parse( value );
+            final Calendar result = Calendar.getInstance();
+            result.setTime( date );
+            return result;
+        } catch ( final Exception e ) {
+            throw new KException( e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getDateValues(org.komodo.spi.repository.Repository.UnitOfWork)
+     * @throws UnsupportedOperationException
+     *         if called
+     */
+    @Override
+    public Calendar[] getDateValues( final UnitOfWork transaction ) {
+        throw new UnsupportedOperationException( Messages.getString( Messages.Relational.INVALID_STATEMENT_OPTION_VALUE ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getDecimalValue(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public BigDecimal getDecimalValue( final UnitOfWork transaction ) throws KException {
+        final String value = getOption( transaction );
+        return new BigDecimal( value );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getDecimalValues(org.komodo.spi.repository.Repository.UnitOfWork)
+     * @throws UnsupportedOperationException
+     *         if called
+     */
+    @Override
+    public BigDecimal[] getDecimalValues( final UnitOfWork transaction ) {
+        throw new UnsupportedOperationException( Messages.getString( Messages.Relational.INVALID_STATEMENT_OPTION_VALUE ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getDescriptor(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public PropertyDescriptor getDescriptor( final UnitOfWork transaction ) throws KException {
+        if ( this.descriptor == null ) {
+            this.descriptor = new OptionDescriptor( this.getName( transaction ) );
+        }
+
+        return this.descriptor;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getDoubleValue(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public double getDoubleValue( final UnitOfWork transaction ) throws KException {
+        final String value = getOption( transaction );
+        return Double.parseDouble( value );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getDoubleValues(org.komodo.spi.repository.Repository.UnitOfWork)
+     * @throws UnsupportedOperationException
+     *         if called
+     */
+    @Override
+    public double[] getDoubleValues( final UnitOfWork transaction ) {
+        throw new UnsupportedOperationException( Messages.getString( Messages.Relational.INVALID_STATEMENT_OPTION_VALUE ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getLongValue(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public long getLongValue( final UnitOfWork transaction ) throws KException {
+        final String value = getOption( transaction );
+        return Long.parseLong( value );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getLongValues(org.komodo.spi.repository.Repository.UnitOfWork)
+     * @throws UnsupportedOperationException
+     *         if called
+     */
+    @Override
+    public long[] getLongValues( final UnitOfWork transaction ) {
+        throw new UnsupportedOperationException( Messages.getString( Messages.Relational.INVALID_STATEMENT_OPTION_VALUE ) );
     }
 
     /**
@@ -132,7 +344,103 @@ public final class StatementOptionImpl extends RelationalChildRestrictedObject i
      */
     @Override
     public String getOption( final UnitOfWork uow ) throws KException {
-        return getObjectProperty(uow, PropertyValueType.STRING, "getOption", StandardDdlLexicon.VALUE); //$NON-NLS-1$
+        return getObjectProperty( uow, PropertyValueType.STRING, "getOption", StandardDdlLexicon.VALUE ); //$NON-NLS-1$
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getStringValue(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getStringValue( final UnitOfWork transaction ) throws KException {
+        return getOption( transaction );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getStringValues(org.komodo.spi.repository.Repository.UnitOfWork)
+     * @throws UnsupportedOperationException
+     *         if called
+     */
+    @Override
+    public String[] getStringValues( final UnitOfWork transaction ) {
+        throw new UnsupportedOperationException( Messages.getString( Messages.Relational.INVALID_STATEMENT_OPTION_VALUE ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.repository.ObjectImpl#getTypeIdentifier(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public KomodoType getTypeIdentifier( final UnitOfWork transaction ) {
+        return RESOLVER.identifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getValue(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getValue( final UnitOfWork transaction ) throws KException {
+        return getOption( transaction );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#getValues(org.komodo.spi.repository.Repository.UnitOfWork)
+     * @throws UnsupportedOperationException
+     *         if called
+     */
+    @Override
+    public Object[] getValues( final UnitOfWork transaction ) {
+        throw new UnsupportedOperationException( Messages.getString( Messages.Relational.INVALID_STATEMENT_OPTION_VALUE ) );
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Always returns {@link PropertyValueType#STRING}
+     *
+     * @see org.komodo.spi.repository.Property#getValueType(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public PropertyValueType getValueType( final UnitOfWork transaction ) {
+        return PropertyValueType.STRING;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Always returns <code>false</code>
+     *
+     * @see org.komodo.spi.repository.Property#isMultiple(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public boolean isMultiple( final UnitOfWork transaction ) {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.Property#set(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.Object[])
+     */
+    @Override
+    public void set( final UnitOfWork transaction,
+                     final Object... values ) throws KException {
+        if ( ( values == null ) || ( values.length == 0 ) ) {
+            setOption( transaction, null );
+        } else if ( values.length == 1 ) {
+            setOption( transaction, values[0].toString() );
+        } else {
+            throw new UnsupportedOperationException( Messages.getString( Messages.Relational.INVALID_STATEMENT_OPTION_VALUE ) );
+        }
+
     }
 
     /**
@@ -142,10 +450,14 @@ public final class StatementOptionImpl extends RelationalChildRestrictedObject i
      *      java.lang.String)
      */
     @Override
-    public void setOption( final UnitOfWork uow,
+    public void setOption( final UnitOfWork transaction,
                            final String newOption ) throws KException {
-        ArgCheck.isNotEmpty(newOption, "newOption"); //$NON-NLS-1$
-        setObjectProperty(uow, "setOption", StandardDdlLexicon.VALUE, newOption); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( newOption, "newOption" ); //$NON-NLS-1$
+        setObjectProperty( transaction, "setOption", StandardDdlLexicon.VALUE, newOption ); //$NON-NLS-1$
+
+        if ( StringUtils.isBlank( newOption ) ) {
+            remove( transaction );
+        }
     }
 
 }

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
@@ -149,11 +149,6 @@ public interface KomodoObject extends KNode {
     Descriptor[] getDescriptors( final UnitOfWork transaction ) throws KException;
 
     /**
-     * @return the object's zero-based index relative to any other same-name-siblings or -1 if there is no same-name-siblings
-     */
-    int getIndex();
-
-    /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
      * @return this object's primary type descriptor (never <code>null</code>)
@@ -450,5 +445,10 @@ public interface KomodoObject extends KNode {
      */
     void visit( final UnitOfWork transaction,
                 final KomodoObjectVisitor visitor ) throws Exception;
+
+    /**
+     * @return the object's zero-based index relative to any other same-name-siblings or -1 if there is no same-name-siblings
+     */
+    int getIndex();
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AbstractProcedureImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AbstractProcedureImplTest.java
@@ -9,9 +9,11 @@ package org.komodo.relational.model.internal;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,6 +27,7 @@ import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.PropertyDescriptor;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon.CreateProcedure;
 
@@ -288,6 +291,195 @@ public final class AbstractProcedureImplTest extends RelationalModelTest {
 
         // tests
         assertThat( this.procedure.getUuid( this.uow ), is( value ) );
+    }
+
+    @Test
+    public void shouldIncludeCustomOptionsWithPropertyDescriptors() throws Exception {
+        final String customName = "blah";
+        this.procedure.setStatementOption( this.uow, customName, "elvis" );
+
+        final PropertyDescriptor[] propDescriptors = this.procedure.getPropertyDescriptors( this.uow );
+        boolean found = false;
+
+        for ( final PropertyDescriptor descriptor : propDescriptors ) {
+            if ( customName.equals( descriptor.getName() ) ) {
+                found = true;
+                break;
+            }
+        }
+
+        if ( !found ) {
+            fail( "Custom option '" + customName + "'was not included in the property descriptors" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeOptionsWithPropertyNames() throws Exception {
+        final String custom = "blah";
+        this.procedure.setStatementOption( this.uow, custom, "sledge" );
+        boolean customFound = false;
+
+        final String standard = this.procedure.getStandardOptionNames()[0];
+        this.procedure.setStatementOption( this.uow, standard, "hammer" );
+        boolean standardFound = false;
+
+        for ( final String prop : this.procedure.getPropertyNames( this.uow ) ) {
+            if ( custom.equals( prop ) ) {
+                if ( customFound ) {
+                    fail( "Custom option included multiple times in property names" );
+                }
+
+                customFound = true;
+            } else if ( standard.equals( prop ) ) {
+                if ( standardFound ) {
+                    fail( "Standard option included multiple times in property names" );
+                }
+
+                standardFound = true;
+            }
+
+            if ( customFound && standardFound ) {
+                break;
+            }
+        }
+
+        if ( !customFound ) {
+            fail( "Custom option not included in property names" );
+        }
+
+        if ( !standardFound ) {
+            fail( "Standard option not included in property names" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPrimaryTypePropertyDescriptors() throws Exception {
+        final String[] optionNames = this.procedure.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.procedure.getPrimaryType( this.uow ).getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the primary type property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPropertyDescriptors() throws Exception {
+        final String[] optionNames = this.procedure.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.procedure.getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldObtainCustomOptions() throws Exception {
+        final String sledge = "sledge";
+        this.procedure.setStatementOption( this.uow, sledge, "hammer" );
+
+        final String elvis = "elvis";
+        this.procedure.setStatementOption( this.uow, elvis, "presley" );
+
+        assertThat( this.procedure.getCustomOptions( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.procedure.getStatementOptionNames( this.uow ) ), hasItems( sledge, elvis ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfCustomOption() throws Exception {
+        final String custom = "sledge";
+        this.procedure.setStatementOption( this.uow, custom, "hammer" );
+
+        assertThat( this.procedure.getPropertyDescriptor( this.uow, custom ), is( notNullValue() ) );
+        assertThat( this.procedure.getPropertyDescriptor( this.uow, custom ).getName(), is( custom ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfStandardOption() throws Exception {
+        final String standard = this.procedure.getStandardOptionNames()[0];
+        this.procedure.setStatementOption( this.uow, standard, "blah" );
+
+        assertThat( this.procedure.getPropertyDescriptor( this.uow, standard ), is( notNullValue() ) );
+        assertThat( this.procedure.getPropertyDescriptor( this.uow, standard ).getName(), is( standard ) );
+    }
+
+    @Test
+    public void shouldObtainStatementOptionNames() throws Exception {
+        final String custom = "blah";
+        this.procedure.setStatementOption( this.uow, custom, "sledge" );
+
+        final String standard = this.procedure.getStandardOptionNames()[0];
+        this.procedure.setStatementOption( this.uow, standard, "hammer" );
+
+        assertThat( this.procedure.getStatementOptionNames( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.procedure.getStatementOptionNames( this.uow ) ), hasItems( custom, standard ) );
+    }
+
+    @Test
+    public void shouldRemoveStandardOptionAsIfProperty() throws Exception {
+        final String option = this.procedure.getStandardOptionNames()[0];
+        final String value = "newValue";
+        this.procedure.setProperty( this.uow, option, value ); // add
+        this.procedure.setProperty( this.uow, option, (Object)null ); // remove
+        assertThat( this.procedure.hasProperty( this.uow, option ), is( false ) );
+        assertThat( this.procedure.hasChild( this.uow, option ), is( false ) );
+    }
+
+    @Test
+    public void shouldSetCustomOptionAsIfProperty() throws Exception {
+        final String option = "blah";
+        this.procedure.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.procedure.setProperty( this.uow, option, value );
+
+        assertThat( this.procedure.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.procedure.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.procedure.getStatementOptions( this.uow ).length, is( 1 ) );
+        assertThat( this.procedure.isCustomOption( this.uow, option ), is( true ) );
+
+        final StatementOption statementOption = this.procedure.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
+    }
+
+    @Test
+    public void shouldSetStandardOptionAsIfProperty() throws Exception {
+        final String option = this.procedure.getStandardOptionNames()[0];
+        this.procedure.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.procedure.setProperty( this.uow, option, value );
+
+        assertThat( this.procedure.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.procedure.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.procedure.isCustomOption( this.uow, option ), is( false ) );
+        assertThat( this.procedure.getStatementOptions( this.uow ).length, is( 1 ) );
+
+        final StatementOption statementOption = this.procedure.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
@@ -8,26 +8,31 @@
 package org.komodo.relational.model.internal;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalConstants;
 import org.komodo.relational.RelationalConstants.Nullable;
-import org.komodo.relational.RelationalObject.Filter;
 import org.komodo.relational.RelationalModelTest;
+import org.komodo.relational.RelationalObject.Filter;
 import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.Column.Searchable;
 import org.komodo.relational.model.Model;
+import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.model.Table;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.PropertyDescriptor;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
@@ -507,6 +512,195 @@ public final class ColumnImplTest extends RelationalModelTest {
         final String value = "uuid";
         this.column.setUuid( this.uow, value );
         assertThat( this.column.getUuid( this.uow ), is( value ) );
+    }
+
+    @Test
+    public void shouldIncludeCustomOptionsWithPropertyDescriptors() throws Exception {
+        final String customName = "blah";
+        this.column.setStatementOption( this.uow, customName, "elvis" );
+
+        final PropertyDescriptor[] propDescriptors = this.column.getPropertyDescriptors( this.uow );
+        boolean found = false;
+
+        for ( final PropertyDescriptor descriptor : propDescriptors ) {
+            if ( customName.equals( descriptor.getName() ) ) {
+                found = true;
+                break;
+            }
+        }
+
+        if ( !found ) {
+            fail( "Custom option '" + customName + "'was not included in the property descriptors" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeOptionsWithPropertyNames() throws Exception {
+        final String custom = "blah";
+        this.column.setStatementOption( this.uow, custom, "sledge" );
+        boolean customFound = false;
+
+        final String standard = this.column.getStandardOptionNames()[0];
+        this.column.setStatementOption( this.uow, standard, "hammer" );
+        boolean standardFound = false;
+
+        for ( final String prop : this.column.getPropertyNames( this.uow ) ) {
+            if ( custom.equals( prop ) ) {
+                if ( customFound ) {
+                    fail( "Custom option included multiple times in property names" );
+                }
+
+                customFound = true;
+            } else if ( standard.equals( prop ) ) {
+                if ( standardFound ) {
+                    fail( "Standard option included multiple times in property names" );
+                }
+
+                standardFound = true;
+            }
+
+            if ( customFound && standardFound ) {
+                break;
+            }
+        }
+
+        if ( !customFound ) {
+            fail( "Custom option not included in property names" );
+        }
+
+        if ( !standardFound ) {
+            fail( "Standard option not included in property names" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPrimaryTypePropertyDescriptors() throws Exception {
+        final String[] optionNames = this.column.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.column.getPrimaryType( this.uow ).getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the primary type property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPropertyDescriptors() throws Exception {
+        final String[] optionNames = this.column.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.column.getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldObtainCustomOptions() throws Exception {
+        final String sledge = "sledge";
+        this.column.setStatementOption( this.uow, sledge, "hammer" );
+
+        final String elvis = "elvis";
+        this.column.setStatementOption( this.uow, elvis, "presley" );
+
+        assertThat( this.column.getCustomOptions( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.column.getStatementOptionNames( this.uow ) ), hasItems( sledge, elvis ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfCustomOption() throws Exception {
+        final String custom = "sledge";
+        this.column.setStatementOption( this.uow, custom, "hammer" );
+
+        assertThat( this.column.getPropertyDescriptor( this.uow, custom ), is( notNullValue() ) );
+        assertThat( this.column.getPropertyDescriptor( this.uow, custom ).getName(), is( custom ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfStandardOption() throws Exception {
+        final String standard = this.column.getStandardOptionNames()[0];
+        this.column.setStatementOption( this.uow, standard, "blah" );
+
+        assertThat( this.column.getPropertyDescriptor( this.uow, standard ), is( notNullValue() ) );
+        assertThat( this.column.getPropertyDescriptor( this.uow, standard ).getName(), is( standard ) );
+    }
+
+    @Test
+    public void shouldObtainStatementOptionNames() throws Exception {
+        final String custom = "blah";
+        this.column.setStatementOption( this.uow, custom, "sledge" );
+
+        final String standard = this.column.getStandardOptionNames()[0];
+        this.column.setStatementOption( this.uow, standard, "hammer" );
+
+        assertThat( this.column.getStatementOptionNames( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.column.getStatementOptionNames( this.uow ) ), hasItems( custom, standard ) );
+    }
+
+    @Test
+    public void shouldRemoveStandardOptionAsIfProperty() throws Exception {
+        final String option = this.column.getStandardOptionNames()[0];
+        final String value = "newValue";
+        this.column.setProperty( this.uow, option, value ); // add
+        this.column.setProperty( this.uow, option, (Object)null ); // remove
+        assertThat( this.column.hasProperty( this.uow, option ), is( false ) );
+        assertThat( this.column.hasChild( this.uow, option ), is( false ) );
+    }
+
+    @Test
+    public void shouldSetCustomOptionAsIfProperty() throws Exception {
+        final String option = "blah";
+        this.column.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.column.setProperty( this.uow, option, value );
+
+        assertThat( this.column.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.column.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.column.getStatementOptions( this.uow ).length, is( 1 ) );
+        assertThat( this.column.isCustomOption( this.uow, option ), is( true ) );
+
+        final StatementOption statementOption = this.column.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
+    }
+
+    @Test
+    public void shouldSetStandardOptionAsIfProperty() throws Exception {
+        final String option = this.column.getStandardOptionNames()[0];
+        this.column.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.column.setProperty( this.uow, option, value );
+
+        assertThat( this.column.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.column.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.column.isCustomOption( this.uow, option ), is( false ) );
+        assertThat( this.column.getStatementOptions( this.uow ).length, is( 1 ) );
+
+        final StatementOption statementOption = this.column.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StoredProcedureImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StoredProcedureImplTest.java
@@ -8,11 +8,13 @@
 package org.komodo.relational.model.internal;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
@@ -22,12 +24,14 @@ import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.model.DataTypeResultSet;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.SchemaElement.SchemaElementType;
+import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.model.StoredProcedure;
 import org.komodo.relational.model.TabularResultSet;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.PropertyDescriptor;
 
 @SuppressWarnings( { "javadoc", "nls" } )
 public final class StoredProcedureImplTest extends RelationalModelTest {
@@ -155,6 +159,195 @@ public final class StoredProcedureImplTest extends RelationalModelTest {
     public void shouldSetTabularResultSet() throws Exception {
         assertThat( this.procedure.setResultSet( this.uow, TabularResultSet.class ), is( notNullValue() ) );
         assertThat( this.procedure.getResultSet( this.uow ), is( instanceOf( TabularResultSet.class ) ) );
+    }
+
+    @Test
+    public void shouldIncludeCustomOptionsWithPropertyDescriptors() throws Exception {
+        final String customName = "blah";
+        this.procedure.setStatementOption( this.uow, customName, "elvis" );
+
+        final PropertyDescriptor[] propDescriptors = this.procedure.getPropertyDescriptors( this.uow );
+        boolean found = false;
+
+        for ( final PropertyDescriptor descriptor : propDescriptors ) {
+            if ( customName.equals( descriptor.getName() ) ) {
+                found = true;
+                break;
+            }
+        }
+
+        if ( !found ) {
+            fail( "Custom option '" + customName + "'was not included in the property descriptors" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeOptionsWithPropertyNames() throws Exception {
+        final String custom = "blah";
+        this.procedure.setStatementOption( this.uow, custom, "sledge" );
+        boolean customFound = false;
+
+        final String standard = this.procedure.getStandardOptionNames()[0];
+        this.procedure.setStatementOption( this.uow, standard, "hammer" );
+        boolean standardFound = false;
+
+        for ( final String prop : this.procedure.getPropertyNames( this.uow ) ) {
+            if ( custom.equals( prop ) ) {
+                if ( customFound ) {
+                    fail( "Custom option included multiple times in property names" );
+                }
+
+                customFound = true;
+            } else if ( standard.equals( prop ) ) {
+                if ( standardFound ) {
+                    fail( "Standard option included multiple times in property names" );
+                }
+
+                standardFound = true;
+            }
+
+            if ( customFound && standardFound ) {
+                break;
+            }
+        }
+
+        if ( !customFound ) {
+            fail( "Custom option not included in property names" );
+        }
+
+        if ( !standardFound ) {
+            fail( "Standard option not included in property names" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPrimaryTypePropertyDescriptors() throws Exception {
+        final String[] optionNames = this.procedure.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.procedure.getPrimaryType( this.uow ).getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the primary type property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPropertyDescriptors() throws Exception {
+        final String[] optionNames = this.procedure.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.procedure.getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldObtainCustomOptions() throws Exception {
+        final String sledge = "sledge";
+        this.procedure.setStatementOption( this.uow, sledge, "hammer" );
+
+        final String elvis = "elvis";
+        this.procedure.setStatementOption( this.uow, elvis, "presley" );
+
+        assertThat( this.procedure.getCustomOptions( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.procedure.getStatementOptionNames( this.uow ) ), hasItems( sledge, elvis ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfCustomOption() throws Exception {
+        final String custom = "sledge";
+        this.procedure.setStatementOption( this.uow, custom, "hammer" );
+
+        assertThat( this.procedure.getPropertyDescriptor( this.uow, custom ), is( notNullValue() ) );
+        assertThat( this.procedure.getPropertyDescriptor( this.uow, custom ).getName(), is( custom ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfStandardOption() throws Exception {
+        final String standard = this.procedure.getStandardOptionNames()[0];
+        this.procedure.setStatementOption( this.uow, standard, "blah" );
+
+        assertThat( this.procedure.getPropertyDescriptor( this.uow, standard ), is( notNullValue() ) );
+        assertThat( this.procedure.getPropertyDescriptor( this.uow, standard ).getName(), is( standard ) );
+    }
+
+    @Test
+    public void shouldObtainStatementOptionNames() throws Exception {
+        final String custom = "blah";
+        this.procedure.setStatementOption( this.uow, custom, "sledge" );
+
+        final String standard = this.procedure.getStandardOptionNames()[0];
+        this.procedure.setStatementOption( this.uow, standard, "hammer" );
+
+        assertThat( this.procedure.getStatementOptionNames( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.procedure.getStatementOptionNames( this.uow ) ), hasItems( custom, standard ) );
+    }
+
+    @Test
+    public void shouldRemoveStandardOptionAsIfProperty() throws Exception {
+        final String option = this.procedure.getStandardOptionNames()[0];
+        final String value = "newValue";
+        this.procedure.setProperty( this.uow, option, value ); // add
+        this.procedure.setProperty( this.uow, option, (Object)null ); // remove
+        assertThat( this.procedure.hasProperty( this.uow, option ), is( false ) );
+        assertThat( this.procedure.hasChild( this.uow, option ), is( false ) );
+    }
+
+    @Test
+    public void shouldSetCustomOptionAsIfProperty() throws Exception {
+        final String option = "blah";
+        this.procedure.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.procedure.setProperty( this.uow, option, value );
+
+        assertThat( this.procedure.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.procedure.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.procedure.getStatementOptions( this.uow ).length, is( 1 ) );
+        assertThat( this.procedure.isCustomOption( this.uow, option ), is( true ) );
+
+        final StatementOption statementOption = this.procedure.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
+    }
+
+    @Test
+    public void shouldSetStandardOptionAsIfProperty() throws Exception {
+        final String option = this.procedure.getStandardOptionNames()[0];
+        this.procedure.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.procedure.setProperty( this.uow, option, value );
+
+        assertThat( this.procedure.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.procedure.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.procedure.isCustomOption( this.uow, option ), is( false ) );
+        assertThat( this.procedure.getStatementOptions( this.uow ).length, is( 1 ) );
+
+        final StatementOption statementOption = this.procedure.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableImplTest.java
@@ -38,6 +38,7 @@ import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.PropertyDescriptor;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
@@ -489,6 +490,195 @@ public final class TableImplTest extends RelationalModelTest {
     public void shouldHaveSchemaElementTypePropertyDefaultValueAfterConstruction() throws Exception {
         assertThat( this.table.getSchemaElementType( this.uow ), is( SchemaElementType.DEFAULT_VALUE ) );
         assertThat( this.table.hasProperty( this.uow, StandardDdlLexicon.DEFAULT_VALUE ), is( false ) );
+    }
+
+    @Test
+    public void shouldIncludeCustomOptionsWithPropertyDescriptors() throws Exception {
+        final String customName = "blah";
+        this.table.setStatementOption( this.uow, customName, "elvis" );
+
+        final PropertyDescriptor[] propDescriptors = this.table.getPropertyDescriptors( this.uow );
+        boolean found = false;
+
+        for ( final PropertyDescriptor descriptor : propDescriptors ) {
+            if ( customName.equals( descriptor.getName() ) ) {
+                found = true;
+                break;
+            }
+        }
+
+        if ( !found ) {
+            fail( "Custom option '" + customName + "'was not included in the property descriptors" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeOptionsWithPropertyNames() throws Exception {
+        final String custom = "blah";
+        this.table.setStatementOption( this.uow, custom, "sledge" );
+        boolean customFound = false;
+
+        final String standard = this.table.getStandardOptionNames()[0];
+        this.table.setStatementOption( this.uow, standard, "hammer" );
+        boolean standardFound = false;
+
+        for ( final String prop : this.table.getPropertyNames( this.uow ) ) {
+            if ( custom.equals( prop ) ) {
+                if ( customFound ) {
+                    fail( "Custom option included multiple times in property names" );
+                }
+
+                customFound = true;
+            } else if ( standard.equals( prop ) ) {
+                if ( standardFound ) {
+                    fail( "Standard option included multiple times in property names" );
+                }
+
+                standardFound = true;
+            }
+
+            if ( customFound && standardFound ) {
+                break;
+            }
+        }
+
+        if ( !customFound ) {
+            fail( "Custom option not included in property names" );
+        }
+
+        if ( !standardFound ) {
+            fail( "Standard option not included in property names" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPrimaryTypePropertyDescriptors() throws Exception {
+        final String[] optionNames = this.table.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.table.getPrimaryType( this.uow ).getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the primary type property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPropertyDescriptors() throws Exception {
+        final String[] optionNames = this.table.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.table.getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldObtainCustomOptions() throws Exception {
+        final String sledge = "sledge";
+        this.table.setStatementOption( this.uow, sledge, "hammer" );
+
+        final String elvis = "elvis";
+        this.table.setStatementOption( this.uow, elvis, "presley" );
+
+        assertThat( this.table.getCustomOptions( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.table.getStatementOptionNames( this.uow ) ), hasItems( sledge, elvis ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfCustomOption() throws Exception {
+        final String custom = "sledge";
+        this.table.setStatementOption( this.uow, custom, "hammer" );
+
+        assertThat( this.table.getPropertyDescriptor( this.uow, custom ), is( notNullValue() ) );
+        assertThat( this.table.getPropertyDescriptor( this.uow, custom ).getName(), is( custom ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfStandardOption() throws Exception {
+        final String standard = this.table.getStandardOptionNames()[0];
+        this.table.setStatementOption( this.uow, standard, "blah" );
+
+        assertThat( this.table.getPropertyDescriptor( this.uow, standard ), is( notNullValue() ) );
+        assertThat( this.table.getPropertyDescriptor( this.uow, standard ).getName(), is( standard ) );
+    }
+
+    @Test
+    public void shouldObtainStatementOptionNames() throws Exception {
+        final String custom = "blah";
+        this.table.setStatementOption( this.uow, custom, "sledge" );
+
+        final String standard = this.table.getStandardOptionNames()[0];
+        this.table.setStatementOption( this.uow, standard, "hammer" );
+
+        assertThat( this.table.getStatementOptionNames( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.table.getStatementOptionNames( this.uow ) ), hasItems( custom, standard ) );
+    }
+
+    @Test
+    public void shouldRemoveStandardOptionAsIfProperty() throws Exception {
+        final String option = this.table.getStandardOptionNames()[0];
+        final String value = "newValue";
+        this.table.setProperty( this.uow, option, value ); // add
+        this.table.setProperty( this.uow, option, (Object)null ); // remove
+        assertThat( this.table.hasProperty( this.uow, option ), is( false ) );
+        assertThat( this.table.hasChild( this.uow, option ), is( false ) );
+    }
+
+    @Test
+    public void shouldSetCustomOptionAsIfProperty() throws Exception {
+        final String option = "blah";
+        this.table.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.table.setProperty( this.uow, option, value );
+
+        assertThat( this.table.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.table.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.table.getStatementOptions( this.uow ).length, is( 1 ) );
+        assertThat( this.table.isCustomOption( this.uow, option ), is( true ) );
+
+        final StatementOption statementOption = this.table.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
+    }
+
+    @Test
+    public void shouldSetStandardOptionAsIfProperty() throws Exception {
+        final String option = this.table.getStandardOptionNames()[0];
+        this.table.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.table.setProperty( this.uow, option, value );
+
+        assertThat( this.table.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.table.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.table.isCustomOption( this.uow, option ), is( false ) );
+        assertThat( this.table.getStatementOptions( this.uow ).length, is( 1 ) );
+
+        final StatementOption statementOption = this.table.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UserDefinedFunctionImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UserDefinedFunctionImplTest.java
@@ -8,10 +8,14 @@
 package org.komodo.relational.model.internal;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
@@ -20,9 +24,11 @@ import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.SchemaElement.SchemaElementType;
+import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.model.UserDefinedFunction;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.PropertyDescriptor;
 
 @SuppressWarnings( { "javadoc", "nls" } )
 public final class UserDefinedFunctionImplTest extends RelationalModelTest {
@@ -181,6 +187,195 @@ public final class UserDefinedFunctionImplTest extends RelationalModelTest {
         final String value = "javaMethod";
         this.function.setJavaMethod( this.uow, value );
         assertThat( this.function.getJavaMethod( this.uow ), is( value ) );
+    }
+
+    @Test
+    public void shouldIncludeCustomOptionsWithPropertyDescriptors() throws Exception {
+        final String customName = "blah";
+        this.function.setStatementOption( this.uow, customName, "elvis" );
+
+        final PropertyDescriptor[] propDescriptors = this.function.getPropertyDescriptors( this.uow );
+        boolean found = false;
+
+        for ( final PropertyDescriptor descriptor : propDescriptors ) {
+            if ( customName.equals( descriptor.getName() ) ) {
+                found = true;
+                break;
+            }
+        }
+
+        if ( !found ) {
+            fail( "Custom option '" + customName + "'was not included in the property descriptors" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeOptionsWithPropertyNames() throws Exception {
+        final String custom = "blah";
+        this.function.setStatementOption( this.uow, custom, "sledge" );
+        boolean customFound = false;
+
+        final String standard = this.function.getStandardOptionNames()[0];
+        this.function.setStatementOption( this.uow, standard, "hammer" );
+        boolean standardFound = false;
+
+        for ( final String prop : this.function.getPropertyNames( this.uow ) ) {
+            if ( custom.equals( prop ) ) {
+                if ( customFound ) {
+                    fail( "Custom option included multiple times in property names" );
+                }
+
+                customFound = true;
+            } else if ( standard.equals( prop ) ) {
+                if ( standardFound ) {
+                    fail( "Standard option included multiple times in property names" );
+                }
+
+                standardFound = true;
+            }
+
+            if ( customFound && standardFound ) {
+                break;
+            }
+        }
+
+        if ( !customFound ) {
+            fail( "Custom option not included in property names" );
+        }
+
+        if ( !standardFound ) {
+            fail( "Standard option not included in property names" );
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPrimaryTypePropertyDescriptors() throws Exception {
+        final String[] optionNames = this.function.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.function.getPrimaryType( this.uow ).getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the primary type property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldIncludeStandardOptionsWithPropertyDescriptors() throws Exception {
+        final String[] optionNames = this.function.getStandardOptionNames();
+        final PropertyDescriptor[] propDescriptors = this.function.getPropertyDescriptors( this.uow );
+
+        for ( final String optionName : optionNames ) {
+            boolean found = false;
+
+            for ( final PropertyDescriptor descriptor : propDescriptors ) {
+                if ( optionName.equals( descriptor.getName() ) ) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if ( !found ) {
+                fail( "Option '" + optionName + "'was not included in the property descriptors" );
+            }
+        }
+    }
+
+    @Test
+    public void shouldObtainCustomOptions() throws Exception {
+        final String sledge = "sledge";
+        this.function.setStatementOption( this.uow, sledge, "hammer" );
+
+        final String elvis = "elvis";
+        this.function.setStatementOption( this.uow, elvis, "presley" );
+
+        assertThat( this.function.getCustomOptions( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.function.getStatementOptionNames( this.uow ) ), hasItems( sledge, elvis ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfCustomOption() throws Exception {
+        final String custom = "sledge";
+        this.function.setStatementOption( this.uow, custom, "hammer" );
+
+        assertThat( this.function.getPropertyDescriptor( this.uow, custom ), is( notNullValue() ) );
+        assertThat( this.function.getPropertyDescriptor( this.uow, custom ).getName(), is( custom ) );
+    }
+
+    @Test
+    public void shouldObtainPropertyDescriptorOfStandardOption() throws Exception {
+        final String standard = this.function.getStandardOptionNames()[0];
+        this.function.setStatementOption( this.uow, standard, "blah" );
+
+        assertThat( this.function.getPropertyDescriptor( this.uow, standard ), is( notNullValue() ) );
+        assertThat( this.function.getPropertyDescriptor( this.uow, standard ).getName(), is( standard ) );
+    }
+
+    @Test
+    public void shouldObtainStatementOptionNames() throws Exception {
+        final String custom = "blah";
+        this.function.setStatementOption( this.uow, custom, "sledge" );
+
+        final String standard = this.function.getStandardOptionNames()[0];
+        this.function.setStatementOption( this.uow, standard, "hammer" );
+
+        assertThat( this.function.getStatementOptionNames( this.uow ).length, is( 2 ) );
+        assertThat( Arrays.asList( this.function.getStatementOptionNames( this.uow ) ), hasItems( custom, standard ) );
+    }
+
+    @Test
+    public void shouldRemoveStandardOptionAsIfProperty() throws Exception {
+        final String option = this.function.getStandardOptionNames()[0];
+        final String value = "newValue";
+        this.function.setProperty( this.uow, option, value ); // add
+        this.function.setProperty( this.uow, option, (Object)null ); // remove
+        assertThat( this.function.hasProperty( this.uow, option ), is( false ) );
+        assertThat( this.function.hasChild( this.uow, option ), is( false ) );
+    }
+
+    @Test
+    public void shouldSetCustomOptionAsIfProperty() throws Exception {
+        final String option = "blah";
+        this.function.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.function.setProperty( this.uow, option, value );
+
+        assertThat( this.function.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.function.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.function.getStatementOptions( this.uow ).length, is( 1 ) );
+        assertThat( this.function.isCustomOption( this.uow, option ), is( true ) );
+
+        final StatementOption statementOption = this.function.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
+    }
+
+    @Test
+    public void shouldSetStandardOptionAsIfProperty() throws Exception {
+        final String option = this.function.getStandardOptionNames()[0];
+        this.function.setStatementOption( this.uow, option, "initialValue" );
+
+        final String value = "newValue";
+        this.function.setProperty( this.uow, option, value );
+
+        assertThat( this.function.hasProperty( this.uow, option ), is( true ) );
+        assertThat( this.function.getProperty( this.uow, option ), is( instanceOf( StatementOption.class ) ) );
+        assertThat( this.function.isCustomOption( this.uow, option ), is( false ) );
+        assertThat( this.function.getStatementOptions( this.uow ).length, is( 1 ) );
+
+        final StatementOption statementOption = this.function.getStatementOptions( this.uow )[0];
+        assertThat( statementOption.getName( this.uow ), is( option ) );
+        assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
     }
 
 }


### PR DESCRIPTION
Statement options will now appear as though they are properties. So methods that get/set properties and property descriptors will also work with statement options. The standard/well known statement options have property descriptors and are included with the primary type descriptor.
- OptionContainer now extends KomodoObject
- StatementOption now extends Property
- OptionContainerUtils is a new class that helps OptionContainers work with statement options