### PR TITLE
Issue 167 VirtualProcedure And StoredProcedure Have Incorrect Type When Displayed In Shell

### DIFF
--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StoredProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StoredProcedureImpl.java
@@ -229,6 +229,16 @@ public final class StoredProcedureImpl extends AbstractProcedureImpl implements 
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.repository.ObjectImpl#getTypeIdentifier(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public KomodoType getTypeIdentifier( final UnitOfWork transaction ) {
+        return RESOLVER.identifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.relational.model.StoredProcedure#isNonPrepared(org.komodo.spi.repository.Repository.UnitOfWork)
      */
     @Override

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/VirtualProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/VirtualProcedureImpl.java
@@ -132,6 +132,16 @@ public final class VirtualProcedureImpl extends AbstractProcedureImpl implements
     /**
      * {@inheritDoc}
      *
+     * @see org.komodo.repository.ObjectImpl#getTypeIdentifier(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public KomodoType getTypeIdentifier( final UnitOfWork transaction ) {
+        return RESOLVER.identifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @see org.komodo.relational.model.VirtualProcedure#setAsClauseStatement(org.komodo.spi.repository.Repository.UnitOfWork,
      *      java.lang.String)
      */

--- a/plugins/org.komodo.relational/src/org/komodo/relational/teiid/internal/TeiidImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/teiid/internal/TeiidImpl.java
@@ -458,7 +458,7 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
 
     @Override
     public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return KomodoType.TEIID;
+        return RESOLVER.identifier();
     }
 
     @Override

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ConditionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ConditionImpl.java
@@ -120,7 +120,7 @@ public final class ConditionImpl extends RelationalChildRestrictedObject impleme
 
     @Override
     public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return KomodoType.VDB_CONDITION;
+        return RESOLVER.identifier();
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/DataRoleImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/DataRoleImpl.java
@@ -129,7 +129,7 @@ public final class DataRoleImpl extends RelationalObjectImpl implements DataRole
 
     @Override
     public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return KomodoType.VDB_DATA_ROLE;
+        return RESOLVER.identifier();
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/EntryImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/EntryImpl.java
@@ -119,7 +119,7 @@ public final class EntryImpl extends RelationalChildRestrictedObject implements 
 
     @Override
     public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return KomodoType.VDB_ENTRY;
+        return RESOLVER.identifier();
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/MaskImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/MaskImpl.java
@@ -120,7 +120,7 @@ public final class MaskImpl extends RelationalChildRestrictedObject implements M
 
     @Override
     public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return KomodoType.VDB_MASK;
