### PR TITLE
Issues 155 and 156 Filter PropertyDescriptors and Residual Filter

### DIFF
--- a/plugins/org.komodo.relational/src/org/komodo/relational/RelationalObject.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/RelationalObject.java
@@ -10,6 +10,7 @@ package org.komodo.relational;
 import org.komodo.spi.repository.Descriptor;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.PropertyDescriptor;
+import org.komodo.utils.ArgCheck;
 import org.modeshape.jcr.JcrLexicon;
 import org.modeshape.jcr.JcrMixLexicon;
 import org.modeshape.jcr.JcrNtLexicon;
@@ -67,9 +68,40 @@ public interface RelationalObject extends KomodoObject {
     Filter NT_FILTER = new ExcludeNamespaceFilter( JcrNtLexicon.Namespace.PREFIX, JcrNtLexicon.Namespace.URI );
 
     /**
+     * A filter to exclude residual properties and type descriptors.
+     */
+    Filter RESIDUAL_FILTER = new Filter() {
+
+        private String NAME = "*"; //$NON-NLS-1$
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.RelationalObject.Filter#rejectProperty(java.lang.String)
+         */
+        @Override
+        public boolean rejectProperty( final String propName ) {
+            ArgCheck.isNotEmpty( propName, "propName" ); //$NON-NLS-1$
+            return NAME.equals( propName );
+        }
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.RelationalObject.Filter#rejectDescriptor(java.lang.String)
+         */
+        @Override
+        public boolean rejectDescriptor( final String descriptorName ) {
+            ArgCheck.isNotEmpty( descriptorName, "descriptorName" ); //$NON-NLS-1$
+            return NAME.equals( descriptorName );
+        }
+
+    };
+
+    /**
      * The default set of filters for restricting which properties and descriptors apply to relational objects.
      */
-    Filter[] DEFAULT_FILTERS = new Filter[] { JCR_FILTER, MIX_FILTER, MODE_FILTER, NT_FILTER };
+    Filter[] DEFAULT_FILTERS = new Filter[] { JCR_FILTER, MIX_FILTER, MODE_FILTER, NT_FILTER, RESIDUAL_FILTER };
 
     /**
      * @return the filters to use when deciding which {@link PropertyDescriptor properties} and {@link Descriptor descriptors} are

--- a/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalObjectImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalObjectImpl.java
@@ -327,6 +327,29 @@ public abstract class RelationalObjectImpl extends ObjectImpl implements Relatio
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.repository.ObjectImpl#getPropertyDescriptors(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public PropertyDescriptor[] getPropertyDescriptors( final UnitOfWork transaction ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        final PropertyDescriptor[] descriptors = super.getPropertyDescriptors( transaction );
+        final List< PropertyDescriptor > result = new ArrayList<>( descriptors.length );
+
+        for ( final PropertyDescriptor descriptor : descriptors ) {
+            if ( !isPropertyFiltered( descriptor.getName() ) ) {
+                result.add( descriptor );
+            }
+
+        }
+
+        return result.toArray( new PropertyDescriptor[ result.size() ] );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.repository.ObjectImpl#getPropertyNames(org.komodo.spi.repository.Repository.UnitOfWork)
      */
     @Override

--- a/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
@@ -68,6 +68,11 @@ public class WorkspaceManager extends RelationalObjectImpl {
      */
     private static final KomodoType[] CHILD_TYPES = new KomodoType[] { Vdb.IDENTIFIER, Model.IDENTIFIER };
 
+    /**
+     * The type identifier.
+     */
+    public static final int TYPE_ID = WorkspaceManager.class.hashCode();
+
     private static final String FIND_QUERY_PATTERN = "SELECT [jcr:path] FROM [%s] WHERE ISDESCENDANTNODE('" //$NON-NLS-1$
                                                      + RepositoryImpl.WORKSPACE_ROOT + "') ORDER BY [jcr:name] ASC"; //$NON-NLS-1$
 
@@ -116,6 +121,16 @@ public class WorkspaceManager extends RelationalObjectImpl {
     @Override
     public KomodoType[] getChildTypes() {
         return CHILD_TYPES;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.repository.ObjectImpl#getTypeId()
+     */
+    @Override
+    public int getTypeId() {
+        return TYPE_ID;
     }
 
     @Override

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
@@ -184,8 +184,8 @@ public interface KomodoObject extends KNode {
     /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
-     * @return the property descriptors from the primary type descriptor and the mixin descriptors (can be <code>null</code> if
-     *         not found)
+     * @return the property descriptors from the primary type descriptor and the mixin descriptors (never <code>null</code> but
+     *         can be empty)
      * @throws KException
      *         if an error occurs
      */

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/RelationalObjectImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/RelationalObjectImplTest.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.model.internal;
+
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import org.komodo.relational.RelationalModelTest;
+import org.komodo.relational.RelationalObject;
+import org.komodo.relational.internal.RelationalModelFactory;
+import org.komodo.relational.internal.RelationalObjectImpl;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.Descriptor;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.PropertyDescriptor;
+import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.modeshape.jcr.JcrLexicon;
+import org.modeshape.jcr.JcrMixLexicon;
+import org.modeshape.jcr.ModeShapeLexicon;
+
+@SuppressWarnings( { "javadoc", "nls" } )
+public final class RelationalObjectImplTest extends RelationalModelTest {
+
+    class RelationalTestObject extends RelationalObjectImpl {
+
+        RelationalTestObject( final UnitOfWork uow,
+                              final Repository repository,
+                              final String path ) throws KException {
+            super( uow, repository, path );
+        }
+
+    }
+
+    private RelationalObject robject;
+
+    @Before
+    public void init() throws Exception {
+        final Vdb vdb = RelationalModelFactory.createVdb( this.uow, _repo, null, "vdb", "/my/vdb" );
+        final KomodoObject model = RelationalModelFactory.createModel( this.uow, _repo, vdb, "robject" );
+        this.robject = new RelationalTestObject( this.uow, model.getRepository(), model.getAbsolutePath() );
+        commit();
+    }
+
+    @Test
+    public void shouldFilterJcrNamespace() throws Exception {
+        this.robject.setFilters( new RelationalObject.Filter[] { RelationalObject.JCR_FILTER } );
+
+        for ( final PropertyDescriptor descriptor : this.robject.getPropertyDescriptors( this.uow ) ) {
+            if ( descriptor.getName().startsWith( JcrLexicon.Namespace.PREFIX ) ) {
+                fail();
+            }
+        }
+    }
+
+    @Test
+    public void shouldFilterMixNamespace() throws Exception {
+        this.robject.addDescriptor( this.uow, JcrMixLexicon.CREATED.getString() );
+        this.robject.setFilters( new RelationalObject.Filter[] { RelationalObject.MIX_FILTER } );
+
+        for ( final Descriptor descriptor : this.robject.getDescriptors( this.uow ) ) {
+            if ( descriptor.getName().startsWith( JcrMixLexicon.Namespace.PREFIX ) ) {
+                fail();
+            }
+        }
+    }
+
+    @Test
+    public void shouldFilterModeNamespace() throws Exception {
+        this.robject.setFilters( new RelationalObject.Filter[] { RelationalObject.MODE_FILTER } );
+
+        for ( final PropertyDescriptor descriptor : this.robject.getPropertyDescriptors( this.uow ) ) {
+            if ( descriptor.getName().startsWith( ModeShapeLexicon.Namespace.PREFIX ) ) {
+                fail();
+            }
+        }
+    }
+
+    @Test
+    public void shouldFilterResidual() throws Exception {
+        this.robject.setFilters( new RelationalObject.Filter[] { RelationalObject.RESIDUAL_FILTER } );
+
+        for ( final PropertyDescriptor descriptor : this.robject.getPropertyDescriptors( this.uow ) ) {
+            if ( "*".equals( descriptor.getName() ) ) {
+                fail();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Issue 155 PropertyDescriptors Are Not Being Filtered When Getting All At Once
- Added RelationalObjectImpl.getPropertyDescriptors(UnitOfWork) which filters the descriptors for relational objects.

Issue 156 Residual Properties And Children Need To Be Filtered
- Added a residual filter and added it to the default filters
- added some filter tests