### PR TITLE
Fixes the shell tests that were failing

### DIFF
--- a/tests/org.komodo.shell.test/resources/setCommand1.txt
+++ b/tests/org.komodo.shell.test/resources/setCommand1.txt
@@ -3,4 +3,4 @@ create Model MyModel
 create Table MyTable ./MyModel
 cd MyModel/MyTable
 #
-set Property ddl:length 99
+set Property ANNOTATION mydescription

--- a/tests/org.komodo.shell.test/resources/setCommand2.txt
+++ b/tests/org.komodo.shell.test/resources/setCommand2.txt
@@ -2,4 +2,4 @@
 create Model MyModel
 create Table MyTable ./MyModel
 #
-set Property ddl:length 99 ./MyModel/MyTable
+set Property ANNOTATION mydescription ./MyModel/MyTable

--- a/tests/org.komodo.shell.test/resources/setCommand3.txt
+++ b/tests/org.komodo.shell.test/resources/setCommand3.txt
@@ -2,4 +2,4 @@
 create Model MyModel
 create Table MyTable ./MyModel
 #
-set Property ddl:length 99 /workspace/MyModel/MyTable
+set Property CARDINALITY 5 /workspace/MyModel/MyTable

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/ListCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/ListCommandTest.java
@@ -16,21 +16,20 @@
 package org.komodo.shell;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.komodo.shell.commands.core.ListCommand;
-import org.komodo.spi.repository.KomodoType;
 
 /**
  * Test Class to test ListCommand
  *
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "nls"})
 public class ListCommandTest extends AbstractCommandTest {
 
 	private static final String LIST_COMMAND1 = "listCommand1.txt"; //$NON-NLS-1$
 	private static final String LIST_COMMAND2 = "listCommand2.txt"; //$NON-NLS-1$
 	private static final String LIST_COMMAND3 = "listCommand3.txt"; //$NON-NLS-1$
-	private static final String INDENT = getIndentStr();
 
 	/**
 	 * Test for ListCommand
@@ -45,10 +44,12 @@ public class ListCommandTest extends AbstractCommandTest {
 
     	execute();
 
-    	String expectedOutput = INDENT+"No children for WORKSPACE[workspace].\n"; //$NON-NLS-1$
+        // make sure no children and path appear in output
     	String writerOutput = getCommandOutput();
-    	assertEquals(expectedOutput,writerOutput);
-    	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+        assertTrue( writerOutput.contains( "No children" ) );
+        assertTrue( writerOutput.contains( "WORKSPACE \"/workspace\"" ) );
+
+        assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
     }
 
     @Test
@@ -57,11 +58,13 @@ public class ListCommandTest extends AbstractCommandTest {
 
     	execute();
 
-    	String expectedOutput = INDENT+"Model1 ["+KomodoType.MODEL.name()+"]\n"+ //$NON-NLS-1$ //$NON-NLS-2$
-    			                INDENT+"Model2 ["+KomodoType.MODEL.name()+"]\n"+ //$NON-NLS-1$ //$NON-NLS-2$
-    			                INDENT+"Model3 ["+KomodoType.MODEL.name()+"]\n"; //$NON-NLS-1$ //$NON-NLS-2$
-    	String writerOutput = getCommandOutput();
-    	assertEquals(expectedOutput,writerOutput);
+        // make sure model names and model type appear in output
+        String writerOutput = getCommandOutput();
+        assertTrue( writerOutput.contains( "Model1" ) );
+        assertTrue( writerOutput.contains( "Model2" ) );
+        assertTrue( writerOutput.contains( "Model3" ) );
+        assertTrue( writerOutput.contains( "MODEL" ) );
+
     	assertEquals("/workspace/MyVdb", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
     }
 
@@ -71,12 +74,12 @@ public class ListCommandTest extends AbstractCommandTest {
 
     	execute();
 
-    	assertEquals("/workspace/MyVdb/Model1", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+        // make sure table name and table type appear in output
+        String writerOutput = getCommandOutput();
+        assertTrue( writerOutput.contains( "Table1" ) );
+        assertTrue( writerOutput.contains( "TABLE" ) );
 
-    	String expectedOutput = INDENT+"Table1 ["+KomodoType.TABLE.name()+"]\n"; //$NON-NLS-1$ //$NON-NLS-2$
-    	String writerOutput = getCommandOutput();
-    	assertEquals(expectedOutput,writerOutput);
-
+        assertEquals("/workspace/MyVdb/Model1", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/SetCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/SetCommandTest.java
@@ -2,9 +2,7 @@ package org.komodo.shell;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
 import java.io.File;
-
 import org.junit.Test;
 import org.komodo.relational.model.Table;
 import org.komodo.shell.api.WorkspaceContext;
@@ -13,14 +11,13 @@ import org.komodo.shell.commands.core.SetCommand;
 import org.komodo.shell.util.ContextUtils;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
-import org.komodo.spi.repository.Property;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 
 /**
  * SetCommand - allows setting of properties, global properties, recording state, etc.
- * 
+ *
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "nls"})
 public class SetCommandTest extends AbstractCommandTest {
 
 	private static final String SET_COMMAND_1 = "setCommand1.txt"; //$NON-NLS-1$
@@ -28,14 +25,14 @@ public class SetCommandTest extends AbstractCommandTest {
 	private static final String SET_COMMAND_3 = "setCommand3.txt"; //$NON-NLS-1$
 	private static final String SET_COMMAND_4 = "setCommand4.txt"; //$NON-NLS-1$
 	private static final String SET_COMMAND_5 = "setCommand5.txt"; //$NON-NLS-1$
-	
+
 	/**
 	 * Test for SetCommand
 	 */
 	public SetCommandTest( ) {
 		super();
 	}