+        return RESOLVER.identifier();
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ModelSourceImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ModelSourceImpl.java
@@ -117,7 +117,7 @@ public final class ModelSourceImpl extends RelationalChildRestrictedObject imple
 
     @Override
     public KomodoType getTypeIdentifier( UnitOfWork uow ) {
-        return KomodoType.VDB_MODEL_SOURCE;
+        return RESOLVER.identifier();
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/PermissionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/PermissionImpl.java
@@ -131,7 +131,7 @@ public final class PermissionImpl extends RelationalObjectImpl implements Permis
 
     @Override
     public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return KomodoType.VDB_PERMISSION;
+        return RESOLVER.identifier();
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/TranslatorImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/TranslatorImpl.java
@@ -119,7 +119,7 @@ public final class TranslatorImpl extends RelationalChildRestrictedObject implem
 
     @Override
     public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return KomodoType.VDB_TRANSLATOR;
+        return RESOLVER.identifier();
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
@@ -60,7 +60,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
      */
     private static final KomodoType[] CHILD_TYPES = new KomodoType[] { DataRole.IDENTIFIER, Entry.IDENTIFIER, Model.IDENTIFIER,
                                                                       Translator.IDENTIFIER, VdbImport.IDENTIFIER };
-    
+
 	/**
 	 * Include the special properties into the primary type descriptor.
 	 *
@@ -314,7 +314,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
 
     @Override
     public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return KomodoType.VDB;
+        return RESOLVER.identifier();
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImportImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImportImpl.java
@@ -117,7 +117,7 @@ public class VdbImportImpl extends RelationalChildRestrictedObject implements Vd
 
     @Override
     public KomodoType getTypeIdentifier(UnitOfWork uow) {
-        return KomodoType.VDB_IMPORT;
+        return RESOLVER.identifier();
     }
 
     /**

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
@@ -13,6 +13,7 @@ import org.komodo.relational.model.internal.ModelImplTest;
 import org.komodo.relational.model.internal.ParameterImplTest;
 import org.komodo.relational.model.internal.PrimaryKeyImplTest;
 import org.komodo.relational.model.internal.PushdownFunctionImplTest;
+import org.komodo.relational.model.internal.RelationalObjectImplTest;
 import org.komodo.relational.model.internal.ResultSetColumnImplTest;
 import org.komodo.relational.model.internal.SchemaImplTest;
 import org.komodo.relational.model.internal.StatementOptionImplTest;
@@ -41,6 +42,8 @@ import org.komodo.relational.workspace.WorkspaceManagerTest;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+    RelationalObjectImplTest.class,
+
     // Model
     AbstractProcedureImplTest.class,
 	AccessPatternImplTest.class,

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AccessPatternImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AccessPatternImplTest.java
@@ -23,6 +23,7 @@ import org.komodo.relational.model.Model;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -67,6 +68,11 @@ public final class AccessPatternImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectDescriptor() throws Exception {
         assertThat( this.accessPattern.hasDescriptor( this.uow, TeiidDdlLexicon.Constraint.TABLE_ELEMENT ), is( true ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.accessPattern.getTypeIdentifier( this.uow ), is(KomodoType.ACCESS_PATTERN));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
@@ -32,6 +32,7 @@ import org.komodo.relational.model.Table;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.PropertyDescriptor;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
@@ -151,6 +152,11 @@ public final class ColumnImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectName() throws Exception {
         assertThat( this.column.getName( this.uow ), is( NAME ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.column.getTypeIdentifier( this.uow ), is(KomodoType.COLUMN));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/DataTypeResultSetImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/DataTypeResultSetImplTest.java
@@ -23,6 +23,7 @@ import org.komodo.relational.model.DataTypeResultSet.Type;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.StoredProcedure;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon.CreateProcedure;
 
@@ -73,6 +74,11 @@ public final class DataTypeResultSetImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectName() throws Exception {
         assertThat( this.resultSet.getName( this.uow ), is( CreateProcedure.RESULT_SET ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.resultSet.getTypeIdentifier( this.uow ), is(KomodoType.DATA_TYPE_RESULT_SET));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ForeignKeyImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ForeignKeyImplTest.java
@@ -27,6 +27,7 @@ import org.komodo.relational.model.Model;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon.Constraint;
 
@@ -98,6 +99,11 @@ public final class ForeignKeyImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectDescriptor() throws Exception {
         assertThat( this.foreignKey.hasDescriptor( this.uow, Constraint.FOREIGN_KEY_CONSTRAINT ), is( true ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.foreignKey.getTypeIdentifier( this.uow ), is(KomodoType.FOREIGN_KEY));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/IndexImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/IndexImplTest.java
@@ -28,6 +28,7 @@ import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -93,6 +94,11 @@ public final class IndexImplTest extends RelationalModelTest {
         assertThat( this.index.getConstraintType(), is( TableConstraint.ConstraintType.INDEX ) );
         assertThat( this.index.getProperty( this.uow, TeiidDdlLexicon.Constraint.TYPE ).getStringValue( this.uow ),
                     is( TableConstraint.ConstraintType.INDEX.toValue() ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.index.getTypeIdentifier( this.uow ), is(KomodoType.INDEX));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ModelImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ModelImplTest.java
@@ -35,6 +35,7 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
 
 @SuppressWarnings( { "javadoc", "nls" } )
 public final class ModelImplTest extends RelationalModelTest {
@@ -370,6 +371,11 @@ public final class ModelImplTest extends RelationalModelTest {
                               View.IDENTIFIER,
                               VirtualProcedure.IDENTIFIER ) );
         assertThat( this.model.getChildTypes().length, is( 7 ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.model.getTypeIdentifier( this.uow ), is(KomodoType.MODEL));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ParameterImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ParameterImplTest.java
@@ -32,6 +32,7 @@ import org.komodo.relational.model.Parameter.Direction;
 import org.komodo.relational.model.StatementOption;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.PropertyDescriptor;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
@@ -158,6 +159,11 @@ public final class ParameterImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectDescriptor() throws Exception {
         assertThat( this.parameter.hasDescriptor( this.uow, CreateProcedure.PARAMETER ), is( true ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.parameter.getTypeIdentifier( this.uow ), is(KomodoType.PARAMETER));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PrimaryKeyImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PrimaryKeyImplTest.java
@@ -23,6 +23,7 @@ import org.komodo.relational.model.PrimaryKey;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -72,6 +73,11 @@ public final class PrimaryKeyImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectName() throws Exception {
         assertThat( this.primaryKey.getName( this.uow ), is( NAME ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.primaryKey.getTypeIdentifier( this.uow ), is(KomodoType.PRIMARY_KEY));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PushdownFunctionImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PushdownFunctionImplTest.java
@@ -27,6 +27,7 @@ import org.komodo.relational.model.SchemaElement.SchemaElementType;
 import org.komodo.relational.model.TabularResultSet;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
 
 @SuppressWarnings( { "javadoc", "nls" } )
 public final class PushdownFunctionImplTest extends RelationalModelTest {
@@ -73,6 +74,11 @@ public final class PushdownFunctionImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectSchemaElementType() throws Exception {
         assertThat( this.function.getSchemaElementType( this.uow ), is( SchemaElementType.FOREIGN ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.function.getTypeIdentifier( this.uow ), is(KomodoType.PUSHDOWN_FUNCTION));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ResultSetColumnImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ResultSetColumnImplTest.java
@@ -32,6 +32,7 @@ import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.PropertyDescriptor;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 
@@ -111,6 +112,11 @@ public final class ResultSetColumnImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectName() throws Exception {
         assertThat( this.column.getName( this.uow ), is( NAME ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.column.getTypeIdentifier( this.uow ), is(KomodoType.RESULT_SET_COLUMN));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/SchemaImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/SchemaImplTest.java
@@ -27,6 +27,7 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.repository.SynchronousCallback;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 
 @SuppressWarnings( {"javadoc", "nls"} )
@@ -132,6 +133,11 @@ public class SchemaImplTest extends RelationalModelTest {
         assertThat(fragment, is(notNullValue()));
         assertThat(fragment.isEmpty(), is(false));
         assertEquals(DDL_VIEW, fragment);
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.schema.getTypeIdentifier( this.uow ), is(KomodoType.SCHEMA));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StatementOptionImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StatementOptionImplTest.java
@@ -21,6 +21,7 @@ import org.komodo.relational.model.OptionContainer;
 import org.komodo.relational.model.StatementOption;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -60,6 +61,11 @@ public final class StatementOptionImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectDescriptor() throws Exception {
         assertThat( this.option.hasDescriptor( this.uow, StandardDdlLexicon.TYPE_STATEMENT_OPTION ), is( true ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.option.getTypeIdentifier( this.uow ), is(KomodoType.STATEMENT_OPTION));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StoredProcedureImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/StoredProcedureImplTest.java
@@ -31,6 +31,7 @@ import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.PropertyDescriptor;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -90,6 +91,11 @@ public final class StoredProcedureImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectSchemaElementType() throws Exception {
         assertThat( this.procedure.getSchemaElementType( this.uow ), is( SchemaElementType.FOREIGN ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.procedure.getTypeIdentifier( this.uow ), is(KomodoType.STORED_PROCEDURE));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableImplTest.java
@@ -38,6 +38,7 @@ import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.PropertyDescriptor;
 import org.modeshape.sequencer.ddl.StandardDdlLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
@@ -456,6 +457,11 @@ public final class TableImplTest extends RelationalModelTest {
                               Index.IDENTIFIER,
                               UniqueConstraint.IDENTIFIER ) );
         assertThat( this.table.getChildTypes().length, is( 5 ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.table.getTypeIdentifier( this.uow ), is(KomodoType.TABLE));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TabularResultSetImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TabularResultSetImplTest.java
@@ -25,6 +25,7 @@ import org.komodo.relational.model.StoredProcedure;
 import org.komodo.relational.model.TabularResultSet;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
 
 @SuppressWarnings( { "javadoc", "nls" } )
 public final class TabularResultSetImplTest extends RelationalModelTest {
@@ -66,6 +67,11 @@ public final class TabularResultSetImplTest extends RelationalModelTest {
     public void shouldHaveCorrectChildTypes() {
         assertThat( Arrays.asList( this.resultSet.getChildTypes() ), hasItem( ResultSetColumn.IDENTIFIER ) );
         assertThat( this.resultSet.getChildTypes().length, is( 1 ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.resultSet.getTypeIdentifier( this.uow ), is(KomodoType.TABULAR_RESULT_SET));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UniqueConstraintImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UniqueConstraintImplTest.java
@@ -23,6 +23,7 @@ import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.relational.model.UniqueConstraint;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -67,6 +68,11 @@ public final class UniqueConstraintImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectDescriptor() throws Exception {
         assertThat( this.uniqueConstraint.hasDescriptor( this.uow, TeiidDdlLexicon.Constraint.TABLE_ELEMENT ), is( true ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.uniqueConstraint.getTypeIdentifier( this.uow ), is(KomodoType.UNIQUE_CONSTRAINT));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UserDefinedFunctionImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UserDefinedFunctionImplTest.java
@@ -28,6 +28,7 @@ import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.model.UserDefinedFunction;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.PropertyDescriptor;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -56,6 +57,11 @@ public final class UserDefinedFunctionImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectSchemaElementType() throws Exception {
         assertThat( this.function.getSchemaElementType( this.uow ), is( SchemaElementType.VIRTUAL ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.function.getTypeIdentifier( this.uow ), is(KomodoType.USER_DEFINED_FUNCTION));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ViewImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ViewImplTest.java
@@ -24,6 +24,7 @@ import org.komodo.relational.model.View;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
 
 @SuppressWarnings( { "javadoc", "nls" } )
 public final class ViewImplTest extends RelationalModelTest {
@@ -74,6 +75,11 @@ public final class ViewImplTest extends RelationalModelTest {
     @Test( expected = UnsupportedOperationException.class )
     public void shouldFailWhenSettingPrimaryKey() throws KException {
         this.view.setPrimaryKey( this.uow, "blah" );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.view.getTypeIdentifier( this.uow ), is(KomodoType.VIEW));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/VirtualProcedureImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/VirtualProcedureImplTest.java
@@ -23,6 +23,7 @@ import org.komodo.relational.model.VirtualProcedure;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -69,6 +70,11 @@ public final class VirtualProcedureImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectSchemaElementType() throws Exception {
         assertThat( this.procedure.getSchemaElementType( this.uow ), is( SchemaElementType.VIRTUAL ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.procedure.getTypeIdentifier( this.uow ), is(KomodoType.VIRTUAL_PROCEDURE));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/ConditionImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/ConditionImplTest.java
@@ -22,6 +22,7 @@ import org.komodo.relational.vdb.DataRole;
 import org.komodo.relational.vdb.Permission;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -66,6 +67,11 @@ public final class ConditionImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectPrimaryType() throws Exception {
         assertThat( this.condition.getPrimaryType( this.uow ).getName(), is( VdbLexicon.DataRole.Permission.Condition.CONDITION ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.condition.getTypeIdentifier( this.uow ), is(KomodoType.VDB_CONDITION));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/DataRoleImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/DataRoleImplTest.java
@@ -26,6 +26,7 @@ import org.komodo.relational.vdb.Permission;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -94,6 +95,11 @@ public final class DataRoleImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectPrimaryType() throws Exception {
         assertThat( this.dataRole.getPrimaryType( this.uow ).getName(), is( VdbLexicon.DataRole.DATA_ROLE ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.dataRole.getTypeIdentifier( this.uow ), is(KomodoType.VDB_DATA_ROLE));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/EntryImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/EntryImplTest.java
@@ -23,6 +23,7 @@ import org.komodo.relational.vdb.Entry;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -58,6 +59,11 @@ public final class EntryImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectPrimaryType() throws Exception {
         assertThat( this.entry.getPrimaryType( this.uow ).getName(), is( VdbLexicon.Entry.ENTRY ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.entry.getTypeIdentifier( this.uow ), is(KomodoType.VDB_ENTRY));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/MaskImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/MaskImplTest.java
@@ -23,6 +23,7 @@ import org.komodo.relational.vdb.Mask;
 import org.komodo.relational.vdb.Permission;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -62,6 +63,11 @@ public final class MaskImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectPrimaryType() throws Exception {
         assertThat( this.mask.getPrimaryType( this.uow ).getName(), is( VdbLexicon.DataRole.Permission.Mask.MASK ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.mask.getTypeIdentifier( this.uow ), is(KomodoType.VDB_MASK));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/ModelSourceImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/ModelSourceImplTest.java
@@ -23,6 +23,7 @@ import org.komodo.relational.vdb.ModelSource;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -86,6 +87,11 @@ public final class ModelSourceImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectPrimaryType() throws Exception {
         assertThat( this.source.getPrimaryType( this.uow ).getName(), is( VdbLexicon.Source.SOURCE ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.source.getTypeIdentifier( this.uow ), is(KomodoType.VDB_MODEL_SOURCE));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/PermissionImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/PermissionImplTest.java
@@ -27,6 +27,7 @@ import org.komodo.relational.vdb.Permission;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -102,6 +103,11 @@ public final class PermissionImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectPrimaryType() throws Exception {
         assertThat( this.permission.getPrimaryType( this.uow ).getName(), is( VdbLexicon.DataRole.Permission.PERMISSION ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.permission.getTypeIdentifier( this.uow ), is(KomodoType.VDB_PERMISSION));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/TranslatorImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/TranslatorImplTest.java
@@ -23,6 +23,7 @@ import org.komodo.relational.vdb.Translator;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -58,6 +59,11 @@ public final class TranslatorImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectPrimaryType() throws Exception {
         assertThat( this.translator.getPrimaryType( this.uow ).getName(), is( VdbLexicon.Translator.TRANSLATOR ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.translator.getTypeIdentifier( this.uow ), is(KomodoType.VDB_TRANSLATOR));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/VdbImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/VdbImplTest.java
@@ -33,6 +33,7 @@ import org.komodo.relational.vdb.Vdb.VdbManifest;
 import org.komodo.relational.vdb.VdbImport;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.PropertyDescriptor;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
@@ -236,6 +237,11 @@ public final class VdbImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectPrimaryType() throws Exception {
         assertThat( this.vdb.getPrimaryType( this.uow ).getName(), is( VdbLexicon.Vdb.VIRTUAL_DATABASE ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.vdb.getTypeIdentifier( this.uow ), is(KomodoType.VDB));
     }
 
     @Test

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/VdbImportImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/VdbImportImplTest.java
@@ -20,6 +20,7 @@ import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.vdb.VdbImport;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -55,6 +56,11 @@ public final class VdbImportImplTest extends RelationalModelTest {
     @Test
     public void shouldHaveCorrectPrimaryType() throws Exception {
         assertThat( this.vdbImport.getPrimaryType( this.uow ).getName(), is( VdbLexicon.ImportVdb.IMPORT_VDB ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.vdbImport.getTypeIdentifier( this.uow ), is(KomodoType.VDB_IMPORT));
     }
 
     @Test


### PR DESCRIPTION
Added getTypeIdentifier(UnitOfWork) method to StoredProcedureImpl and VirtualProcedureImpl to fix problem. Added tests to check each relational type test to make sure they were returning the correct KomodoType.