-	
+
     @Test
     public void testSetProperty1() throws Exception {
     	setup(SET_COMMAND_1, SetCommand.class);
@@ -43,18 +40,16 @@ public class SetCommandTest extends AbstractCommandTest {
     	execute();
 
     	assertEquals("/workspace/MyModel/MyTable", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
-    	
+
     	KomodoObject ko = wsStatus.getCurrentContext().getKomodoObj();
     	UnitOfWork trans = wsStatus.getTransaction();
      	// Verify the komodo class is a Table and is TABLE type
     	assertEquals(KomodoType.TABLE.name(), ko.getTypeIdentifier(trans).name());
-    	
+
     	Table table = (Table)resolveType(trans, ko, Table.class);
-    	Property prop = table.getProperty(trans, "ddl:length"); //$NON-NLS-1$
-    	
-    	assertEquals(99L, prop.getValue(trans));
+    	assertEquals("mydescription", table.getDescription( trans ));
     }
-    
+
     @Test
     public void testSetProperty2() throws Exception {
     	setup(SET_COMMAND_2, SetCommand.class);
@@ -62,7 +57,7 @@ public class SetCommandTest extends AbstractCommandTest {
     	execute();
 
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
-    	
+
     	WorkspaceContext tableContext = ContextUtils.getContextForPath(wsStatus, "/workspace/MyModel/MyTable"); //$NON-NLS-1$
     	assertNotNull(tableContext);
 
@@ -70,13 +65,11 @@ public class SetCommandTest extends AbstractCommandTest {
     	UnitOfWork trans = wsStatus.getTransaction();
     	// Verify the komodo class is a Table and is TABLE type
     	assertEquals(KomodoType.TABLE.name(), ko.getTypeIdentifier(trans).name());
-    	
+
     	Table table = (Table)resolveType(trans, ko, Table.class);
-    	Property prop = table.getProperty(trans, "ddl:length"); //$NON-NLS-1$
-    	
-    	assertEquals(99L, prop.getValue(trans));
+    	assertEquals("mydescription", table.getDescription( trans ));
     }
-    
+
     @Test
     public void testSetProperty3() throws Exception {
     	setup(SET_COMMAND_3, SetCommand.class);
@@ -84,7 +77,7 @@ public class SetCommandTest extends AbstractCommandTest {
     	execute();
 
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
-    	
+
     	WorkspaceContext tableContext = ContextUtils.getContextForPath(wsStatus, "/workspace/MyModel/MyTable"); //$NON-NLS-1$
         assertNotNull(tableContext);
 
@@ -92,13 +85,11 @@ public class SetCommandTest extends AbstractCommandTest {
     	UnitOfWork trans = wsStatus.getTransaction();
     	// Verify the komodo class is a Table and is TABLE type
     	assertEquals(KomodoType.TABLE.name(), ko.getTypeIdentifier(trans).name());
-    	
+
     	Table table = (Table)resolveType(trans, ko, Table.class);
-    	Property prop = table.getProperty(trans, "ddl:length"); //$NON-NLS-1$
-    	
-    	assertEquals(99L, prop.getValue(trans));
+    	assertEquals(5, table.getCardinality(trans));
     }
-    
+
     @Test
     public void testSetGlobal() throws Exception {
     	setup(SET_COMMAND_4, SetCommand.class);
@@ -108,7 +99,7 @@ public class SetCommandTest extends AbstractCommandTest {
     	File recordFile = wsStatus.getRecordingOutputFile();
     	assertEquals("BogusFile.txt", recordFile.getName()); //$NON-NLS-1$
     }
-    
+
     @Test
     public void testSetRecord() throws Exception {
     	setup(SET_COMMAND_5, SetCommand.class);
@@ -118,5 +109,5 @@ public class SetCommandTest extends AbstractCommandTest {
 
     	assertEquals(true, wsStatus.getRecordingStatus());
     }
-    
+
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/ShowCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/ShowCommandTest.java
@@ -16,6 +16,7 @@
 package org.komodo.shell;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.komodo.shell.commands.core.ShowCommand;
 
@@ -23,7 +24,7 @@ import org.komodo.shell.commands.core.ShowCommand;
  * Test Class to test ShowCommand
  *
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "nls"})
 public class ShowCommandTest extends AbstractCommandTest {
 
 	private static final String SHOW_STATUS1 = "showStatus1.txt"; //$NON-NLS-1$
@@ -45,12 +46,13 @@ public class ShowCommandTest extends AbstractCommandTest {
 
     	execute();
 
-    	String expectedOutput = INDENT+"Current Repo    : local Repository\n"+ //$NON-NLS-1$
-                                        INDENT+"Current Teiid Instance  : None set\n"+ //$NON-NLS-1$
-                                        INDENT+"Current Context : [/workspace]\n"; //$NON-NLS-1$
-
+    	// make sure repository URL and workspace appear, no Teiid is set, and current context path
     	String writerOutput = getCommandOutput();
-    	assertEquals(expectedOutput,writerOutput);
+        assertTrue(writerOutput.contains("test-local-repository-in-memory-config.json"));
+        assertTrue(writerOutput.contains("Workspace : komodoLocalWorkspace"));
+        assertTrue(writerOutput.contains("None set"));
+        assertTrue(writerOutput.contains("/workspace"));
+
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
     }
 
@@ -60,12 +62,14 @@ public class ShowCommandTest extends AbstractCommandTest {
 
     	execute();
 
-    	String expectedOutput = INDENT+"Current Repo    : local Repository\n"+ //$NON-NLS-1$
-                                INDENT+"Current Teiid Instance  : None set\n"+ //$NON-NLS-1$
-    	                        INDENT+"Current Context : [/workspace/MyVdb/MyModel]\n"; //$NON-NLS-1$
-    	String writerOutput = getCommandOutput();
-    	assertEquals(expectedOutput,writerOutput);
-    	assertEquals("/workspace/MyVdb/MyModel", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+        // make sure repository URL and workspace appear, no Teiid is set, and current context path
+        String writerOutput = getCommandOutput();
+        assertTrue(writerOutput.contains("test-local-repository-in-memory-config.json"));
+        assertTrue(writerOutput.contains("Workspace : komodoLocalWorkspace"));
+        assertTrue(writerOutput.contains("None set"));
+        assertTrue(writerOutput.contains("/workspace/MyVdb/MyModel"));
+
+        assertEquals("/workspace/MyVdb/MyModel", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
     }
 
     @Test
@@ -87,15 +91,14 @@ public class ShowCommandTest extends AbstractCommandTest {
 
     	execute();
 
-    	String expectedOutput = INDENT+"Children for VDB \"/workspace/MyVdb\"\n"+ //$NON-NLS-1$
-                                INDENT+"---------------          \n"+ //$NON-NLS-1$
-    	                        INDENT+"Model1 [MODEL]\n"+ //$NON-NLS-1$
-    	                        INDENT+"Model2 [MODEL]\n"+ //$NON-NLS-1$
-    	                        INDENT+"Model3 [MODEL]\n"; //$NON-NLS-1$
+        // make sure model names and model type appear in output
+        String writerOutput = getCommandOutput();
+        assertTrue( writerOutput.contains( "Model1" ) );
+        assertTrue( writerOutput.contains( "Model2" ) );
+        assertTrue( writerOutput.contains( "Model3" ) );
+        assertTrue( writerOutput.contains( "MODEL" ) );
 
-    	String writerOutput = getCommandOutput();
-    	assertEquals(expectedOutput,writerOutput);
-    	assertEquals("/workspace/MyVdb", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+        assertEquals("/workspace/MyVdb", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
     }
 
 }


### PR DESCRIPTION
The issues were that the format of the ListCommand and ShowCommand outputs were changed and the tests were checking for exact output matches. I've changed the tests to just check for the key words that need to appear in the output. The isse with the SetCommand tests were they were using DDL namespace properties that are now being filtered out so are not valid properties.