### PR TITLE
Issue 149 CLI commands for creating PKs, ResultSets, etc need further  investigation (and other improvements and fixes)

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
@@ -822,16 +822,8 @@ public class ObjectImpl implements KomodoObject, StringConstants {
      */
     @Override
     public PropertyDescriptor[] getPropertyDescriptors( final UnitOfWork transaction ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
-        final List< PropertyDescriptor > result = new ArrayList<>();
-
-        for ( final Descriptor descriptor : getAllDescriptors( transaction, this ) ) {
-            result.addAll( Arrays.asList( descriptor.getPropertyDescriptors( transaction ) ) );
-        }
-
-        return result.toArray( new PropertyDescriptor[ result.size() ] );
+        final PropertyDescriptor[] result = getRawPropertyDescriptors( transaction );
+        return result;
     }
 
     /**
@@ -841,9 +833,6 @@ public class ObjectImpl implements KomodoObject, StringConstants {
      */
     @Override
     public String[] getPropertyNames( final UnitOfWork transaction ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
         final String[] result = getRawPropertyNames( transaction );
         return result;
     }
@@ -919,6 +908,25 @@ public class ObjectImpl implements KomodoObject, StringConstants {
         } catch ( final Exception e ) {
             throw handleError( e );
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.KomodoObject#getRawPropertyDescriptors(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public PropertyDescriptor[] getRawPropertyDescriptors( final UnitOfWork transaction ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        final List< PropertyDescriptor > result = new ArrayList<>();
+
+        for ( final Descriptor descriptor : getAllDescriptors( transaction, this ) ) {
+            result.addAll( Arrays.asList( descriptor.getPropertyDescriptors( transaction ) ) );
+        }
+
+        return result.toArray( new PropertyDescriptor[ result.size() ] );
     }
 
     /**
@@ -1154,6 +1162,18 @@ public class ObjectImpl implements KomodoObject, StringConstants {
     @Override
     public boolean hasProperty( final UnitOfWork transaction,
                                 final String name ) throws KException {
+        return hasRawProperty( transaction, name );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.KomodoObject#hasRawProperty(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public boolean hasRawProperty( final UnitOfWork transaction,
+                                   final String name ) throws KException {
         ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
         ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
         ArgCheck.isNotEmpty(name, "name"); //$NON-NLS-1$

--- a/plugins/org.komodo.relational/src/org/komodo/relational/Messages.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/Messages.java
@@ -78,6 +78,11 @@ public class Messages implements StringConstants {
         FUNCTION_NOT_FOUND_TO_REMOVE,
 
         /**
+         * An error message indicating the type of the parent object is invalid.
+         */
+        INVALID_PARENT_TYPE,
+
+        /**
          * An error message indicating the proposed statement option value is invalid. Most likely this is a multi-valued value
          * which is not supported.
          */

--- a/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalModelFactory.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalModelFactory.java
@@ -451,18 +451,12 @@ public final class RelationalModelFactory {
         ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
         ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
         ArgCheck.isNotNull( repository, "repository" ); //$NON-NLS-1$
+        ArgCheck.isNotNull( vdb, "vdb" ); //$NON-NLS-1$
         ArgCheck.isNotEmpty( modelName, "modelName" ); //$NON-NLS-1$
 
-        KomodoObject kobject = null;
-
-        if ( vdb == null ) {
-            final KomodoObject workspace = repository.komodoWorkspace( transaction );
-            kobject = workspace.addChild( transaction, modelName, VdbLexicon.Vdb.DECLARATIVE_MODEL );
-        } else {
-            kobject = vdb.addChild( transaction, modelName, VdbLexicon.Vdb.DECLARATIVE_MODEL );
-        }
-
+        final KomodoObject kobject = vdb.addChild( transaction, modelName, VdbLexicon.Vdb.DECLARATIVE_MODEL );
         final Model result = new ModelImpl( transaction, repository, kobject.getAbsolutePath() );
+
         return result;
     }
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/messages.properties
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/messages.properties
@@ -26,6 +26,7 @@ Relational.DATA_ROLE_NOT_FOUND_TO_REMOVE = VDB data role name "{0}" could not be
 Relational.DUPLICATE_ROLE_NAME = Mapped role name "{0}" could not be added because it already exists
 Relational.ENTRY_NOT_FOUND_TO_REMOVE = VDB data role name "{0}" could not be removed because it was not found
 Relational.FUNCTION_NOT_FOUND_TO_REMOVE = Function with name of "{0}" could not be removed because it was not found
+Relational.INVALID_PARENT_TYPE = The object at "{0}" is not a valid parent of a "{1}" object
 Relational.INVALID_STATEMENT_OPTION_VALUE = Statement options cannot contain or be set to multiple values 
 Relational.MAPPED_ROLE_NOT_FOUND_TO_REMOVE = Mapped role name "{0}" could not be removed because it was not found
 Relational.MASK_NOT_FOUND_TO_REMOVE = Permission mask with name "{0}" could not be removed because it was not found

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AbstractProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AbstractProcedureImpl.java
@@ -130,12 +130,7 @@ abstract class AbstractProcedureImpl extends RelationalObjectImpl implements Abs
     @Override
     public Parameter addParameter( final UnitOfWork transaction,
                                    final String parameterName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( parameterName, "parameterName" ); //$NON-NLS-1$
-
-        final Parameter result = RelationalModelFactory.createParameter( transaction, getRepository(), this, parameterName );
-        return result;
+        return RelationalModelFactory.createParameter( transaction, getRepository(), this, parameterName );
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AccessPatternImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/AccessPatternImpl.java
@@ -7,9 +7,10 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.AccessPattern;
 import org.komodo.relational.model.Table;
@@ -47,7 +48,14 @@ public final class AccessPatternImpl extends TableConstraintImpl implements Acce
                                      final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Table parentTable = adapter.adapt( transaction, parent, Table.class );
-            return RelationalModelFactory.createAccessPattern( transaction, repository, parentTable, id );
+
+            if ( parentTable == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          AccessPattern.class.getSimpleName() ) );
+            }
+
+            return parentTable.addAccessPattern( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ColumnImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ColumnImpl.java
@@ -7,12 +7,13 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalConstants;
 import org.komodo.relational.RelationalConstants.Nullable;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.StatementOption;
@@ -109,7 +110,14 @@ public final class ColumnImpl extends RelationalChildRestrictedObject implements
                               RelationalProperties properties ) throws KException {
             AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
             Table parentTable = adapter.adapt( transaction, parent, Table.class );
-            return RelationalModelFactory.createColumn( transaction, parent.getRepository(), parentTable, id );
+
+            if ( parentTable == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Column.class.getSimpleName() ) );
+            }
+
+            return parentTable.addColumn( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/DataTypeResultSetImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/DataTypeResultSetImpl.java
@@ -13,10 +13,11 @@ import org.komodo.relational.RelationalConstants;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.AbstractProcedure;
 import org.komodo.relational.model.DataTypeResultSet;
+import org.komodo.relational.model.PushdownFunction;
+import org.komodo.relational.model.StoredProcedure;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
@@ -58,7 +59,22 @@ public final class DataTypeResultSetImpl extends RelationalChildRestrictedObject
             final Class< ? extends AbstractProcedure > clazz = AbstractProcedureImpl.getProcedureType( transaction, parent );
             final AdapterFactory adapter = new AdapterFactory( repository );
             final AbstractProcedure parentProc = adapter.adapt( transaction, parent, clazz );
-            return RelationalModelFactory.createDataTypeResultSet( transaction, repository, parentProc );
+
+            if ( parentProc == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          DataTypeResultSet.class.getSimpleName() ) );
+            }
+
+            if ( parentProc instanceof StoredProcedure ) {
+                return ( ( StoredProcedure )parentProc ).setResultSet( transaction, DataTypeResultSet.class );
+            }
+
+            if ( parentProc instanceof PushdownFunction ) {
+                return ( ( PushdownFunction )parentProc ).setResultSet( transaction, DataTypeResultSet.class );
+            }
+
+            throw new KException( Messages.getString( Relational.UNEXPECTED_RESULT_SET_TYPE, clazz.getName() ) );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ForeignKeyImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ForeignKeyImpl.java
@@ -11,7 +11,6 @@ import org.komodo.relational.Messages;
 import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.ForeignKey;
@@ -54,8 +53,15 @@ public final class ForeignKeyImpl extends TableConstraintImpl implements Foreign
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Table parentTable = adapter.adapt( transaction, parent, Table.class );
             final Object keyRefValue = properties.getValue( Constraint.FOREIGN_KEY_CONSTRAINT );
-            final Table keyRef = adapter.adapt( transaction, keyRefValue, Table.class );
-            return RelationalModelFactory.createForeignKey( transaction, repository, parentTable, id, keyRef );
+            final Table keyRefTable = adapter.adapt( transaction, keyRefValue, Table.class );
+
+            if ( parentTable == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          ForeignKey.class.getSimpleName() ) );
+            }
+
+            return parentTable.addForeignKey( transaction, id, keyRefTable );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/IndexImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/IndexImpl.java
@@ -7,9 +7,10 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.Index;
 import org.komodo.relational.model.Table;
@@ -48,7 +49,14 @@ public final class IndexImpl extends TableConstraintImpl implements Index {
                              final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Table parentTable = adapter.adapt( transaction, parent, Table.class );
-            return RelationalModelFactory.createIndex( transaction, repository, parentTable, id );
+
+            if ( parentTable == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Index.class.getSimpleName() ) );
+            }
+
+            return parentTable.addIndex( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
@@ -81,8 +81,15 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
                              final String id,
                              final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
-            final Vdb parentVdb = ( ( parent == null ) ? null : adapter.adapt( transaction, parent, Vdb.class ) );
-            return RelationalModelFactory.createModel( transaction, repository, parentVdb, id );
+            final Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
+
+            if ( parentVdb == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Model.class.getSimpleName() ) );
+            }
+
+            return parentVdb.addModel( transaction, id );
         }
 
         /**
@@ -161,15 +168,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
     @Override
     public PushdownFunction addPushdownFunction( final UnitOfWork transaction,
                                                  final String functionName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( functionName, "functionName" ); //$NON-NLS-1$
-
-        final PushdownFunction result = RelationalModelFactory.createPushdownFunction( transaction,
-                                                                                       getRepository(),
-                                                                                       this,
-                                                                                       functionName );
-        return result;
+        return RelationalModelFactory.createPushdownFunction( transaction, getRepository(), this, functionName );
     }
 
     /**
@@ -181,15 +180,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
     @Override
     public UserDefinedFunction addUserDefinedFunction( final UnitOfWork transaction,
                                                        final String functionName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( functionName, "functionName" ); //$NON-NLS-1$
-
-        final UserDefinedFunction result = RelationalModelFactory.createUserDefinedFunction( transaction,
-                                                                                             getRepository(),
-                                                                                             this,
-                                                                                             functionName );
-        return result;
+        return RelationalModelFactory.createUserDefinedFunction( transaction, getRepository(), this, functionName );
     }
 
     /**
@@ -201,15 +192,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
     @Override
     public StoredProcedure addStoredProcedure( final UnitOfWork transaction,
                                                final String procedureName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( procedureName, "procedureName" ); //$NON-NLS-1$
-
-        final StoredProcedure result = RelationalModelFactory.createStoredProcedure( transaction,
-                                                                                     getRepository(),
-                                                                                     this,
-                                                                                     procedureName );
-        return result;
+        return RelationalModelFactory.createStoredProcedure( transaction, getRepository(), this, procedureName );
     }
 
     /**
@@ -221,15 +204,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
     @Override
     public VirtualProcedure addVirtualProcedure( final UnitOfWork transaction,
                                                  final String procedureName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( procedureName, "procedureName" ); //$NON-NLS-1$
-
-        final VirtualProcedure result = RelationalModelFactory.createVirtualProcedure( transaction,
-                                                                                       getRepository(),
-                                                                                       this,
-                                                                                       procedureName );
-        return result;
+        return RelationalModelFactory.createVirtualProcedure( transaction, getRepository(), this, procedureName );
     }
 
     /**
@@ -240,12 +215,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
     @Override
     public ModelSource addSource( final UnitOfWork transaction,
                                   final String sourceName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( sourceName, "sourceName" ); //$NON-NLS-1$
-
-        final ModelSource result = RelationalModelFactory.createModelSource( transaction, getRepository(), this, sourceName );
-        return result;
+        return RelationalModelFactory.createModelSource( transaction, getRepository(), this, sourceName );
     }
 
     /**
@@ -256,12 +226,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
     @Override
     public Table addTable( final UnitOfWork transaction,
                            final String tableName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( tableName, "tableName" ); //$NON-NLS-1$
-
-        final Table result = RelationalModelFactory.createTable( transaction, getRepository(), this, tableName );
-        return result;
+        return RelationalModelFactory.createTable( transaction, getRepository(), this, tableName );
     }
 
     /**
@@ -272,12 +237,7 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
     @Override
     public View addView( final UnitOfWork transaction,
                          final String viewName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( viewName, "viewName" ); //$NON-NLS-1$
-
-        final View result = RelationalModelFactory.createView( transaction, getRepository(), this, viewName );
-        return result;
+        return RelationalModelFactory.createView( transaction, getRepository(), this, viewName );
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ParameterImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ParameterImpl.java
@@ -7,12 +7,13 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalConstants;
 import org.komodo.relational.RelationalConstants.Nullable;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.AbstractProcedure;
 import org.komodo.relational.model.Parameter;
@@ -60,7 +61,14 @@ public final class ParameterImpl extends RelationalChildRestrictedObject impleme
             final Class< ? extends AbstractProcedure > clazz = AbstractProcedureImpl.getProcedureType( transaction, parent );
             final AdapterFactory adapter = new AdapterFactory( repository );
             final AbstractProcedure parentProc = adapter.adapt( transaction, parent, clazz );
-            return RelationalModelFactory.createParameter( transaction, repository, parentProc, id );
+
+            if ( parentProc == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Parameter.class.getSimpleName() ) );
+            }
+
+            return parentProc.addParameter( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/PrimaryKeyImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/PrimaryKeyImpl.java
@@ -7,9 +7,10 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.PrimaryKey;
 import org.komodo.relational.model.Table;
@@ -47,7 +48,14 @@ public final class PrimaryKeyImpl extends TableConstraintImpl implements Primary
                                   final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Table parentTable = adapter.adapt( transaction, parent, Table.class );
-            return RelationalModelFactory.createPrimaryKey( transaction, repository, parentTable, id );
+
+            if ( parentTable == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          PrimaryKey.class.getSimpleName() ) );
+            }
+
+            return parentTable.setPrimaryKey( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/PushdownFunctionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/PushdownFunctionImpl.java
@@ -54,7 +54,14 @@ public final class PushdownFunctionImpl extends FunctionImpl implements Pushdown
                                         final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Model parentModel = adapter.adapt( transaction, parent, Model.class );
-            return RelationalModelFactory.createPushdownFunction( transaction, repository, parentModel, id );
+
+            if ( parentModel == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          PushdownFunction.class.getSimpleName() ) );
+            }
+
+            return parentModel.addPushdownFunction( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ResultSetColumnImpl.java
@@ -7,12 +7,13 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalConstants;
 import org.komodo.relational.RelationalConstants.Nullable;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.ResultSetColumn;
 import org.komodo.relational.model.StatementOption;
@@ -95,7 +96,14 @@ public final class ResultSetColumnImpl extends RelationalChildRestrictedObject i
                                        final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final TabularResultSet parentResultSet = adapter.adapt( transaction, parent, TabularResultSet.class );
-            return RelationalModelFactory.createResultSetColumn( transaction, repository, parentResultSet, id );
+
+            if ( parentResultSet == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          ResultSetColumn.class.getSimpleName() ) );
+            }
+
+            return parentResultSet.addColumn( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/SchemaImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/SchemaImpl.java
@@ -26,10 +26,10 @@ import javax.jcr.Node;
 import org.komodo.core.KomodoLexicon;
 import org.komodo.modeshape.visitor.DdlNodeVisitor;
 import org.komodo.relational.RelationalProperties;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.Schema;
+import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
@@ -64,8 +64,8 @@ public class SchemaImpl extends RelationalObjectImpl implements Schema {
                               final KomodoObject parent,
                               final String id,
                               final RelationalProperties properties ) throws KException {
-            final String parentPath = ( ( parent == null ) ? null : parent.getAbsolutePath() );
-            return RelationalModelFactory.createSchema( transaction, repository, parentPath, id );
+            final WorkspaceManager mgr = WorkspaceManager.getInstance( repository );
+            return mgr.createSchema( transaction, parent, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StatementOptionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StatementOptionImpl.java
@@ -12,13 +12,13 @@ import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
+import org.komodo.relational.model.OptionContainer;
 import org.komodo.relational.model.StatementOption;
-import org.komodo.relational.model.Table;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
@@ -129,8 +129,15 @@ public final class StatementOptionImpl extends RelationalChildRestrictedObject i
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Object optionValueValue = properties.getValue( StandardDdlLexicon.VALUE );
             final String optionValue = optionValueValue == null ? null : optionValueValue.toString();
-            final Table parentTable = adapter.adapt( transaction, parent, Table.class );
-            return RelationalModelFactory.createStatementOption( transaction, repository, parentTable, id, optionValue );
+            final OptionContainer parentContainer = adapter.adapt( transaction, parent, OptionContainer.class );
+
+            if ( parentContainer == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          StatementOption.class.getSimpleName() ) );
+            }
+
+            return parentContainer.setStatementOption( transaction, id, optionValue );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StoredProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StoredProcedureImpl.java
@@ -101,7 +101,14 @@ public final class StoredProcedureImpl extends AbstractProcedureImpl implements 
                                        final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Model parentModel = adapter.adapt( transaction, parent, Model.class );
-            return RelationalModelFactory.createStoredProcedure( transaction, repository, parentModel, id );
+
+            if ( parentModel == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          StoredProcedure.class.getSimpleName() ) );
+            }
+
+            return parentModel.addStoredProcedure( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TableImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TableImpl.java
@@ -54,7 +54,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
      */
     private static final KomodoType[] CHILD_TYPES = new KomodoType[] { AccessPattern.IDENTIFIER, Column.IDENTIFIER,
                                                                       ForeignKey.IDENTIFIER, Index.IDENTIFIER,
-                                                                      UniqueConstraint.IDENTIFIER };
+                                                                      PrimaryKey.IDENTIFIER, UniqueConstraint.IDENTIFIER };
 
     private enum StandardOption {
 
@@ -118,7 +118,14 @@ public class TableImpl extends RelationalObjectImpl implements Table {
                              final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Model parentModel = adapter.adapt( transaction, parent, Model.class );
-            return RelationalModelFactory.createTable( transaction, repository, parentModel, id );
+
+            if ( parentModel == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Table.class.getSimpleName() ) );
+            }
+
+            return parentModel.addTable( transaction, id );
         }
 
         /**
@@ -191,15 +198,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public AccessPattern addAccessPattern( final UnitOfWork transaction,
                                            final String accessPatternName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( accessPatternName, "accessPatternName" ); //$NON-NLS-1$
-
-        final AccessPattern result = RelationalModelFactory.createAccessPattern( transaction,
-                                                                                 getRepository(),
-                                                                                 this,
-                                                                                 accessPatternName );
-        return result;
+        return RelationalModelFactory.createAccessPattern( transaction, getRepository(), this, accessPatternName );
     }
 
     /**
@@ -210,12 +209,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public Column addColumn( final UnitOfWork transaction,
                              final String columnName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( columnName, "columnName" ); //$NON-NLS-1$
-
-        final Column result = RelationalModelFactory.createColumn( transaction, getRepository(), this, columnName );
-        return result;
+        return RelationalModelFactory.createColumn( transaction, getRepository(), this, columnName );
     }
 
     /**
@@ -251,12 +245,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public Index addIndex( final UnitOfWork transaction,
                            final String indexName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( indexName, "indexName" ); //$NON-NLS-1$
-
-        final Index result = RelationalModelFactory.createIndex( transaction, getRepository(), this, indexName );
-        return result;
+        return RelationalModelFactory.createIndex( transaction, getRepository(), this, indexName );
     }
 
     /**
@@ -268,15 +257,7 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public UniqueConstraint addUniqueConstraint( final UnitOfWork transaction,
                                                  final String constraintName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( constraintName, "constraintName" ); //$NON-NLS-1$
-
-        final UniqueConstraint result = RelationalModelFactory.createUniqueConstraint( transaction,
-                                                                                       getRepository(),
-                                                                                       this,
-                                                                                       constraintName );
-        return result;
+        return RelationalModelFactory.createUniqueConstraint( transaction, getRepository(), this, constraintName );
     }
 
     /**
@@ -494,9 +475,6 @@ public class TableImpl extends RelationalObjectImpl implements Table {
      */
     @Override
     public PrimaryKey getPrimaryKey( final UnitOfWork transaction ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
         PrimaryKey result = null;
 
         for ( final KomodoObject kobject : getChildrenOfType( transaction, Constraint.TABLE_ELEMENT ) ) {
@@ -1038,10 +1016,6 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     @Override
     public PrimaryKey setPrimaryKey( final UnitOfWork transaction,
                                      final String newPrimaryKeyName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( newPrimaryKeyName, "newPrimaryKeyName" ); //$NON-NLS-1$
-
         // delete existing primary key (don't call removePrimaryKey as it throws exception if one does not exist)
         final PrimaryKey primaryKey = getPrimaryKey( transaction );
 

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/UniqueConstraintImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/UniqueConstraintImpl.java
@@ -7,9 +7,10 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.UniqueConstraint;
@@ -47,7 +48,14 @@ public final class UniqueConstraintImpl extends TableConstraintImpl implements U
                                         final RelationalProperties properties ) throws KException {
             AdapterFactory adapter = new AdapterFactory( repository );
             Table parentTable = adapter.adapt( transaction, parent, Table.class );
-            return RelationalModelFactory.createUniqueConstraint( transaction, repository, parentTable, id );
+
+            if ( parentTable == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          UniqueConstraint.class.getSimpleName() ) );
+            }
+
+            return parentTable.addUniqueConstraint( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/UserDefinedFunctionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/UserDefinedFunctionImpl.java
@@ -7,9 +7,10 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.UserDefinedFunction;
@@ -86,7 +87,14 @@ public final class UserDefinedFunctionImpl extends FunctionImpl implements UserD
                                            final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Model parentModel = adapter.adapt( transaction, parent, Model.class );
-            return RelationalModelFactory.createUserDefinedFunction( transaction, repository, parentModel, id );
+
+            if ( parentModel == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          UserDefinedFunction.class.getSimpleName() ) );
+            }
+
+            return parentModel.addUserDefinedFunction( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ViewImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ViewImpl.java
@@ -7,9 +7,10 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.ForeignKey;
 import org.komodo.relational.model.Model;
@@ -51,7 +52,14 @@ public final class ViewImpl extends TableImpl implements View {
                             final RelationalProperties properties ) throws KException {
             AdapterFactory adapter = new AdapterFactory( repository );
             Model parentModel = adapter.adapt( transaction, parent, Model.class );
-            return RelationalModelFactory.createView( transaction, repository, parentModel, id );
+
+            if ( parentModel == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          View.class.getSimpleName() ) );
+            }
+
+            return parentModel.addView( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/VirtualProcedureImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/VirtualProcedureImpl.java
@@ -7,9 +7,10 @@
  */
 package org.komodo.relational.model.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.VirtualProcedure;
@@ -49,7 +50,14 @@ public final class VirtualProcedureImpl extends AbstractProcedureImpl implements
                                         final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Model parentModel = adapter.adapt( transaction, parent, Model.class );
-            return RelationalModelFactory.createVirtualProcedure( transaction, repository, parentModel, id );
+
+            if ( parentModel == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          VirtualProcedure.class.getSimpleName() ) );
+            }
+
+            return parentModel.addVirtualProcedure( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/teiid/internal/TeiidImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/teiid/internal/TeiidImpl.java
@@ -25,9 +25,9 @@ import org.komodo.core.KEngine;
 import org.komodo.core.KomodoLexicon;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.teiid.Teiid;
+import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
@@ -73,8 +73,8 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
                              final KomodoObject parent,
                              final String id,
                              final RelationalProperties properties ) throws KException {
-            final String workspacePath = ( ( parent == null ) ? null : parent.getAbsolutePath() );
-            return RelationalModelFactory.createTeiid( transaction, repository, workspacePath, id );
+            final WorkspaceManager mgr = WorkspaceManager.getInstance( repository );
+            return mgr.createTeiid( transaction, parent, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ConditionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ConditionImpl.java
@@ -7,10 +7,11 @@
  */
 package org.komodo.relational.vdb.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.vdb.Condition;
 import org.komodo.relational.vdb.Permission;
@@ -50,7 +51,14 @@ public final class ConditionImpl extends RelationalChildRestrictedObject impleme
                                  final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Permission parentPerm = adapter.adapt( transaction, parent, Permission.class );
-            return RelationalModelFactory.createCondition( transaction, repository, parentPerm, id );
+
+            if ( parentPerm == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Condition.class.getSimpleName() ) );
+            }
+
+            return parentPerm.addCondition( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/DataRoleImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/DataRoleImpl.java
@@ -62,7 +62,14 @@ public final class DataRoleImpl extends RelationalObjectImpl implements DataRole
                                 final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
-            return RelationalModelFactory.createDataRole( transaction, repository, parentVdb, id );
+
+            if ( parentVdb == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          DataRole.class.getSimpleName() ) );
+            }
+
+            return parentVdb.addDataRole( transaction, id );
         }
 
         /**
@@ -178,12 +185,7 @@ public final class DataRoleImpl extends RelationalObjectImpl implements DataRole
     @Override
     public Permission addPermission( final UnitOfWork transaction,
                                      final String permissionName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( permissionName, "permissionName" ); //$NON-NLS-1$
-
-        final Permission result = RelationalModelFactory.createPermission( transaction, getRepository(), this, permissionName );
-        return result;
+        return RelationalModelFactory.createPermission( transaction, getRepository(), this, permissionName );
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/EntryImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/EntryImpl.java
@@ -7,10 +7,11 @@
  */
 package org.komodo.relational.vdb.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.vdb.Entry;
 import org.komodo.relational.vdb.Vdb;
@@ -52,7 +53,14 @@ public final class EntryImpl extends RelationalChildRestrictedObject implements 
             final String entryPath = entryPathValue == null ? null : entryPathValue.toString();
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
-            return RelationalModelFactory.createEntry( transaction, repository, parentVdb, id, entryPath );
+
+            if ( parentVdb == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Entry.class.getSimpleName() ) );
+            }
+
+            return parentVdb.addEntry( transaction, id, entryPath );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/MaskImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/MaskImpl.java
@@ -7,10 +7,11 @@
  */
 package org.komodo.relational.vdb.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.vdb.Mask;
 import org.komodo.relational.vdb.Permission;
@@ -50,7 +51,14 @@ public final class MaskImpl extends RelationalChildRestrictedObject implements M
                             final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
             final Permission parentPerm = adapter.adapt( transaction, parent, Permission.class );
-            return RelationalModelFactory.createMask( transaction, parent.getRepository(), parentPerm, id );
+
+            if ( parentPerm == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Mask.class.getSimpleName() ) );
+            }
+
+            return parentPerm.addMask( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ModelSourceImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/ModelSourceImpl.java
@@ -7,10 +7,11 @@
  */
 package org.komodo.relational.vdb.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.vdb.ModelSource;
@@ -50,7 +51,14 @@ public final class ModelSourceImpl extends RelationalChildRestrictedObject imple
                                    final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Model parentModel = adapter.adapt( transaction, parent, Model.class );
-            return RelationalModelFactory.createModelSource( transaction, repository, parentModel, id );
+
+            if ( parentModel == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          ModelSource.class.getSimpleName() ) );
+            }
+
+            return parentModel.addSource( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/PermissionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/PermissionImpl.java
@@ -61,7 +61,14 @@ public final class PermissionImpl extends RelationalObjectImpl implements Permis
                                   final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final DataRole parentDataRole = adapter.adapt( transaction, parent, DataRole.class );
-            return RelationalModelFactory.createPermission( transaction, repository, parentDataRole, id );
+
+            if ( parentDataRole == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Permission.class.getSimpleName() ) );
+            }
+
+            return parentDataRole.addPermission( transaction, id );
         }
 
         /**
@@ -142,12 +149,7 @@ public final class PermissionImpl extends RelationalObjectImpl implements Permis
     @Override
     public Condition addCondition( final UnitOfWork transaction,
                                    final String conditionName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( conditionName, "conditionName" ); //$NON-NLS-1$
-
-        final Condition result = RelationalModelFactory.createCondition( transaction, getRepository(), this, conditionName );
-        return result;
+        return RelationalModelFactory.createCondition( transaction, getRepository(), this, conditionName );
     }
 
     /**
@@ -158,12 +160,7 @@ public final class PermissionImpl extends RelationalObjectImpl implements Permis
     @Override
     public Mask addMask( final UnitOfWork transaction,
                          final String maskName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-        ArgCheck.isNotEmpty( maskName, "maskName" ); //$NON-NLS-1$
-
-        final Mask result = RelationalModelFactory.createMask( transaction, getRepository(), this, maskName );
-        return result;
+        return RelationalModelFactory.createMask( transaction, getRepository(), this, maskName );
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/TranslatorImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/TranslatorImpl.java
@@ -7,10 +7,11 @@
  */
 package org.komodo.relational.vdb.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.vdb.Translator;
 import org.komodo.relational.vdb.Vdb;
@@ -52,7 +53,14 @@ public final class TranslatorImpl extends RelationalChildRestrictedObject implem
             final String transType = transTypeValue == null ? null : transTypeValue.toString();
             final AdapterFactory adapter = new AdapterFactory( parent.getRepository() );
             final Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
-            return RelationalModelFactory.createTranslator( transaction, parent.getRepository(), parentVdb, id, transType );
+
+            if ( parentVdb == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          Translator.class.getSimpleName() ) );
+            }
+
+            return parentVdb.addTranslator( transaction, id, transType );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImpl.java
@@ -30,6 +30,7 @@ import org.komodo.relational.vdb.Entry;
 import org.komodo.relational.vdb.Translator;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.vdb.VdbImport;
+import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.repository.DescriptorImpl;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.repository.PropertyDescriptorImpl;
@@ -246,8 +247,8 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
                            final RelationalProperties properties ) throws KException {
             final Object origFilePathValue = properties.getValue( VdbLexicon.Vdb.ORIGINAL_FILE );
             final String origFilePath = origFilePathValue == null ? null : origFilePathValue.toString();
-            final String workspacePath = ( ( parent == null ) ? null : parent.getAbsolutePath() );
-            return RelationalModelFactory.createVdb( transaction, repository, workspacePath, id, origFilePath );
+            final WorkspaceManager mgr = WorkspaceManager.getInstance( repository );
+            return mgr.createVdb( transaction, parent, id, origFilePath );
         }
 
         /**
@@ -325,11 +326,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
     @Override
     public DataRole addDataRole( final UnitOfWork transaction,
                                  final String dataRoleName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
-        final DataRole result = RelationalModelFactory.createDataRole( transaction, getRepository(), this, dataRoleName );
-        return result;
+        return RelationalModelFactory.createDataRole( transaction, getRepository(), this, dataRoleName );
     }
 
     /**
@@ -342,11 +339,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
     public Entry addEntry( final UnitOfWork transaction,
                            final String entryName,
                            final String entryPath ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
-        final Entry result = RelationalModelFactory.createEntry( transaction, getRepository(), this, entryName, entryPath );
-        return result;
+        return RelationalModelFactory.createEntry( transaction, getRepository(), this, entryName, entryPath );
     }
 
     /**
@@ -357,11 +350,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
     @Override
     public VdbImport addImport( final UnitOfWork transaction,
                                 final String vdbName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
-        final VdbImport result = RelationalModelFactory.createVdbImport( transaction, getRepository(), this, vdbName );
-        return result;
+        return RelationalModelFactory.createVdbImport( transaction, getRepository(), this, vdbName );
     }
 
     /**
@@ -372,11 +361,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
     @Override
     public Model addModel( final UnitOfWork transaction,
                            final String modelName ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
-        final Model result = RelationalModelFactory.createModel( transaction, getRepository(), this, modelName );
-        return result;
+        return RelationalModelFactory.createModel( transaction, getRepository(), this, modelName );
     }
 
     /**
@@ -389,15 +374,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
     public Translator addTranslator( final UnitOfWork transaction,
                                      final String translatorName,
                                      final String translatorType ) throws KException {
-        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
-        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
-
-        final Translator result = RelationalModelFactory.createTranslator( transaction,
-                                                                           getRepository(),
-                                                                           this,
-                                                                           translatorName,
-                                                                           translatorType );
-        return result;
+        return RelationalModelFactory.createTranslator( transaction, getRepository(), this, translatorName, translatorType );
     }
 
     /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImportImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/vdb/internal/VdbImportImpl.java
@@ -7,10 +7,11 @@
  */
 package org.komodo.relational.vdb.internal;
 
+import org.komodo.relational.Messages;
+import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.RelationalChildRestrictedObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.vdb.VdbImport;
@@ -50,7 +51,14 @@ public class VdbImportImpl extends RelationalChildRestrictedObject implements Vd
                                  final RelationalProperties properties ) throws KException {
             final AdapterFactory adapter = new AdapterFactory( repository );
             final Vdb parentVdb = adapter.adapt( transaction, parent, Vdb.class );
-            return RelationalModelFactory.createVdbImport( transaction, repository, parentVdb, id );
+
+            if ( parentVdb == null ) {
+                throw new KException( Messages.getString( Relational.INVALID_PARENT_TYPE,
+                                                          parent.getAbsolutePath(),
+                                                          VdbImport.class.getSimpleName() ) );
+            }
+
+            return parentVdb.addImport( transaction, id );
         }
 
         /**

--- a/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
@@ -30,6 +30,7 @@ import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.RelationalProperty;
 import org.komodo.relational.internal.AdapterFactory;
+import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.internal.TypeResolver;
 import org.komodo.relational.internal.TypeResolverRegistry;
@@ -66,7 +67,7 @@ public class WorkspaceManager extends RelationalObjectImpl {
     /**
      * The allowed child types.
      */
-    private static final KomodoType[] CHILD_TYPES = new KomodoType[] { Vdb.IDENTIFIER, Model.IDENTIFIER };
+    private static final KomodoType[] CHILD_TYPES = new KomodoType[] { Vdb.IDENTIFIER, Schema.IDENTIFIER };
 
     /**
      * The type identifier.
@@ -169,22 +170,18 @@ public class WorkspaceManager extends RelationalObjectImpl {
      * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
-     * @param parent
-     *        the parent of the model object being created (can be <code>null</code> if creating at workspace root)
+     * @param vdb
+     *        the parent of the model object being created (cannot be <code>null</code>)
      * @param modelName
      *        the name of the model to create (cannot be empty)
      * @return the model object (never <code>null</code>)
      * @throws KException
      *         if an error occurs
      */
-    public Model createModel( UnitOfWork uow,
-                              KomodoObject parent,
-                              String modelName ) throws KException {
-        KomodoObject kobject = create(uow, parent, modelName, KomodoType.MODEL);
-        if (! (kobject instanceof Model))
-           return null;
-
-        return (Model) kobject;
+    public Model createModel( final UnitOfWork uow,
+                              final Vdb vdb,
+                              final String modelName ) throws KException {
+        return RelationalModelFactory.createModel( uow, getRepository(), vdb, modelName );
     }
 
     /**
@@ -192,24 +189,19 @@ public class WorkspaceManager extends RelationalObjectImpl {
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @param parent
-     *        the parent of the schema object being created (cannot be <code>null</code>)
+     *        the parent of the schema object being created (can be <code>null</code>)
      * @param schemaName
      *        the name of the schema to create (cannot be empty)
      * @return the schema object (never <code>null</code>)
      * @throws KException
      *         if an error occurs
      */
-    public Schema createSchema( UnitOfWork uow,
-                                KomodoObject parent,
-                                String schemaName ) throws KException {
-        if (parent == null)
-            parent = getRepository().komodoWorkspace(uow);
-
-        KomodoObject kobject = create(uow, parent, schemaName, KomodoType.SCHEMA);
-        if (! (kobject instanceof Schema))
-           return null;
-
-        return (Schema) kobject;
+    public Schema createSchema( final UnitOfWork uow,
+                                final KomodoObject parent,
+                                final String schemaName ) throws KException {
+        final String path = ( ( parent == null ) ? getRepository().komodoWorkspace( uow ).getAbsolutePath()
+                                                 : parent.getAbsolutePath() );
+         return RelationalModelFactory.createSchema( uow, getRepository(), path, schemaName );
     }
 
     /**
@@ -224,17 +216,12 @@ public class WorkspaceManager extends RelationalObjectImpl {
      * @throws KException
      *         if an error occurs
      */
-    public Teiid createTeiid( UnitOfWork uow,
-                              KomodoObject parent,
-                              String id ) throws KException {
-        if (parent == null)
-            parent = getRepository().komodoWorkspace(uow);
-
-        KomodoObject kobject = create(uow, parent, id, KomodoType.TEIID);
-        if (! (kobject instanceof Teiid))
-           return null;
-
-        return (Teiid) kobject;
+    public Teiid createTeiid( final UnitOfWork uow,
+                              final KomodoObject parent,
+                              final String id ) throws KException {
+        final String path = ( ( parent == null ) ? getRepository().komodoWorkspace( uow ).getAbsolutePath()
+                                                : parent.getAbsolutePath() );
+        return RelationalModelFactory.createTeiid( uow, getRepository(), path, id );
     }
 
     /**
@@ -253,21 +240,12 @@ public class WorkspaceManager extends RelationalObjectImpl {
      *         if an error occurs
      */
     public Vdb createVdb( final UnitOfWork uow,
-                          KomodoObject parent,
+                          final KomodoObject parent,
                           final String vdbName,
                           final String externalFilePath ) throws KException {
-        ArgCheck.isNotNull(externalFilePath, "externalFilePath"); //$NON-NLS-1$
-
-        RelationalProperty filePathProperty = new RelationalProperty( VdbLexicon.Vdb.ORIGINAL_FILE, externalFilePath );
-
-        if (parent == null)
-            parent = getRepository().komodoWorkspace(uow);
-
-        KomodoObject kobject = create(uow, parent, vdbName, KomodoType.VDB, filePathProperty);
-        if (! (kobject instanceof Vdb))
-           return null;
-
-        return (Vdb) kobject;
+        final String path = ( ( parent == null ) ? getRepository().komodoWorkspace( uow ).getAbsolutePath()
+                                                : parent.getAbsolutePath() );
+        return RelationalModelFactory.createVdb( uow, getRepository(), path, vdbName, externalFilePath );
     }
 
     /**

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/AbstractShellCommand.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/AbstractShellCommand.java
@@ -34,33 +34,21 @@ import org.komodo.utils.ArgCheck;
  */
 public abstract class AbstractShellCommand implements ShellCommand {
 
-	private WorkspaceStatus wsStatus;
+	private final WorkspaceStatus wsStatus;
 	private Arguments arguments;
 	private Writer writer;
 	protected List<String> validWsContextTypes = Collections.emptyList();
-	private String name;
 
-	/**
-	 * Constructor.
-	 */
-	public AbstractShellCommand() {
-	}
-
-	/**
-	 * @see org.komodo.shell.api.ShellCommand#getName()
-	 */
-	@Override
-	public String getName() {
-		return this.name;
-	}
-
-	/**
-	 * @see org.komodo.shell.api.ShellCommand#setName(String)
-	 */
-	@Override
-	public void setName(String name) {
-		this.name=name;
-	}
+    /**
+     * Constructs a command.
+     *
+     * @param status
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public AbstractShellCommand( final WorkspaceStatus status ) {
+        ArgCheck.isNotNull( status, "status" ); //$NON-NLS-1$
+        this.wsStatus = status;
+    }
 
 	/**
 	 * @see org.komodo.shell.api.ShellCommand#initValidWsContextTypes()
@@ -99,14 +87,6 @@ public abstract class AbstractShellCommand implements ShellCommand {
 		}
 
 		return false;
-	}
-
-	/**
-	 * @see org.komodo.shell.api.ShellCommand#setWorkspaceStatus(org.komodo.shell.api.WorkspaceStatus)
-	 */
-	@Override
-	public void setWorkspaceStatus(WorkspaceStatus wsStatus) {
-		this.wsStatus = wsStatus;
 	}
 
 	/**

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoShell.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoShell.java
@@ -24,7 +24,6 @@ package org.komodo.shell.api;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.Writer;
-
 import org.komodo.core.KEngine;
 import org.komodo.spi.constants.StringConstants;
 
@@ -47,9 +46,17 @@ public interface KomodoShell extends StringConstants {
      * @return the shell's output stream
      */
     PrintStream getOutputStream();
-    
+
     /**
-     * 
+     * The directory where the shell saves user settings, preferences, or any other data needed to restore a user session.The
+     * <code>${user.home}/.komodo</code> directory is the default location.
+     *
+     * @return the shell's workspace directory (never empty)
+     */
+    String getShellDataLocation();
+
+    /**
+     *
      * @return the command output writer
      */
     Writer getCommandOutput();
@@ -58,6 +65,6 @@ public interface KomodoShell extends StringConstants {
      * Exit the shell
      */
     void exit();
-    
+
 
 }

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
@@ -29,17 +29,15 @@ import java.util.List;
  */
 public interface ShellCommand {
 
-	/**
-	 * Get the name of the command.
-	 * @return the command name
-	 */
-	public String getName();
+    /**
+     * @return the command name (never empty)
+     */
+    public String getName();
 
 	/**
-	 * Set the name of the command.
-	 * @param name the command name
+	 * @return the command name aliases (never <code>null</code> but can be empty)
 	 */
-	public void setName(String name);
+	public String[] getAliases();
 
     /**
      * @return the command arguments (can be <code>null</code>)
@@ -62,12 +60,6 @@ public interface ShellCommand {
 	 * @return the stream writer (can be <code>null</code> if not set)
 	 */
 	Writer getWriter();
-
-	/**
-	 * Set the workspace status
-	 * @param wsStatus the workspace status
-	 */
-	public void setWorkspaceStatus(WorkspaceStatus wsStatus);
 
 	/**
 	 * Init Valid workspace context types for this command

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
@@ -24,8 +24,9 @@ package org.komodo.shell.api;
 import java.io.File;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import org.komodo.core.KEngine;
 import org.komodo.relational.teiid.Teiid;
@@ -50,41 +51,104 @@ public interface WorkspaceStatus extends StringConstants {
 	public static final String EXPORT_DEFAULT_DIR_KEY = "EXPORT_DEFAULT_DIR"; //$NON-NLS-1$
 
     /**
-     * Set to <code>true</code> if property namespace prefixes should be shown.
+     * Set to <code>true</code> if the full path of the current context object should be displayed in the prompt.
      */
-    public static final String SHOW_PROP_NAME_PREFIX_KEY = "SHOW_PROP_NAME_PREFIX"; //$NON-NLS-1$
+    String SHOW_FULL_PATH_IN_PROMPT_KEY = "SHOW_FULL_PATH_IN_PROMPT"; //$NON-NLS-1$
 
     /**
-     * A collection of the valid global property names.
+     * Set to <code>true</code> if the hidden properties should also be displayed.
      */
-    public static final List< String > GLOBAL_PROP_KEYS = Arrays.asList( RECORDING_FILE_KEY,
-                                                                         IMPORT_DEFAULT_DIR_KEY,
-                                                                         EXPORT_DEFAULT_DIR_KEY );
+    String SHOW_HIDDEN_PROPERTIES_KEY = "SHOW_HIDDEN_PROPERTIES"; //$NON-NLS-1$
+
+    /**
+     * Set to <code>true</code> if property namespace prefixes should be shown.
+     */
+    String SHOW_PROP_NAME_PREFIX_KEY = "SHOW_PROP_NAME_PREFIX"; //$NON-NLS-1$
+
+    /**
+     * Set to <code>true</code> if the type of the current context object should be displayed in the prompt.
+     */
+    String SHOW_TYPE_IN_PROMPT_KEY = "SHOW_TYPE_IN_PROMPT"; //$NON-NLS-1$
+
+    /**
+     * An unmodifiable collection of the valid global property names and their non-<code>null</code> default values.
+     */
+    Map< String, String > GLOBAL_PROPS = Collections.unmodifiableMap( new HashMap< String, String >() {
+
+        private static final long serialVersionUID = 1L;
+
+        // add default values for EVERY property
+        {
+            put( EXPORT_DEFAULT_DIR_KEY, StringConstants.EMPTY_STRING );
+            put( IMPORT_DEFAULT_DIR_KEY, StringConstants.EMPTY_STRING );
+            put( RECORDING_FILE_KEY, StringConstants.EMPTY_STRING );
+            put( SHOW_FULL_PATH_IN_PROMPT_KEY, Boolean.FALSE.toString() );
+            put( SHOW_HIDDEN_PROPERTIES_KEY, Boolean.FALSE.toString() );
+            put( SHOW_PROP_NAME_PREFIX_KEY, Boolean.FALSE.toString() );
+            put( SHOW_TYPE_IN_PROMPT_KEY, Boolean.TRUE.toString() );
+        }
+    } );
+
+    /**
+     * Sets the specified global property value.
+     *
+     * @param propKey
+     *        the property key (cannot be empty)
+     * @param propValue
+     *        the property value (can be empty when changing to the default value)
+     */
+    void setProperty( final String propKey,
+                      final String propValue );
+
+    /**
+     * Sets global workspace properties on startup
+     *
+     * @param props
+     *        the properties (can be <code>null</code> or empty if resetting to default values)
+     */
+    void setProperties( final Properties props );
 
 	/**
-	 * Sets the specified global property value
-	 * @param propKey the property key
-	 * @param propValue the property value
+	 * Set all properties back to their default values.
 	 */
-	void setProperty(String propKey, String propValue);
+	void resetProperties();
 
-	/**
-	 * Sets global workspace properties on startup
-	 * @param props the properties
-	 */
-	void setProperties(Properties props);
+    /**
+     * Gets a copy of the global workspace properties.
+     *
+     * @return the global workspace properties (never <code>null</code> or empty)
+     * @see #setProperty(String, String)
+     */
+    Properties getProperties();
 
-	/**
-	 * Gets global workspace properties
-	 * @return the global workspace properties
-	 */
-	Properties getProperties();
+    /**
+     * @param propertyName the name of the property being checked (cannot be empty)
+     * @return <code>true</code> if a known boolean property
+     */
+    boolean isBooleanProperty( final String propertyName );
+
+    /**
+     * @param propertyName
+     *        the name of the property being checked (cannot be empty)
+     * @param proposedValue
+     *        the proposed value (can be empty if removing or resetting to the default value)
+     * @return an error message or <code>null</code> if name and proposed value are valid
+     */
+    String validateGlobalPropertyValue( final String propertyName,
+                                        final String proposedValue );
 
 	/**
 	 * Get the workspace context
 	 * @return the workspace context
 	 */
 	WorkspaceContext getWorkspaceContext();
+
+    /**
+     * Saves data needed to restore next session (preferences, settings, configuration, etc.).
+     *
+     * @throws Exception
+     */
+    void save() throws Exception;
 
 	/**
 	 * Set the current workspace context
@@ -118,9 +182,28 @@ public interface WorkspaceStatus extends StringConstants {
 	File getRecordingOutputFile();
 
     /**
+     * @return <code>true</code> if the full object path is being displayed in the prompt
+     * @see #SHOW_FULL_PATH_IN_PROMPT_KEY
+     */
+    boolean isShowingFullPathInPrompt();
+
+    /**
+     * @return <code>true</code> if hidden properties are being displayed
+     * @see #SHOW_HIDDEN_PROPERTIES_KEY
+     */
+    boolean isShowingHiddenProperties();
+
+    /**
      * @return <code>true</code> if property namespace prefixes should be shown
+     * @see #SHOW_PROP_NAME_PREFIX_KEY
      */
     boolean isShowingPropertyNamePrefixes();
+
+    /**
+     * @return <code>true</code> if property namespace prefixes should be shown
+     * @see #SHOW_TYPE_IN_PROMPT_KEY
+     */
+    boolean isShowingTypeInPrompt();
 
 	/**
      * @return current teiid model

--- a/plugins/org.komodo.shell/src/org/komodo/shell/AbstractShellCommandReader.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/AbstractShellCommandReader.java
@@ -36,10 +36,10 @@ import org.komodo.shell.commands.NoOpCommand;
 
 /**
  * Abstract class for all shell command readers.
- * 
+ *
  * This class adapted from https://github.com/Governance/s-ramp/blob/master/s-ramp-shell
  * - altered to use WorkspaceStatus
- * 
+ *
  * @author eric.wittmann@redhat.com
  */
 public abstract class AbstractShellCommandReader implements ShellCommandReader {
@@ -103,7 +103,7 @@ public abstract class AbstractShellCommandReader implements ShellCommandReader {
         line = filterLine(line, properties);
 		Arguments arguments = new Arguments(line);
 		if (arguments.isEmpty()) {
-			return new NoOpCommand("NoOp"); //$NON-NLS-1$
+            return new NoOpCommand( this.wsStatus );
 		}
 
 		// The first argument is the command name.
@@ -213,4 +213,23 @@ public abstract class AbstractShellCommandReader implements ShellCommandReader {
 	    return false;
 	}
 
+    protected String getPrompt() throws Exception {
+        // see if full path should be displayed
+        String path = null;
+
+        if ( getWorkspaceStatus().isShowingFullPathInPrompt() ) {
+            path = getWorkspaceStatus().getCurrentContext().getFullName();
+        } else {
+            path = getWorkspaceStatus().getCurrentContext().getName();
+        }
+
+        assert ( path != null );
+
+        // see if type should be displayed
+        if ( getWorkspaceStatus().isShowingTypeInPrompt() ) {
+            return Messages.getString( Messages.SHELL.PROMPT_WITH_TYPE, path, getWorkspaceStatus().getCurrentContext().getType() );
+        }
+
+        return Messages.getString( Messages.SHELL.PROMPT, path );
+    }
 }

--- a/plugins/org.komodo.shell/src/org/komodo/shell/ConsoleShellCommandReader.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/ConsoleShellCommandReader.java
@@ -24,10 +24,10 @@ import org.komodo.shell.api.WorkspaceStatus;
  * An implementation of the {@link ShellCommandReader} that uses standard input
  * to read commands typed in by the user.  This implementation uses the Java
  * System.console() facility to read user input.
- * 
+ *
  * This class adapted from https://github.com/Governance/s-ramp/blob/master/s-ramp-shell
  * - altered to use WorkspaceStatus
- * 
+ *
  * @author eric.wittmann@redhat.com
  */
 public class ConsoleShellCommandReader extends AbstractShellCommandReader {
@@ -77,8 +77,7 @@ public class ConsoleShellCommandReader extends AbstractShellCommandReader {
 	 */
 	@Override
 	protected String readLine() throws Exception {
-		String prompt = "["+getWorkspaceStatus().getCurrentContext().getName()+"] > "; //$NON-NLS-1$ //$NON-NLS-2$
-		return console.readLine(prompt);
+		return console.readLine(getPrompt() + " > "); //$NON-NLS-1$
 	}
 
 	/**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -39,6 +39,10 @@ public class Messages implements StringConstants {
 
     @SuppressWarnings( "javadoc" )
     public enum SHELL {
+        INVALID_GLOBAL_PROPERTY_NAME,
+        INVALID_BOOLEAN_GLOBAL_PROPERTY_VALUE,
+        PROMPT,
+        PROMPT_WITH_TYPE,
         CHILD_NAME_HEADER,
         CHILD_TYPE_HEADER,
         PROPERTY_NAME_HEADER,
@@ -81,6 +85,8 @@ public class Messages implements StringConstants {
     	InvalidArgMsg_propertiesFile_error_reading,
     	InvalidArgMsg_propertiesFile_error_reading_line,
         FileShellCommandReader_NoConsole,
+        HelpNoAliases,
+        HelpAliasesHeading,
         HelpUsageHeading,
         HelpDescription,
         HelpDescriptionHeading,

--- a/plugins/org.komodo.shell/src/org/komodo/shell/StdInShellCommandReader.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/StdInShellCommandReader.java
@@ -24,10 +24,10 @@ import org.komodo.shell.api.WorkspaceStatus;
 /**
  * An implementation of the {@link ShellCommandReader} that uses standard input
  * to read commands typed in by the user.
- * 
+ *
  * This class adapted from https://github.com/Governance/s-ramp/blob/master/s-ramp-shell
  * - altered to use WorkspaceStatus
- * 
+ *
  * @author eric.wittmann@redhat.com
  */
 public class StdInShellCommandReader extends AbstractShellCommandReader {
@@ -73,8 +73,7 @@ public class StdInShellCommandReader extends AbstractShellCommandReader {
 	@Override
 	protected String readLine() throws Exception {
 		if (!stdinReader.ready()) {
-			String prompt = "["+getWorkspaceStatus().getCurrentContext().getName()+"] > "; //$NON-NLS-1$ //$NON-NLS-2$
-			getOutputStream().print(prompt);
+			getOutputStream().print(getPrompt() + " > "); //$NON-NLS-1$
 		}
 		return stdinReader.readLine();
 	}

--- a/plugins/org.komodo.shell/src/org/komodo/shell/TabCompleter.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/TabCompleter.java
@@ -27,10 +27,10 @@ import org.komodo.shell.commands.CommandNotFoundCommand;
 
 /**
  * Implements tab completion for the interactive
- * 
+ *
  * This class adapted from https://github.com/Governance/s-ramp/blob/master/s-ramp-shell
  * - altered complete method due to removal of shell context
- * 
+ *
  * @author eric.wittmann@redhat.com
  */
 public class TabCompleter implements Completion {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceContextImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceContextImpl.java
@@ -269,6 +269,30 @@ public class WorkspaceContextImpl implements WorkspaceContext {
         return props;
     }
 
+    /**
+     * @return the names of the unfiltered properties that have values (includes those that have not been set yet)
+     * @throws Exception
+     *         if an error occurs
+     */
+    public List< String > getUnfilteredProperties() throws Exception {
+        final KomodoObject relObj = getKomodoObj();
+        final UnitOfWork transaction = this.wsStatus.getTransaction();
+        final List< String > props = new ArrayList<>( Arrays.asList( relObj.getRawPropertyNames( transaction ) ) ); // props with values
+        final PropertyDescriptor[] descriptors = relObj.getRawPropertyDescriptors( transaction );
+
+        if ( descriptors.length != 0 ) {
+            for ( final PropertyDescriptor descriptor : descriptors ) {
+                final String name = descriptor.getName();
+
+                if ( !props.contains( name ) ) {
+                    props.add( name );
+                }
+            }
+        }
+
+        return props;
+    }
+
     @Override
     public String getPropertyValue( final String propertyName ) throws Exception {
         final KomodoObject relObj = getKomodoObj();
@@ -276,6 +300,25 @@ public class WorkspaceContextImpl implements WorkspaceContext {
 
         if ( relObj.hasProperty( transaction, propertyName ) ) {
             final Property property = relObj.getProperty( transaction, propertyName );
+            return RepositoryTools.getDisplayValue( transaction, property );
+        }
+
+        return Messages.getString( SHELL.NO_PROPERTY_VALUE );
+    }
+
+    /**
+     * @param propertyName
+     *        the name of the unfiltered being requested (cannot be empty)
+     * @return the property value (never empty)
+     * @throws Exception
+     *         if an error occurs
+     */
+    public String getUnfilteredPropertyValue( final String propertyName ) throws Exception {
+        final KomodoObject relObj = getKomodoObj();
+        final UnitOfWork transaction = this.wsStatus.getTransaction();
+
+        if ( relObj.hasRawProperty( transaction, propertyName ) ) {
+            final Property property = relObj.getRawProperty( transaction, propertyName );
             return RepositoryTools.getDisplayValue( transaction, property );
         }
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/CommandNotFoundCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/CommandNotFoundCommand.java
@@ -19,6 +19,9 @@ import org.komodo.shell.CompletionConstants;
 import org.komodo.shell.Messages;
 import org.komodo.shell.Messages.SHELL;
 import org.komodo.shell.api.AbstractShellCommand;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.spi.constants.StringConstants;
+import org.komodo.utils.ArgCheck;
 
 /**
  * The command used when a command does not exist for a given command name.
@@ -30,14 +33,38 @@ import org.komodo.shell.api.AbstractShellCommand;
  */
 public class CommandNotFoundCommand extends AbstractShellCommand {
 
-	/**
-	 * Constructor.
-	 * @param name the command name
-	 */
-	public CommandNotFoundCommand(String name) {
-		super();
-		setName(name);
-	}
+    private final String name;
+
+    /**
+     * @param name
+     *        the command name that was not found (cannot be empty)
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public CommandNotFoundCommand( final String name,
+                                   final WorkspaceStatus wsStatus ) {
+        super( wsStatus );
+        ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
+        this.name = name;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommand#getAliases()
+     */
+    @Override
+    public final String[] getAliases() {
+        return StringConstants.EMPTY_ARRAY;
+    }
+
+    /**
+     * @see org.komodo.shell.api.ShellCommand#getName()
+     */
+    @Override
+    public final String getName() {
+        return this.name;
+    }
 
 	/**
      * @see org.komodo.shell.api.ShellCommand#printUsage(int indent)

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/ExitCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/ExitCommand.java
@@ -15,7 +15,6 @@
  */
 package org.komodo.shell.commands;
 
-import org.komodo.core.KEngine;
 import org.komodo.shell.BuiltInShellCommand;
 import org.komodo.shell.CompletionConstants;
 import org.komodo.shell.Messages;
@@ -24,39 +23,26 @@ import org.komodo.shell.api.WorkspaceStatus;
 
 /**
  * Implements the 'exit' command.
- * 
+ *
  * This class adapted from https://github.com/Governance/s-ramp/blob/master/s-ramp-shell
  * - altered to use different Message class
- * 
+ *
  * @author eric.wittmann@redhat.com
  */
 public class ExitCommand extends BuiltInShellCommand {
 
-	
-	/**
-	 * Constructor.
-	 * @param name the command name
-	 * @param wsStatus the workspace status
-	 */
-	public ExitCommand(String name, WorkspaceStatus wsStatus) {
-		super(name,wsStatus);
-	}
+    /**
+     * The command name.
+     */
+    public static final String NAME = "exit"; //$NON-NLS-1$
 
-	/**
-	 * @see org.komodo.shell.api.ShellCommand#printUsage(int indent)
-	 */
-	@Override
-	public void printUsage(int indent) {
-		print(indent,"exit"); //$NON-NLS-1$
-	}
-
-	/**
-	 * @see org.komodo.shell.api.ShellCommand#printHelp(int indent)
-	 */
-	@Override
-	public void printHelp(int indent) {
-	    printUsage(indent);
-	}
+    /**
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public ExitCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME, "quit" ); //$NON-NLS-1$
+    }
 
 	/**
 	 * @see org.komodo.shell.api.ShellCommand#execute()
@@ -64,14 +50,7 @@ public class ExitCommand extends BuiltInShellCommand {
 	@Override
 	public boolean execute() throws Exception {
 		print(CompletionConstants.MESSAGE_INDENT,Messages.getString(SHELL.GOOD_BYE));
-
-		KEngine engine = this.getWorkspaceStatus().getEngine();
-		if (engine != null) {
-		    engine.shutdownAndWait();
-		}
-
 		getWorkspaceStatus().getShell().exit();
-
         return true;
 	}
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/NoOpCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/NoOpCommand.java
@@ -16,6 +16,8 @@
 package org.komodo.shell.commands;
 
 import org.komodo.shell.api.AbstractShellCommand;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.spi.constants.StringConstants;
 
 /**
  * The command about nothing.  The Seinfeld command.
@@ -27,13 +29,36 @@ import org.komodo.shell.api.AbstractShellCommand;
  */
 public class NoOpCommand extends AbstractShellCommand {
 
-	/**
-	 * Constructor.
-	 * @param name the command name
-	 */
-	public NoOpCommand(String name) {
-		setName(name);
-	}
+    /**
+     * The command name.
+     */
+    public static final String NAME = "NoOp"; //$NON-NLS-1$
+
+    /**
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public NoOpCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommand#getAliases()
+     */
+    @Override
+    public final String[] getAliases() {
+        return StringConstants.EMPTY_ARRAY;
+    }
+
+    /**
+     * @see org.komodo.shell.api.ShellCommand#getName()
+     */
+    @Override
+    public final String getName() {
+        return NAME;
+    }
 
 	/**
 	 * @see org.komodo.shell.api.ShellCommand#printUsage(int indent)

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
@@ -1,0 +1,158 @@
+/*************************************************************************************
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership. Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ ************************************************************************************/
+package org.komodo.shell.commands.core;
+
+import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.komodo.relational.model.Column;
+import org.komodo.relational.model.TableConstraint;
+import org.komodo.shell.BuiltInShellCommand;
+import org.komodo.shell.Messages;
+import org.komodo.shell.api.Arguments;
+import org.komodo.shell.api.WorkspaceContext;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.shell.util.ContextUtils;
+import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+
+/**
+ * Adds a {@link Column column reference} to a {@link TableConstraint table constraint}.
+ */
+public final class AddConstraintColumnCommand extends BuiltInShellCommand {
+
+    /**
+     * The command name.
+     */
+    public static final String NAME = "add-column"; //$NON-NLS-1$
+
+    private final FindCommand findCommand;
+
+    /**
+     * @param status
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public AddConstraintColumnCommand( final WorkspaceStatus status ) {
+        super( status, NAME );
+        this.findCommand = new FindCommand( status );
+        this.findCommand.setOutput( getWriter() );
+
+        try {
+            this.findCommand.setArguments( new Arguments( StringConstants.EMPTY_STRING ) );
+        } catch ( final Exception e ) {
+            // only occurs on parsing error of arguments and we have no arguments
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommand#execute()
+     */
+    @Override
+    public boolean execute() throws Exception {
+        try {
+            final String columnPathArg = requiredArgument( 0,
+                                                           Messages.getString( "AddConstraintColumnCommand.missingColumnPathArg" ) ); //$NON-NLS-1$
+
+            // get reference of the column at the specified path
+            final WorkspaceContext columnContext = ContextUtils.getContextForPath( getWorkspaceStatus(), columnPathArg );
+
+            if ( columnContext == null ) {
+                print( MESSAGE_INDENT, Messages.getString( "AddConstraintColumnCommand.columnPathNotFound", columnPathArg ) ); //$NON-NLS-1$
+                return false;
+            }
+
+            final KomodoObject column = columnContext.getKomodoObj();
+
+            if ( column instanceof Column ) {
+                // initValidWsContextTypes() method assures execute is called only if current context is a TableConstraint
+                final KomodoObject kobject = getContext().getKomodoObj();
+                assert ( kobject instanceof TableConstraint );
+                final TableConstraint constraint = ( TableConstraint )kobject;
+                constraint.addColumn( getWorkspaceStatus().getTransaction(), ( Column )column );
+
+                print( MESSAGE_INDENT,
+                       Messages.getString( "AddConstraintColumnCommand.columnRefAdded", columnPathArg, getContext().getFullName() ) ); //$NON-NLS-1$
+                return true;
+            } else {
+                print( MESSAGE_INDENT, Messages.getString( "AddConstraintColumnCommand.invalidColumnPath", columnPathArg ) ); //$NON-NLS-1$
+                return false;
+            }
+        } catch ( final Exception e ) {
+            print( MESSAGE_INDENT, Messages.getString( "AddConstraintColumnCommand.error" ) ); //$NON-NLS-1$
+            print( MESSAGE_INDENT, "\t" + e.getMessage() ); //$NON-NLS-1$
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.AbstractShellCommand#initValidWsContextTypes()
+     */
+    @Override
+    public void initValidWsContextTypes() {
+        final List< String > temp = new ArrayList<>();
+        temp.add( KomodoType.PRIMARY_KEY.getType() );
+        temp.add( KomodoType.UNIQUE_CONSTRAINT.getType() );
+        temp.add( KomodoType.ACCESS_PATTERN.getType() );
+        temp.add( KomodoType.FOREIGN_KEY.getType() );
+        temp.add( KomodoType.INDEX.getType() );
+
+        this.validWsContextTypes = Collections.unmodifiableList( temp );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.AbstractShellCommand#tabCompletion(java.lang.String, java.util.List)
+     */
+    @Override
+    public int tabCompletion( final String lastArgument,
+                              final List< CharSequence > candidates ) throws Exception {
+        if ( getArguments().isEmpty() ) {
+            final boolean noLastArg = ( lastArgument == null );
+
+            // find columns in workspace
+            final String[] columnPaths = this.findCommand.query( KomodoType.COLUMN );
+
+            if ( columnPaths.length == 0 ) {
+                return -1;
+            }
+
+            for ( final String path : columnPaths ) {
+                if ( ( noLastArg ) || ( path.toUpperCase().startsWith( lastArgument.toUpperCase() ) ) ) {
+                    candidates.add( path );
+                }
+            }
+
+            return 0;
+        }
+
+        // no completions if more than one arg
+        return -1;
+    }
+
+}

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CdCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CdCommand.java
@@ -37,15 +37,18 @@ import org.komodo.spi.constants.StringConstants;
  */
 public class CdCommand extends BuiltInShellCommand implements StringConstants {
 
-    private static final String CD = "cd"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "cd"; //$NON-NLS-1$
 
     /**
-	 * Constructor
-	 * @param wsStatus the workspace status
-	 */
-	public CdCommand(WorkspaceStatus wsStatus) {
-		super(CD,wsStatus);
-	}
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public CdCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME, "edit", "goto" ); //$NON-NLS-1$ //$NON-NLS-2$
+    }
 
 	/**
 	 * @see org.komodo.shell.api.ShellCommand#execute()

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
@@ -32,14 +32,17 @@ import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
  */
 public class CreateCommand extends BuiltInShellCommand implements StringConstants {
 
-    private static final String CREATE = "create"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "create"; //$NON-NLS-1$
 
     /**
-     * Constructor.
-     * @param wsStatus the workspace status
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
      */
-    public CreateCommand(WorkspaceStatus wsStatus) {
-        super(CREATE, wsStatus);
+    public CreateCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME );
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/DeleteCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/DeleteCommand.java
@@ -20,14 +20,17 @@ import org.komodo.spi.repository.Repository.UnitOfWork;
  */
 public class DeleteCommand extends BuiltInShellCommand implements StringConstants {
 
-    private static final String DELETE = "delete"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "delete"; //$NON-NLS-1$
 
     /**
-     * Constructor.
-     * @param wsStatus the workspace status
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
      */
-    public DeleteCommand(WorkspaceStatus wsStatus) {
-        super(DELETE, wsStatus);
+    public DeleteCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME, "rm" ); //$NON-NLS-1$
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/DeployCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/DeployCommand.java
@@ -23,7 +23,6 @@ package org.komodo.shell.commands.core;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-
 import org.komodo.relational.teiid.Teiid;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.workspace.WorkspaceManager;
@@ -45,17 +44,21 @@ import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
  */
 public class DeployCommand extends BuiltInShellCommand implements StringConstants {
 
-    private static final String DEPLOY = "deploy"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "deploy"; //$NON-NLS-1$
 
     private static final String VDB_TYPE = VdbLexicon.Vdb.VIRTUAL_DATABASE;
 
     /**
-     * @param wsStatus a workspace status (cannot be <code>null</code>)
+     * @param wsStatus
+     *        a workspace status (cannot be <code>null</code>)
      */
-    public DeployCommand(WorkspaceStatus wsStatus) {
-        super(DEPLOY, wsStatus);
+    public DeployCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME );
     }
-    
+
     @Override
     public boolean execute() throws Exception {
         WorkspaceStatus wsStatus = getWorkspaceStatus();

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ExportCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ExportCommand.java
@@ -29,14 +29,17 @@ import org.komodo.spi.repository.Repository.UnitOfWork;
  */
 public class ExportCommand extends BuiltInShellCommand implements StringConstants {
 
-    private static final String EXPORT = "export"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "export"; //$NON-NLS-1$
 
     /**
-     * Constructor.
-     * @param wsStatus the workspace status
+     * @param wsStatus
+     *        the workspace status
      */
-    public ExportCommand(WorkspaceStatus wsStatus) {
-        super(EXPORT, wsStatus);
+    public ExportCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME );
     }
 
     /**
@@ -162,37 +165,10 @@ public class ExportCommand extends BuiltInShellCommand implements StringConstant
             fileNameString = fileNameString + DOT + fileExtension;
         }
 
-        FileWriter fileWriter = null;
-        BufferedWriter outputBufferWriter = null;
-        PrintWriter printWriter = null;
-        try {
-            fileWriter = new FileWriter(fileNameString);
-            outputBufferWriter = new BufferedWriter(fileWriter);
-            printWriter = new PrintWriter(outputBufferWriter);
-            printWriter.write(contents);
-        } finally {
-            // Clean up writers & buffers
-            try {
-                if (printWriter != null)
-                    printWriter.close();
-            } finally {
-                // Do nothing
-            }
-
-            try {
-                if (outputBufferWriter != null)
-                    outputBufferWriter.close();
-            } finally {
-                // Do nothing
-            }
-
-            try {
-                if (fileWriter != null) {
-                    fileWriter.close();
-                }
-            } catch (java.io.IOException e) {
-                // Do nothing
-            }
+        try ( final FileWriter fileWriter = new FileWriter( fileNameString );
+              final BufferedWriter outputBufferWriter = new BufferedWriter( fileWriter );
+              final PrintWriter printWriter = new PrintWriter( outputBufferWriter ) ) {
+            printWriter.write( contents );
         }
     }
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/HomeCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/HomeCommand.java
@@ -26,23 +26,21 @@ import org.komodo.shell.api.Arguments;
 import org.komodo.shell.api.WorkspaceStatus;
 
 /**
- * Displays a summary of the current status, including what repository the
- * user is currently connected to (if any).
- *
+ * Changes the context to the workspace root.
  */
-public class ListCommand extends BuiltInShellCommand {
+public class HomeCommand extends BuiltInShellCommand {
 
     /**
      * The command name.
      */
-    public static final String NAME = "list"; //$NON-NLS-1$
+    public static final String NAME = "home"; //$NON-NLS-1$
 
     /**
      * @param wsStatus
      *        the workspace status (cannot be <code>null</code>)
      */
-    public ListCommand( final WorkspaceStatus wsStatus ) {
-        super( wsStatus, NAME, "ls", "ll" ); //$NON-NLS-1$ //$NON-NLS-2$
+    public HomeCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME );
     }
 
 	/**
@@ -50,12 +48,12 @@ public class ListCommand extends BuiltInShellCommand {
 	 */
 	@Override
     public boolean execute() throws Exception {
-        final ShowCommand showCmd = new ShowCommand( getWorkspaceStatus() );
-        final Arguments args = new Arguments( ShowCommand.SUBCMD_CHILDREN );
-        showCmd.setArguments( args );
-        showCmd.setOutput( getWriter() );
+        final CdCommand cdCmd = new CdCommand( getWorkspaceStatus() );
+        final Arguments args = new Arguments( "/" ); //$NON-NLS-1$
+        cdCmd.setArguments( args );
+        cdCmd.setOutput( getWriter() );
 
-        return showCmd.execute();
+        return cdCmd.execute();
     }
 
 }

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ImportCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ImportCommand.java
@@ -33,7 +33,10 @@ import org.komodo.spi.repository.Repository;
  */
 public class ImportCommand extends BuiltInShellCommand {
 
-    private static final String IMPORT = "import"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "import"; //$NON-NLS-1$
 
     private static final String SUBCMD_DDL = "ddl"; //$NON-NLS-1$
     private static final String SUBCMD_VDB = "vdb"; //$NON-NLS-1$
@@ -44,11 +47,11 @@ public class ImportCommand extends BuiltInShellCommand {
     private ImportMessages importMessages = null;
 
     /**
-     * Constructor.
-     * @param wsStatus the workspace status
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
      */
-    public ImportCommand(WorkspaceStatus wsStatus) {
-        super(IMPORT, wsStatus);
+    public ImportCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME );
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/NavigateCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/NavigateCommand.java
@@ -32,15 +32,18 @@ import org.komodo.shell.api.WorkspaceStatus;
  */
 public class NavigateCommand extends BuiltInShellCommand {
 
-    private static final String NAVIGATE = "navigate"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "navigate"; //$NON-NLS-1$
 
-	/**
-	 * Constructor.
-	 * @param wsStatus the workspace status
-	 */
-	public NavigateCommand(WorkspaceStatus wsStatus) {
-		super(NAVIGATE,wsStatus);
-	}
+    /**
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public NavigateCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME );
+    }
 
 	/**
 	 * @see org.komodo.shell.api.ShellCommand#execute()
@@ -48,7 +51,7 @@ public class NavigateCommand extends BuiltInShellCommand {
 	@Override
 	public boolean execute() throws Exception {
 		WorkspaceStatus wsStatus = getWorkspaceStatus();
-		
+
 		WorkspaceContext currentContext = wsStatus.getCurrentContext();
 		TraverseWorkspaceVisitor visitor = new TraverseWorkspaceVisitor();
         Object pathway = currentContext.visit(visitor);

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/PlayCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/PlayCommand.java
@@ -19,15 +19,18 @@ import org.komodo.spi.constants.StringConstants;
  */
 public class PlayCommand  extends BuiltInShellCommand implements StringConstants {
 
-    private static final String PLAY = "play"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "play"; //$NON-NLS-1$
 
     /**
-	 * Constructor.
-	 * @param wsStatus the workspace status
-	 */
-	public PlayCommand(WorkspaceStatus wsStatus) {
-		super(PLAY,wsStatus);
-	}
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
+     */
+    public PlayCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME );
+    }
 
 	/**
 	 * @see org.komodo.shell.api.ShellCommand#execute()

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/RenameCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/RenameCommand.java
@@ -19,14 +19,17 @@ import org.komodo.spi.repository.KomodoType;
  */
 public class RenameCommand extends BuiltInShellCommand implements StringConstants {
 
-    private static final String RENAME = "rename"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "rename"; //$NON-NLS-1$
 
     /**
-     * Constructor.
-     * @param wsStatus the workspace status
+     * @param wsStatus
+     *        the workspace status (cannot be <code>null</code>)
      */
-    public RenameCommand(WorkspaceStatus wsStatus) {
-        super(RENAME, wsStatus);
+    public RenameCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME, "mv" ); //$NON-NLS-1$
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/UnsetPropertyCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/UnsetPropertyCommand.java
@@ -20,14 +20,17 @@ import org.komodo.shell.api.WorkspaceStatus;
  */
 public class UnsetPropertyCommand extends BuiltInShellCommand {
 
-    private static String NAME = "unset"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "unset"; //$NON-NLS-1$
 
     /**
      * @param status
      *        the workspace status (cannot be <code>null</code>)
      */
     public UnsetPropertyCommand( final WorkspaceStatus status ) {
-        super( NAME, status );
+        super( status, NAME );
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/UseTeiidCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/UseTeiidCommand.java
@@ -22,7 +22,6 @@
 package org.komodo.shell.commands.core;
 
 import java.util.List;
-
 import org.komodo.relational.teiid.Teiid;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.BuiltInShellCommand;
@@ -38,13 +37,17 @@ import org.komodo.spi.runtime.TeiidInstance;
  */
 public class UseTeiidCommand extends BuiltInShellCommand implements StringConstants {
 
-    private static final String USE_TEIID = "useTeiid"; //$NON-NLS-1$
+    /**
+     * The command name.
+     */
+    public static final String NAME = "useTeiid"; //$NON-NLS-1$
 
     /**
-     * @param wsStatus a workspace status (cannot be <code>null</code>)
+     * @param wsStatus
+     *        a workspace status (cannot be <code>null</code>)
      */
-    public UseTeiidCommand(WorkspaceStatus wsStatus) {
-        super(USE_TEIID, wsStatus);
+    public UseTeiidCommand( final WorkspaceStatus wsStatus ) {
+        super( wsStatus, NAME );
     }
 
     @Override

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -1,34 +1,26 @@
 # Generic Messages for command-specific messages 
 # Must use the 'dot' notation below, e.g. <commandName>.usage
 
+# AddConstraintColumnCommand
+AddConstraintColumnCommand.examples= \
+\t add-column /workspace/MyVdb/MyModel/MyTable/MyColumn
+AddConstraintColumnCommand.usage = add-column <column-path>
+AddConstraintColumnCommand.help = adds a column reference to the table constraint (i.e., primary key, unique constraint, access pattern, foreign key, or index). \n\n \
+\tNote 1: Use the "find Column" command to find the paths of all the columns in your workspace.\n \
+\tNote 2: You can also use tab completion to get a list of the column paths.
+AddConstraintColumnCommand.columnRefAdded = The reference to the column at "{0}" has been added to the table constraint "{1}".
+AddConstraintColumnCommand.columnPathNotFound = The specified column path of "{0}" cannot be found in the workspace. Use the "find Column" command to find all the column paths.
+AddConstraintColumnCommand.error = Failed to add column to the constraint.
+AddConstraintColumnCommand.invalidColumnPath = The path at "{0}" is not a path to a column.
+AddConstraintColumnCommand.missingColumnPathArg = Please specify the workspace path of the column you wish to reference in this constraint.
+AddConstraintColumnCommand.success = Successfully added a reference to column "{0}" to this constraint.
+
 # BuiltInCommand
 BuiltInShellCommand.locationArg_noContextWithThisName=The specified path "{0}" is not valid
 BuiltInShellCommand.propertyArg_noPropertyWithThisName=The property "{0}" is not valid
 BuiltInShellCommand.locationArg_empty=path arg is empty.
 BuiltInShellCommand.typeArg_childTypeNotAllowed=The object type "{0}" is invalid, or not allowed as a child of "{1}".
 BuiltInShellCommand.objectNameNotValid=The name "{0}" is not valid
-
-# StatusCommand
-StatusCommand.examples= \
-\t status
-StatusCommand.usage=status
-StatusCommand.help=display the current VDB Builder engine status.
-StatusCommand.CurrentRepo   =Current Repo    : {0}
-StatusCommand.NoCurrentTeiid = Current Teiid Instance  : None set
-StatusCommand.CurrentTeiid =Current Teiid Instance  : {0}
-StatusCommand.CurrentTeiidJdbc =Current Teiid Instance Jdbc  : {0}
-StatusCommand.CurrentContext=Current Context : [{0}]
-StatusCommand.Separator=" : "
-StatusCommand.Connected=Connected
-StatusCommand.NotConnected=Not Connected
-StatusCommand.PingOk=Ping OK
-StatusCommand.PingFail=Ping Fail
-
-# ListCommand
-ListCommand.examples= \
-\t list
-ListCommand.usage=list
-ListCommand.help=display children of the current workspace context.
 
 # CdCommand
 CdCommand.examples= \
@@ -37,100 +29,6 @@ CdCommand.examples= \
 \t cd /myVdb/myDataRole
 CdCommand.usage=cd <path>
 CdCommand.help=change the current workspace context.
-
-# PlayCommand
-PlayCommand.examples= \
-\t play /home/vdbuilder_commands/build_my_vdb.txt
-PlayCommand.usage=play <file_name>
-PlayCommand.help=execute commands defined in a specified text file.
-PlayCommand.InvalidArgMsg_FileName=Please specify the command file name.
-PlayCommand.fileExecuted=All commands in file {0} have been executed.
-PlayCommand.Failure=Failed to execute all commands in file {0}
-PlayCommand.CommandFailure=Failed to execute the {0} command
-
-# SetCommand
-SetCommand.examples= \
-\t set property selectable true \n \
-\t set property mappedRoleNames admin,user \n \
-\t set property mappedRoleNames "admin,guest user,tester" \n \
-\t set global RECORDING_FILE /my/output/folder/file.txt \n \
-\t set record on \n \
-\t set description "This is my description"
-SetCommand.help=change various object values. \n\tNote 1: A value containing one or more spaces should be surrounded by double quotes. \n\tNote 2: Multi-valued properties should be comma-separated.
-SetCommand.usage=set <property | global | record> <property_name> <property_value> [object_path]
-SetCommand.propUsage=set property <property_name> <property_value> [object_path]
-SetCommand.globalUsage=set global <property_name> <property_value>
-SetCommand.recordUsage=set record <on | off>
-SetCommand.InvalidArgMsg_SubCommand=Please specify a sub-command (property, global).
-SetCommand.InvalidArgMsg_PropertyName=Please specify a property name.
-SetCommand.InvalidArgMsg_PropertyValue=Please specify a property value.
-SetCommand.InvalidArgMsg_GlobalPropertyName=Please specify a global property name.
-SetCommand.PropertySet=Successfully set property {0}.
-SetCommand.GlobalPropertySet=Successfully set global property {0}.
-SetCommand.InvalidSubCommand=Invalid sub-command, must be ("property", "global")
-SetCommand.Failure=FAILED to change the property.
-SetCommand.onOffArg_empty=The command arg is empty.
-SetCommand.onOffArg_invalid=The command arg must be 'on' or 'off'.
-SetCommand.setRecordingStateMsg=Recording set {0} at {1} - File: "{2}"
-SetCommand.recordingFileNotSet=The recording file global property has not been specified.
-SetCommand.recordingFileNotWriteable=Unable to write to the specified recording file: "{0}"
-
-# Unset Command
-UnsetPropertyCommand.examples= \
-\t unset description
-UnsetPropertyCommand.usage=unset <property_name>
-UnsetPropertyCommand.help=remove a property value from the current object.
-UnsetPropertyCommand.error=Failed to unset the property.
-UnsetPropertyCommand.missingPropertyName = A property name is required when unsetting a property.
-UnsetPropertyCommand.propertyUnset=Successfully unset property "{0}".
-
-# HelpCommand
-HelpCommand.examples = \
-\t help \n \
-\t help cd
-HelpCommand.usage = help [command-name] 
-HelpCommand.help = display available commands or specific command information.
-
-# ShowCommand
-ShowCommand.examples= \
-\t show properties \n \
-\t show children \n \
-\t show summary \n \
-\t show property description \n \
-\t show status \n \
-\t show global
-ShowCommand.usage=show <summary | properties | children | property | global | status> [command_option]
-ShowCommand.help=display various workspace information and status.
-ShowCommand.InvalidArgMsg_SubCommand=Please specify a sub-command (properties, children, property, summary, status, global).
-ShowCommand.InvalidArgMsg_PropertyName=Please specify a valid property name for the current context.
-ShowCommand.InvalidSubCommand=Invalid sub-command, must be "properties", "children", "status", "global", "property", or "summary".
-ShowCommand.Failure=Command FAILED.
-ShowCommand.NoPropertiesMsg=There are no properties for {0} "{1}".\n
-ShowCommand.PropertiesHeader=Properties for {0} "{1}":\n
-ShowCommand.PropertyHeader=Property for {0} "{1}":\n
-ShowCommand.ChildrenHeader=Children for {0} "{1}":\n
-ShowCommand.CurrentRepo   = Current Repository : {0}, Workspace : {1}
-ShowCommand.NoCurrentTeiid = Current Teiid Instance  : None set
-ShowCommand.CurrentTeiid =Current Teiid Instance  : {0}
-ShowCommand.CurrentTeiidJdbc =Current Teiid Instance JDBC  : {0}
-ShowCommand.CurrentContext=Current Context : [{0}]
-ShowCommand.GlobalPropertiesHeader=Global shell properties:\n
-ShowCommand.noChildrenMsg=There are no children for {0} "{1}".
-ShowCommand.InvalidArgMsg_PropertyName=Please specify a valid property name for the current context.
-
-# FindCommand
-FindCommand.examples= \
-\t find Vdb \n \
-\t find Model \n \
-\t find VdbDataRole \n \
-\t find Column
-FindCommand.usage = find <object-type>
-FindCommand.help = display the paths of workspace objects of a specified object type.
-FindCommand.helpTypesHeading = The valid object types are the following:
-FindCommand.Failure = Find command FAILED.
-FindCommand.MissingTypeArg = Please specify a valid object type for the search.
-FindCommand.NoObjectsFound = There are no "{0}" objects in the workspace.
-FindCommand.TypeHeader = Paths of the "{0}" objects found in the workspace:
 
 # CreateCommand
 CreateCommand.examples= \
@@ -167,7 +65,8 @@ CreateCommand.parameterNameRequired=Parameter name required
 # DeleteCommand
 DeleteCommand.examples= \
 \t delete myVdb \n \
-\t delete myVdb/myDataRole
+\t delete myVdb/myDataRole \n \
+\t rm /workspace/anotherVdb/modelA
 DeleteCommand.usage=delete <object_path>
 DeleteCommand.help=delete an object and all its children.
 DeleteCommand.InvalidArgMsg_ObjectPath=Please specify the path of the object to delete.
@@ -178,18 +77,24 @@ DeleteCommand.contextMustBeBelowCurrent=Cannot delete object "{0}" - it must be 
 DeleteCommand.cantDeleteReserved=Cannot delete object "{0}" - it is a reserved context.
 DeleteCommand.cannotRename_objectDoesNotExist=Cannot rename. The object [{0}] does not exist
 
-# RenameCommand
-RenameCommand.examples= \
-\t rename myVdb yourVdb \n \
-\t rename myVdb/myDataRole myVdb/yourDataRole
-RenameCommand.usage=rename <object_path> <new_name>
-RenameCommand.help=change the name and/or location of an object.
-RenameCommand.InvalidArgMsg_ObjectName=Please specify the name of the object to rename.
-RenameCommand.InvalidArgMsg_NewName=Please specify the new name of the object.
-RenameCommand.ObjectRenamed=Successfully renamed "{0}" to "{1}"
-RenameCommand.Failure=FAILED to rename the {0} object.
-RenameCommand.cannotRename_wouldCreateDuplicate=Cannot rename to "{0}" - an object with that name already exists.
-RenameCommand.cannotRename_objectDoesNotExist = Rename failed because object at path "{0}" does not exist.
+# DeployCommand
+DeployCommand.examples= \
+\t deploy \n \
+\t deploy myVdb
+DeployCommand.usage=deploy [vdb_name]
+DeployCommand.help=deploy a VDB to the default Teiid instance. Either make the current context a VDB and execute this command with no arguments or make the current context a VDB's parent and specify the VDB name as the only argument.
+DeployCommand.invalidName=The VDB name argument is invalid
+DeployCommand.InvalidCommand=The VDB to be deployed cannot be determined. Either make the current context a vdb with no arguments or change to vdb's parent and specify its name as the command's argument
+DeployCommand.exportFailure=The VDB failed to be exported
+DeployCommand.noTeiidDefined=No Teiid instance is currently defined
+DeployCommand.noTeiidConnection=A connection to the defined Teiid Instance cannot be established
+
+# ExitCommand
+ExitCommand.examples = \
+\t exit \n \
+\t quit
+ExitCommand.usage = exit 
+ExitCommand.help = exits VDB Builder.
 
 # ExportCommand
 ExportCommand.examples= \
@@ -207,12 +112,34 @@ ExportCommand.CannotExportProblemWithVdb=Problem with VDB. Could not export.
 ExportCommand.CannotExportProblemWithModel=Problem with model. Could not export.
 ExportCommand.CannotExportProblemWithSchema=Problem with schema. Could not export.
 
-# NavigateCommand
-NavigateCommand.examples= \
-\t navigate
-NavigateCommand.usage=navigate
-NavigateCommand.help=display detailed repository information for all objects contained within \
-	and under the current object. Used primarily for debug purposes and workspace exploration.
+# FindCommand
+FindCommand.examples= \
+\t find Vdb \n \
+\t find Model \n \
+\t find VdbDataRole \n \
+\t find Column
+FindCommand.usage = find <object-type>
+FindCommand.help = display the paths of workspace objects of a specified object type.
+FindCommand.helpTypesHeading = The valid object types are the following:
+FindCommand.Failure = Find command FAILED.
+FindCommand.MissingTypeArg = Please specify a valid object type for the search.
+FindCommand.InvalidType = "{0}" is not a valid search type.
+FindCommand.NoObjectsFound = There are no "{0}" objects in the workspace.
+FindCommand.TypeHeader = Paths of the "{0}" objects found in the workspace:
+
+# HelpCommand
+HelpCommand.examples = \
+\t help \n \
+\t help cd \n \
+\t man create
+HelpCommand.usage = help [command-name] 
+HelpCommand.help = display available commands or specific command information.
+
+# HomeCommand
+HomeCommand.examples= \
+\t home
+HomeCommand.usage=home
+HomeCommand.help=changes the current context to the workspace root.
 
 # ImportCommand
 ImportCommand.examples= \
@@ -230,6 +157,113 @@ ImportCommand.ImportFailedMsg=Failed to import from file {0}.
 ImportCommand.childTypeNotAllowed=The object type "{0}" is not allowed as a child of "{1}".
 ImportCommand.cannotImport_wouldCreateDuplicate=Cannot import "{0}" - a "{1}" with that name already exists.
 
+# ListCommand
+ListCommand.examples= \
+\t list \n \
+\t ls \n \
+\t ll
+ListCommand.usage=list
+ListCommand.help=display children of the current workspace context.
+
+# NavigateCommand
+NavigateCommand.examples= \
+\t navigate
+NavigateCommand.usage=navigate
+NavigateCommand.help=display detailed repository information for all objects contained within \
+	and under the current object. Used primarily for debug purposes and workspace exploration.
+
+# PlayCommand
+PlayCommand.examples= \
+\t play /home/vdbuilder_commands/build_my_vdb.txt
+PlayCommand.usage=play <file_name>
+PlayCommand.help=execute commands defined in a specified text file.
+PlayCommand.InvalidArgMsg_FileName=Please specify the command file name.
+PlayCommand.fileExecuted=All commands in file {0} have been executed.
+PlayCommand.Failure=Failed to execute all commands in file {0}
+PlayCommand.CommandFailure=Failed to execute the {0} command
+
+# RenameCommand
+RenameCommand.examples= \
+\t rename myVdb yourVdb \n \
+\t rename myVdb/myDataRole myVdb/yourDataRole \n \
+\t mv tableNew tableOld
+RenameCommand.usage=rename <object_path> <new_name>
+RenameCommand.help=change the name and/or location of an object.
+RenameCommand.InvalidArgMsg_ObjectName=Please specify the name of the object to rename.
+RenameCommand.InvalidArgMsg_NewName=Please specify the new name of the object.
+RenameCommand.ObjectRenamed=Successfully renamed "{0}" to "{1}"
+RenameCommand.Failure=FAILED to rename the {0} object.
+RenameCommand.cannotRename_wouldCreateDuplicate=Cannot rename to "{0}" - an object with that name already exists.
+RenameCommand.cannotRename_objectDoesNotExist = Rename failed because object at path "{0}" does not exist.
+
+# SetCommand
+SetCommand.examples= \
+\t set property selectable true \n \
+\t set property description "This is my description" \n \
+\t set property mappedRoleNames admin,user \n \
+\t set property mappedRoleNames "admin,guest user,tester" \n \
+\t set global RECORDING_FILE /my/output/folder/file.txt \n \
+\t set global --reset \n \
+\t set record on
+SetCommand.help=change workspace object values and system settings. \n\n \
+\tNote 1: A value containing one or more spaces should be surrounded by double quotes. \n \
+\tNote 2: Multi-valued properties should be comma-separated.
+SetCommand.usage= \
+set property <property_name> <property_value> [object_path] \n \
+\t set global [ (<property_name> <property_value>) | --reset ] \n \
+\t set record <on | off>
+SetCommand.InvalidArgMsg_SubCommand=Please specify a sub-command (property, global).
+SetCommand.InvalidArgMsg_PropertyName=Please specify a property name.
+SetCommand.InvalidArgMsg_PropertyValue=Please specify a property value.
+SetCommand.InvalidArgMsg_GlobalPropertyName=Please specify a global property name.
+SetCommand.InvalidGlobalProperty = Command failed. {0}
+SetCommand.PropertySet=Successfully set property {0}.
+SetCommand.GlobalPropertySet=Successfully set global property {0}.
+SetCommand.resetGlobalProperties = All global properties have been reset to their default values.
+SetCommand.InvalidSubCommand=Invalid sub-command, must be ("property", "global")
+SetCommand.Failure=FAILED to change the property.
+SetCommand.onOffArg_empty=The command arg is empty.
+SetCommand.onOffArg_invalid=The command arg must be 'on' or 'off'.
+SetCommand.setRecordingStateMsg=Recording set {0} at {1} - File: "{2}"
+SetCommand.recordingFileNotSet=The recording file global property has not been specified.
+SetCommand.recordingFileNotWriteable=Unable to write to the specified recording file: "{0}"
+
+# ShowCommand
+ShowCommand.examples= \
+\t show properties \n \
+\t show children \n \
+\t show summary \n \
+\t show property description \n \
+\t show status \n \
+\t show global
+ShowCommand.usage=show <summary | properties | children | property | global | status> [command_option]
+ShowCommand.help=display various workspace information and status.
+ShowCommand.InvalidArgMsg_SubCommand=Please specify a sub-command (properties, children, property, summary, status, global).
+ShowCommand.InvalidArgMsg_PropertyName=Please specify a valid property name for the current context.
+ShowCommand.InvalidSubCommand=Invalid sub-command, must be "properties", "children", "status", "global", "property", or "summary".
+ShowCommand.Failure=Command FAILED.
+ShowCommand.NoPropertiesMsg=There are no properties for {0} "{1}".\n
+ShowCommand.PropertiesHeader=Properties for {0} "{1}":\n
+ShowCommand.PropertyHeader=Property for {0} "{1}":\n
+ShowCommand.ChildrenHeader=Children for {0} "{1}":\n
+ShowCommand.CurrentRepo   = Current Repository : {0}, Workspace : {1}
+ShowCommand.NoCurrentTeiid = Current Teiid Instance  : None set
+ShowCommand.CurrentTeiid =Current Teiid Instance  : {0}
+ShowCommand.CurrentTeiidJdbc =Current Teiid Instance JDBC  : {0}
+ShowCommand.CurrentContext=Current Context : [{0}]
+ShowCommand.GlobalPropertiesHeader=Global shell properties:\n
+ShowCommand.noChildrenMsg=There are no children for {0} "{1}".
+ShowCommand.InvalidArgMsg_PropertyName=Please specify a valid property name for the current context.
+
+# Unset Command
+UnsetPropertyCommand.examples= \
+\t unset description
+UnsetPropertyCommand.usage=unset <property_name>
+UnsetPropertyCommand.help=remove a property value from the current object.
+UnsetPropertyCommand.error=Failed to unset the property.
+UnsetPropertyCommand.missingPropertyName = A property name is required when unsetting a property.
+UnsetPropertyCommand.propertyUnset=Successfully unset property "{0}".
+
 # UseTeiidCommand
 UseTeiidCommand.examples= \
 \t useTeiid testTeiid \n \
@@ -241,19 +275,11 @@ UseTeiidCommand.noInstancesDefined=No teiid instances have been defined in the r
 UseTeiidCommand.teiidSetOk=Teiid '{0}' set as current instance with connection status: {1}
 UseTeiidCommand.noTeiidWithName=No teiid instance found that matches the name or id: {0}
 
-# DeployCommand
-DeployCommand.examples= \
-\t deploy \n \
-\t deploy myVdb
-DeployCommand.usage=deploy [vdb_name]
-DeployCommand.help=deploy a VDB to the default Teiid instance. Either make the current context a VDB and execute this command with no arguments or make the current context a VDB's parent and specify the VDB name as the only argument.
-DeployCommand.invalidName=The VDB name argument is invalid
-DeployCommand.InvalidCommand=The VDB to be deployed cannot be determined. Either make the current context a vdb with no arguments or change to vdb's parent and specify its name as the command's argument
-DeployCommand.exportFailure=The VDB failed to be exported
-DeployCommand.noTeiidDefined=No Teiid instance is currently defined
-DeployCommand.noTeiidConnection=A connection to the defined Teiid Instance cannot be established
-
 # This message have SHELL enum definitions in Messages
+SHELL.INVALID_GLOBAL_PROPERTY_NAME = "{0}" is not a valid global property name.
+SHELL.INVALID_BOOLEAN_GLOBAL_PROPERTY_VALUE = "{0}" is not a valid value for global property "{1}." Enter either a "true" or "false" as the value.
+SHELL.PROMPT = [{0}]
+SHELL.PROMPT_WITH_TYPE = [{0} ({1})]
 SHELL.CHILD_NAME_HEADER = NAME
 SHELL.CHILD_TYPE_HEADER = TYPE
 SHELL.PROPERTY_NAME_HEADER = NAME
@@ -270,7 +296,7 @@ SHELL.LOCAL_REPOSITORY_TIMEOUT_ERROR=Error: Timeout awaiting initialization of l
 SHELL.COMMAND_NOT_FOUND=Command not found.  Try "help" for a list of available commands.
 SHELL.GOOD_BYE=Good bye!
 SHELL.Help_COMMAND_LIST_MSG=VDB Builder Shell supports the following commands at this workspace context:\n
-SHELL.Help_INVALID_COMMAND=No help available:  not a valid command.
+SHELL.Help_INVALID_COMMAND=No help available: "{0}" is not a valid command.
 SHELL.Help_GET_HELP_1=Enter "help" to get a list of available commands or "help <command-name>" for specific information about one command.
 SHELL.Help_GET_HELP_2=To execute a specific command, try "<command-name> <args>". Also try entering a tab key for command argument completion help.\n
 SHELL.EXITING=Exiting VDB Builder shell due to an error.
@@ -292,6 +318,8 @@ SHELL.WelcomeMessage=\
 **********************************************************************\n    \
 Welcome to VDB Builder Shell\n\
 **********************************************************************\n
+SHELL.HelpAliasesHeading = ALIASES
+SHELL.HelpNoAliases = None
 SHELL.HelpDescriptionHeading = DESCRIPTION
 SHELL.HelpDescription = \t{0} - {1}
 SHELL.HelpExamplesHeading = EXAMPLES

--- a/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/repository/KomodoObject.java
@@ -239,6 +239,16 @@ public interface KomodoObject extends KNode {
                              final String name ) throws KException;
 
     /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
+     * @return the unfiltered property descriptors from the primary type descriptor and the mixin descriptors (never <code>null</code> but
+     *         can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    PropertyDescriptor[] getRawPropertyDescriptors( final UnitOfWork transaction ) throws KException;
+
+    /**
      * Subclasses may implement {@link #getPropertyNames(UnitOfWork)} in such a way that it does not represent the actual set of
      * properties. This method obtains the actual, physical set of property names.
      *
@@ -337,6 +347,18 @@ public interface KomodoObject extends KNode {
      */
     boolean hasProperty( final UnitOfWork transaction,
                          final String name ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED}))
+     * @param name
+     *        the name the property, filtered or unfiltered, whose existence is being checked (cannot be empty)
+     * @return <code>true</code> if a property with the supplied name exists
+     * @throws KException
+     *         if an error occurs
+     */
+    boolean hasRawProperty( final UnitOfWork transaction,
+                            final String name ) throws KException;
 
     /**
      * The implementing class is responsible for enforcing this restriction.

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/RelationalModelTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/RelationalModelTest.java
@@ -7,11 +7,79 @@
  */
 package org.komodo.relational;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.komodo.relational.model.Model;
+import org.komodo.relational.model.Table;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.test.utils.AbstractLocalRepositoryTest;
+import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
-@SuppressWarnings( { "javadoc" } )
+@SuppressWarnings( { "javadoc", "nls" } )
 public class RelationalModelTest extends AbstractLocalRepositoryTest {
 
-    // nothing to do
+    protected static final String VDB_PATH = "/vdb/path/vdb.vdb";
+
+    protected Model createModel() throws Exception {
+        return createModel( this.name.getMethodName() + "-VDB", VDB_PATH, this.name.getMethodName() + "-Model" );
+    }
+
+    protected Model createModel( final String vdbName,
+                                 final String vdbPath,
+                                 final String modelName ) throws Exception {
+        final WorkspaceManager mgr = WorkspaceManager.getInstance( _repo );
+        final Vdb vdb = mgr.createVdb( this.uow, null, vdbName, vdbPath );
+        final Model model = vdb.addModel( this.uow, modelName );
+
+        assertThat( model.getPrimaryType( this.uow ).getName(), is( VdbLexicon.Vdb.DECLARATIVE_MODEL ) );
+        assertThat( model.getName( this.uow ), is( modelName ) );
+        return model;
+    }
+
+    protected Table createTable() throws Exception {
+        return createTable( getDefaultVdbName(), VDB_PATH, getDefaultModelName(), getDefaultTableName() );
+    }
+
+    protected Table createTable( final String vdbName,
+                                 final String vdbPath,
+                                 final String modelName,
+                                 final String tableName ) throws Exception {
+        final WorkspaceManager mgr = WorkspaceManager.getInstance( _repo );
+        final Vdb vdb = mgr.createVdb( this.uow, null, vdbName, vdbPath );
+        final Model model = vdb.addModel( this.uow, modelName );
+        return model.addTable( this.uow, tableName );
+    }
+
+    protected Vdb createVdb() throws Exception {
+        return createVdb( getDefaultVdbName(), VDB_PATH );
+    }
+
+    protected Vdb createVdb( final String vdbName ) throws Exception {
+        return createVdb( vdbName, VDB_PATH );
+    }
+
+    protected Vdb createVdb( final String vdbName,
+                             final String vdbPath ) throws Exception {
+        final WorkspaceManager mgr = WorkspaceManager.getInstance( _repo );
+        final Vdb vdb = mgr.createVdb( this.uow, null, vdbName, vdbPath );
+
+        assertThat( vdb.getPrimaryType( this.uow ).getName(), is( VdbLexicon.Vdb.VIRTUAL_DATABASE ) );
+        assertThat( vdb.getName( this.uow ), is( vdbName ) );
+        assertThat( vdb.getOriginalFilePath( this.uow ), is( vdbPath ) );
+        return vdb;
+    }
+
+    protected String getDefaultModelName() {
+        return ( this.name.getMethodName() + "-Model" );
+    }
+
+    protected String getDefaultTableName() {
+        return ( this.name.getMethodName() + "-Table" );
+    }
+
+    protected String getDefaultVdbName() {
+        return ( this.name.getMethodName() + "-Vdb" );
+    }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AbstractProcedureImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AbstractProcedureImplTest.java
@@ -18,13 +18,11 @@ import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.model.AbstractProcedure;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.Parameter;
 import org.komodo.relational.model.SchemaElement.SchemaElementType;
 import org.komodo.relational.model.StatementOption;
-import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.PropertyDescriptor;
@@ -38,9 +36,8 @@ public final class AbstractProcedureImplTest extends RelationalModelTest {
 
     @Before
     public void init() throws Exception {
-        final Vdb vdb = RelationalModelFactory.createVdb( this.uow, _repo, null, "vdb", "externalFilePath" );
-        final Model model = RelationalModelFactory.createModel( this.uow, _repo, vdb, "model" );
-        this.procedure = RelationalModelFactory.createVirtualProcedure( this.uow, _repo, model, "procedure" );
+        final Model model = createModel();
+        this.procedure = model.addVirtualProcedure( this.uow, "procedure" );
         commit();
     }
 

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AccessPatternImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/AccessPatternImplTest.java
@@ -9,20 +9,19 @@ package org.komodo.relational.model.internal;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.model.AccessPattern;
-import org.komodo.relational.model.Model;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
@@ -36,8 +35,8 @@ public final class AccessPatternImplTest extends RelationalModelTest {
 
     @Before
     public void init() throws Exception {
-        this.table = RelationalModelFactory.createTable( this.uow, _repo, mock( Model.class ), "table" );
-        this.accessPattern = RelationalModelFactory.createAccessPattern( this.uow, _repo, this.table, NAME );
+        this.table = createTable();
+        this.accessPattern = this.table.addAccessPattern( this.uow, NAME );
         commit();
     }
 
@@ -112,6 +111,27 @@ public final class AccessPatternImplTest extends RelationalModelTest {
                 assertThat( filter.rejectProperty( name ), is( false ) );
             }
         }
+    }
+
+    /*
+     * ********************************************************************
+     * *****                  Resolver Tests                          *****
+     * ********************************************************************
+     */
+
+    @Test
+    public void shouldCreateUsingResolver() throws Exception {
+        final String name = "blah";
+        final KomodoObject kobject = AccessPatternImpl.RESOLVER.create( this.uow, _repo, this.table, name, null );
+        assertThat( kobject, is( notNullValue() ) );
+        assertThat( kobject, is( instanceOf( AccessPattern.class ) ) );
+        assertThat( kobject.getName( this.uow ), is( name ) );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailCreateUsingResolverWithInvalidParent() throws Exception {
+        final KomodoObject bogusParent = _repo.add( this.uow, null, "bogus", null );
+        AccessPatternImpl.RESOLVER.create( this.uow, _repo, bogusParent, "blah", null );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/ColumnImplTest.java
@@ -14,7 +14,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,11 +21,9 @@ import org.komodo.relational.RelationalConstants;
 import org.komodo.relational.RelationalConstants.Nullable;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.Column.Searchable;
-import org.komodo.relational.model.Model;
 import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.model.Table;
 import org.komodo.spi.KException;
@@ -47,8 +44,8 @@ public final class ColumnImplTest extends RelationalModelTest {
 
     @Before
     public void init() throws Exception {
-        this.table = RelationalModelFactory.createTable( this.uow, _repo, mock( Model.class ), "table" );
-        this.column = RelationalModelFactory.createColumn( this.uow, _repo, this.table, NAME );
+        this.table = createTable();
+        this.column = this.table.addColumn( this.uow, NAME );
         commit();
     }
 
@@ -707,6 +704,27 @@ public final class ColumnImplTest extends RelationalModelTest {
         final StatementOption statementOption = this.column.getStatementOptions( this.uow )[0];
         assertThat( statementOption.getName( this.uow ), is( option ) );
         assertThat( statementOption.getValue( this.uow ), is( ( Object )value ) );
+    }
+
+    /*
+     * ********************************************************************
+     * *****                  Resolver Tests                          *****
+     * ********************************************************************
+     */
+
+    @Test
+    public void shouldCreateUsingResolver() throws Exception {
+        final String name = "blah";
+        final KomodoObject kobject = ColumnImpl.RESOLVER.create( this.uow, _repo, this.table, name, null );
+        assertThat( kobject, is( notNullValue() ) );
+        assertThat( kobject, is( instanceOf( Column.class ) ) );
+        assertThat( kobject.getName( this.uow ), is( name ) );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailCreateUsingResolverWithInvalidParent() throws Exception {
+        final KomodoObject bogusParent = _repo.add( this.uow, null, "bogus", null );
+        ColumnImpl.RESOLVER.create( this.uow, _repo, bogusParent, "blah", null );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/FunctionImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/FunctionImplTest.java
@@ -13,13 +13,11 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.model.Function;
 import org.komodo.relational.model.Function.Determinism;
 import org.komodo.relational.model.Model;
@@ -35,7 +33,8 @@ public final class FunctionImplTest extends RelationalModelTest {
 
     @Before
     public void init() throws Exception {
-        this.function = RelationalModelFactory.createPushdownFunction( this.uow, _repo, mock( Model.class ), NAME );
+        final Model model = createModel();
+        this.function = model.addPushdownFunction( this.uow, NAME );
         commit();
     }
 

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PrimaryKeyImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PrimaryKeyImplTest.java
@@ -9,20 +9,19 @@ package org.komodo.relational.model.internal;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
-import org.komodo.relational.model.Model;
 import org.komodo.relational.model.PrimaryKey;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
@@ -36,8 +35,8 @@ public final class PrimaryKeyImplTest extends RelationalModelTest {
 
     @Before
     public void init() throws Exception {
-        this.table = RelationalModelFactory.createTable( this.uow, _repo, mock( Model.class ), "table" );
-        this.primaryKey = RelationalModelFactory.createPrimaryKey( this.uow, _repo, this.table, NAME );
+        this.table = createTable();
+        this.primaryKey = this.table.setPrimaryKey( this.uow, NAME );
         commit();
     }
 
@@ -108,6 +107,27 @@ public final class PrimaryKeyImplTest extends RelationalModelTest {
                 assertThat( filter.rejectProperty( name ), is( false ) );
             }
         }
+    }
+
+    /*
+     * ********************************************************************
+     * *****                  Resolver Tests                          *****
+     * ********************************************************************
+     */
+
+    @Test
+    public void shouldCreateUsingResolver() throws Exception {
+        final String name = "blah";
+        final KomodoObject kobject = PrimaryKeyImpl.RESOLVER.create( this.uow, _repo, this.table, name, null );
+        assertThat( kobject, is( notNullValue() ) );
+        assertThat( kobject, is( instanceOf( PrimaryKey.class ) ) );
+        assertThat( kobject.getName( this.uow ), is( name ) );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailCreateUsingResolverWithInvalidParent() throws Exception {
+        final KomodoObject bogusParent = _repo.add( this.uow, null, "bogus", null );
+        PrimaryKeyImpl.RESOLVER.create( this.uow, _repo, bogusParent, "blah", null );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/RelationalObjectImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/RelationalObjectImplTest.java
@@ -12,9 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
-import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.Descriptor;
 import org.komodo.spi.repository.KomodoObject;
@@ -42,8 +40,7 @@ public final class RelationalObjectImplTest extends RelationalModelTest {
 
     @Before
     public void init() throws Exception {
-        final Vdb vdb = RelationalModelFactory.createVdb( this.uow, _repo, null, "vdb", "/my/vdb" );
-        final KomodoObject model = RelationalModelFactory.createModel( this.uow, _repo, vdb, "robject" );
+        final KomodoObject model = createModel();
         this.robject = new RelationalTestObject( this.uow, model.getRepository(), model.getAbsolutePath() );
         commit();
     }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/SchemaImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/SchemaImplTest.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.model.internal;
 
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -138,6 +139,21 @@ public class SchemaImplTest extends RelationalModelTest {
                 assertThat( filter.rejectProperty( name ), is( false ) );
             }
         }
+    }
+
+    /*
+     * ********************************************************************
+     * *****                  Resolver Tests                          *****
+     * ********************************************************************
+     */
+
+    @Test
+    public void shouldCreateUsingResolver() throws Exception {
+        final String name = "blah";
+        final KomodoObject kobject = SchemaImpl.RESOLVER.create( this.uow, _repo, null, name, null );
+        assertThat( kobject, is( notNullValue() ) );
+        assertThat( kobject, is( instanceOf( Schema.class ) ) );
+        assertThat( kobject.getName( this.uow ), is( name ) );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableConstraintTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/TableConstraintTest.java
@@ -16,7 +16,6 @@ import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
 import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.model.Column;
-import org.komodo.relational.model.Model;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.spi.KException;
@@ -32,8 +31,8 @@ public final class TableConstraintTest extends RelationalModelTest {
 
     @Before
     public void init() throws Exception {
-        this.table = RelationalModelFactory.createTable( this.uow, _repo, mock( Model.class ), "table" );
-        this.constraint = RelationalModelFactory.createAccessPattern( this.uow, _repo, this.table, NAME );
+        this.table = createTable();
+        this.constraint = this.table.addAccessPattern( this.uow, NAME );
         commit();
     }
 

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UniqueConstraintImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/UniqueConstraintImplTest.java
@@ -9,20 +9,19 @@ package org.komodo.relational.model.internal;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
-import org.komodo.relational.model.Model;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.relational.model.UniqueConstraint;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 
@@ -36,8 +35,8 @@ public final class UniqueConstraintImplTest extends RelationalModelTest {
 
     @Before
     public void init() throws Exception {
-        this.table = RelationalModelFactory.createTable( this.uow, _repo, mock( Model.class ), "table" );
-        this.uniqueConstraint = RelationalModelFactory.createUniqueConstraint( this.uow, _repo, this.table, NAME );
+        this.table = createTable();
+        this.uniqueConstraint = this.table.addUniqueConstraint( this.uow, NAME );
         commit();
     }
 
@@ -103,6 +102,27 @@ public final class UniqueConstraintImplTest extends RelationalModelTest {
                 assertThat( filter.rejectProperty( name ), is( false ) );
             }
         }
+    }
+
+    /*
+     * ********************************************************************
+     * *****                  Resolver Tests                          *****
+     * ********************************************************************
+     */
+
+    @Test
+    public void shouldCreateUsingResolver() throws Exception {
+        final String name = "blah";
+        final KomodoObject kobject = UniqueConstraintImpl.RESOLVER.create( this.uow, _repo, this.table, name, null );
+        assertThat( kobject, is( notNullValue() ) );
+        assertThat( kobject, is( instanceOf( UniqueConstraint.class ) ) );
+        assertThat( kobject.getName( this.uow ), is( name ) );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailCreateUsingResolverWithInvalidParent() throws Exception {
+        final KomodoObject bogusParent = _repo.add( this.uow, null, "bogus", null );
+        UniqueConstraintImpl.RESOLVER.create( this.uow, _repo, bogusParent, "blah", null );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/DataRoleImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/DataRoleImplTest.java
@@ -19,13 +19,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.vdb.DataRole;
 import org.komodo.relational.vdb.Permission;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
@@ -33,12 +33,11 @@ import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 public final class DataRoleImplTest extends RelationalModelTest {
 
     private DataRole dataRole;
-    private Vdb vdb;
 
     @Before
     public void init() throws Exception {
-        this.vdb = RelationalModelFactory.createVdb( this.uow, _repo, null, "vdb", "/Users/sledge/hammer/MyVdb.vdb" );
-        this.dataRole = RelationalModelFactory.createDataRole( this.uow, _repo, this.vdb, "dataRole" );
+        final Vdb vdb = createVdb();
+        this.dataRole = vdb.addDataRole( this.uow, "dataRole" );
         commit();
     }
 
@@ -46,7 +45,7 @@ public final class DataRoleImplTest extends RelationalModelTest {
     public void shouldFailConstructionIfNotDataRole() {
         if ( RelationalObjectImpl.VALIDATE_INITIAL_STATE ) {
             try {
-                new DataRoleImpl( this.uow, _repo, this.vdb.getAbsolutePath() );
+                new DataRoleImpl( this.uow, _repo, this.dataRole.getParent( this.uow ).getAbsolutePath() );
                 fail();
             } catch ( final KException e ) {
                 // expected
@@ -231,6 +230,31 @@ public final class DataRoleImplTest extends RelationalModelTest {
         final boolean newValue = !DataRole.DEFAULT_GRANT_ALL;
         this.dataRole.setGrantAll( this.uow, newValue );
         assertThat( this.dataRole.isGrantAll( this.uow ), is( newValue ) );
+    }
+
+    /*
+     * ********************************************************************
+     * *****                  Resolver Tests                          *****
+     * ********************************************************************
+     */
+
+    @Test
+    public void shouldCreateUsingResolver() throws Exception {
+        final String name = "blah";
+        final KomodoObject kobject = DataRoleImpl.RESOLVER.create( this.uow,
+                                                                   _repo,
+                                                                   this.dataRole.getParent( this.uow ),
+                                                                   name,
+                                                                   null );
+        assertThat( kobject, is( notNullValue() ) );
+        assertThat( kobject, is( instanceOf( DataRole.class ) ) );
+        assertThat( kobject.getName( this.uow ), is( name ) );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailCreateUsingResolverWithInvalidParent() throws Exception {
+        final KomodoObject bogusParent = _repo.add( this.uow, null, "bogus", null );
+        DataRoleImpl.RESOLVER.create( this.uow, _repo, bogusParent, "blah", null );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/ModelSourceImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/ModelSourceImplTest.java
@@ -9,6 +9,7 @@ package org.komodo.relational.vdb.internal;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -16,13 +17,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
-import org.komodo.relational.internal.RelationalModelFactory;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.vdb.ModelSource;
-import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
@@ -33,9 +33,8 @@ public final class ModelSourceImplTest extends RelationalModelTest {
 
     @Before
     public void init() throws Exception {
-        final Vdb vdb = RelationalModelFactory.createVdb( this.uow, _repo, null, "vdb", "/Users/sledge/hammer/MyVdb.vdb" );
-        final Model model = RelationalModelFactory.createModel( this.uow, _repo, vdb, "model" );
-        this.source = RelationalModelFactory.createModelSource( this.uow, _repo, model, "source" );
+        final Model model = createModel();
+        this.source = model.addSource( this.uow, "source" );
         commit();
     }
 
@@ -145,6 +144,31 @@ public final class ModelSourceImplTest extends RelationalModelTest {
         final String name = "translatorName";
         this.source.setTranslatorName( this.uow, name );
         assertThat( this.source.getTranslatorName( this.uow ), is( name ) );
+    }
+
+    /*
+     * ********************************************************************
+     * *****                  Resolver Tests                          *****
+     * ********************************************************************
+     */
+
+    @Test
+    public void shouldCreateUsingResolver() throws Exception {
+        final String name = "blah";
+        final KomodoObject kobject = ModelSourceImpl.RESOLVER.create( this.uow,
+                                                                      _repo,
+                                                                      this.source.getParent( this.uow ),
+                                                                      name,
+                                                                      null );
+        assertThat( kobject, is( notNullValue() ) );
+        assertThat( kobject, is( instanceOf( ModelSource.class ) ) );
+        assertThat( kobject.getName( this.uow ), is( name ) );
+    }
+
+    @Test( expected = KException.class )
+    public void shouldFailCreateUsingResolverWithInvalidParent() throws Exception {
+        final KomodoObject bogusParent = _repo.add( this.uow, null, "bogus", null );
+        ModelSourceImpl.RESOLVER.create( this.uow, _repo, bogusParent, "blah", null );
     }
 
 }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/VdbImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/vdb/internal/VdbImplTest.java
@@ -22,7 +22,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
-import org.komodo.relational.internal.RelationalModelFactory;
+import org.komodo.relational.RelationalProperties;
+import org.komodo.relational.RelationalProperty;
 import org.komodo.relational.internal.RelationalObjectImpl;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.vdb.DataRole;
@@ -33,6 +34,7 @@ import org.komodo.relational.vdb.Vdb.VdbManifest;
 import org.komodo.relational.vdb.VdbImport;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.PropertyDescriptor;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
@@ -41,14 +43,13 @@ import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 public final class VdbImplTest extends RelationalModelTest {
 
     private static final String PATH = "/Users/sledge/hammer/MyVdb.vdb";
+    private static final String VDB_NAME = "vdb";
 
     protected Vdb vdb;
-    private String vdbName;
 
     @Before
     public void init() throws Exception {
-        this.vdbName = "vdb";
-        this.vdb = RelationalModelFactory.createVdb( this.uow, _repo, null, this.vdbName, PATH );
+        this.vdb = createVdb( VDB_NAME, PATH );
     }
 
     @Test
@@ -226,7 +227,7 @@ public final class VdbImplTest extends RelationalModelTest {
 
     @Test
     public void shouldHaveCorrectName() throws Exception {
-        assertThat( this.vdb.getName( this.uow ), is( this.vdbName ) );
+        assertThat( this.vdb.getName( this.uow ), is( VDB_NAME ) );
     }
 
     @Test
@@ -593,6 +594,25 @@ public final class VdbImplTest extends RelationalModelTest {
         final int newValue = ( Vdb.DEFAULT_VERSION + 10 );
         this.vdb.setVersion( this.uow, newValue );
         assertThat( this.vdb.getVersion( this.uow ), is( newValue ) );
+    }
+
+    /*
+     * ********************************************************************
+     * *****                  Resolver Tests                          *****
+     * ********************************************************************
+     */
+
+    @Test
+    public void shouldCreateUsingResolver() throws Exception {
+        final String name = "blah";
+
+        final RelationalProperties props = new RelationalProperties();
+        props.add( new RelationalProperty( VdbLexicon.Vdb.ORIGINAL_FILE, "/my/path/vdb.vdb" ) );
+
+        final KomodoObject kobject = VdbImpl.RESOLVER.create( this.uow, _repo, null, name, props );
+        assertThat( kobject, is( notNullValue() ) );
+        assertThat( kobject, is( instanceOf( Vdb.class ) ) );
+        assertThat( kobject.getName( this.uow ), is( name ) );
     }
 
 }

--- a/tests/org.komodo.shell.test/resources/cdCommand_aliases.txt
+++ b/tests/org.komodo.shell.test/resources/cdCommand_aliases.txt
@@ -1,0 +1,7 @@
+#create a vdb and a model, then cd into MyVdb with absolute path
+edit /workspace
+create vdb MyVdb
+goto MyVdb
+create model MyModel
+edit MyModel
+goto /workspace/MyVdb

--- a/tests/org.komodo.shell.test/resources/createCommand7.txt
+++ b/tests/org.komodo.shell.test/resources/createCommand7.txt
@@ -1,41 +1,42 @@
 # -----------------------------------------------
 # Create all relational objects 
 # -----------------------------------------------
-#create Schema MySchema /workspace
+create Schema MySchema /workspace
 #
-create Model MyModel /workspace
+create Vdb MyVdb /workspace
+create Model MyModel /workspace/MyVdb
 #
-create Table MyTable1 /workspace/MyModel
-create Table MyTable2 /workspace/MyModel
+create Table MyTable1 /workspace/MyVdb/MyModel
+create Table MyTable2 /workspace/MyVdb/MyModel
 #
-create View MyView /workspace/MyModel
+create View MyView /workspace/MyVdb/MyModel
 #
-create UserDefinedFunction MyUdf /workspace/MyModel
+create UserDefinedFunction MyUdf /workspace/MyVdb/MyModel
 #
-create PushdownFunction MyPushdownFunc /workspace/MyModel
+create PushdownFunction MyPushdownFunc /workspace/MyVdb/MyModel
 #
-create StoredProcedure MyStoredProc /workspace/MyModel
+create StoredProcedure MyStoredProc /workspace/MyVdb/MyModel
 #
-create VirtualProcedure MyVirtualProc /workspace/MyModel
+create VirtualProcedure MyVirtualProc /workspace/MyVdb/MyModel
 #
-create Column MyCol1 /workspace/MyModel/MyTable1
-create Column MyCol2 /workspace/MyModel/MyTable1
-create Column MyCol3 /workspace/MyModel/MyTable1
+create Column MyCol1 /workspace/MyVdb/MyModel/MyTable1
+create Column MyCol2 /workspace/MyVdb/MyModel/MyTable1
+create Column MyCol3 /workspace/MyVdb/MyModel/MyTable1
 #
-create PrimaryKey MyPk /workspace/MyModel/MyTable1
+create PrimaryKey MyPk /workspace/MyVdb/MyModel/MyTable1
 #
-create AccessPattern MyAp /workspace/MyModel/MyTable1
+create AccessPattern MyAp /workspace/MyVdb/MyModel/MyTable1
 #
-create UniqueConstraint MyUc /workspace/MyModel/MyTable1
+create UniqueConstraint MyUc /workspace/MyVdb/MyModel/MyTable1
 #
-create ForeignKey MyFk /workspace/MyModel/MyTable1 /workspace/MyModel/MyTable2
+create ForeignKey MyFk /workspace/MyVdb/MyModel/MyTable1 /workspace/MyVdb/MyModel/MyTable2
 #
-#create DataTypeResultSet MyDataTypeResultSet /workspace/MyModel/MyStoredProc
+#create DataTypeResultSet MyDataTypeResultSet /workspace/MyVdb/MyModel/MyStoredProc
 #
-#create TabularResultSet MyTabResultSet /workspace/MyModel/MyPushdownFunc
+#create TabularResultSet MyTabResultSet /workspace/MyVdb/MyModel/MyPushdownFunc
 #
-#create ResultSetColumn MyResultSetCol /workspace/MyModel/MyVirtualProc/resultSet
+#create ResultSetColumn MyResultSetCol /workspace/MyVdb/MyModel/MyVirtualProc/resultSet
 #
-create Parameter MyParam /workspace/MyModel/MyVirtualProc
+create Parameter MyParam /workspace/MyVdb/MyModel/MyVirtualProc
 #
-create Index MyIndx /workspace/MyModel/MyTable2
+create Index MyIndx /workspace/MyVdb/MyModel/MyTable2

--- a/tests/org.komodo.shell.test/resources/deleteCommand6.txt
+++ b/tests/org.komodo.shell.test/resources/deleteCommand6.txt
@@ -1,0 +1,8 @@
+# tests absolute path deletion to midpoint object
+create vdb vdb_test_1
+cd vdb_test_1
+create model model_1
+cd model_1
+create table table_1
+cd /workspace
+rm /workspace/vdb_test_1/model_1

--- a/tests/org.komodo.shell.test/resources/listCommand4.txt
+++ b/tests/org.komodo.shell.test/resources/listCommand4.txt
@@ -1,0 +1,11 @@
+# create three models within workspace.
+create vdb MyVdb
+# cd into the vdb
+cd MyVdb
+create model Model1
+# cd into the model
+cd Model1
+create table Table1
+#Listing of table
+ls
+

--- a/tests/org.komodo.shell.test/resources/listCommand5.txt
+++ b/tests/org.komodo.shell.test/resources/listCommand5.txt
@@ -1,0 +1,11 @@
+# create three models within workspace.
+create vdb MyVdb
+# cd into the vdb
+cd MyVdb
+create model Model1
+# cd into the model
+cd Model1
+create table Table1
+#Listing of table
+ll
+

--- a/tests/org.komodo.shell.test/resources/setCommand1.txt
+++ b/tests/org.komodo.shell.test/resources/setCommand1.txt
@@ -1,6 +1,7 @@
 # Tests the Set Property command without optional context path
-create Model MyModel
-create Table MyTable ./MyModel
-cd MyModel/MyTable
+create Vdb MyVdb
+create Model MyModel ./MyVdb
+create Table MyTable ./MyVdb/MyModel
+cd MyVdb/MyModel/MyTable
 #
 set Property ANNOTATION mydescription

--- a/tests/org.komodo.shell.test/resources/setCommand2.txt
+++ b/tests/org.komodo.shell.test/resources/setCommand2.txt
@@ -1,5 +1,6 @@
 # Tests the Set Property command using a relative context path
-create Model MyModel
-create Table MyTable ./MyModel
+create Vdb MyVdb
+create Model MyModel ./MyVdb
+create Table MyTable ./MyVdb/MyModel
 #
-set Property ANNOTATION mydescription ./MyModel/MyTable
+set Property ANNOTATION mydescription ./MyVdb/MyModel/MyTable

--- a/tests/org.komodo.shell.test/resources/setCommand3.txt
+++ b/tests/org.komodo.shell.test/resources/setCommand3.txt
@@ -1,5 +1,6 @@
 # Tests the Set Property command using absolute context path
-create Model MyModel
-create Table MyTable ./MyModel
+create Vdb MyVdb
+create Model MyModel ./MyVdb
+create Table MyTable ./MyVdb/MyModel
 #
-set Property CARDINALITY 5 /workspace/MyModel/MyTable
+set Property CARDINALITY 5 /workspace/MyVdb/MyModel/MyTable

--- a/tests/org.komodo.shell.test/resources/setCommandGlobalProps.txt
+++ b/tests/org.komodo.shell.test/resources/setCommandGlobalProps.txt
@@ -1,0 +1,7 @@
+set global EXPORT_DEFAULT_DIR /export/directory
+set global IMPORT_DEFAULT_DIR /import/directory
+set global RECORDING_FILE /recording/file.txt
+set global SHOW_FULL_PATH_IN_PROMPT true
+set global SHOW_HIDDEN_PROPERTIES true
+set global SHOW_PROP_NAME_PREFIX true
+set global SHOW_TYPE_IN_PROMPT false

--- a/tests/org.komodo.shell.test/resources/setCommandResetGlobalProps.txt
+++ b/tests/org.komodo.shell.test/resources/setCommandResetGlobalProps.txt
@@ -1,0 +1,2 @@
+play ./resources/setCommandGlobalProps.txt
+set global --reset

--- a/tests/org.komodo.shell.test/resources/unsetCommand1.txt
+++ b/tests/org.komodo.shell.test/resources/unsetCommand1.txt
@@ -1,5 +1,6 @@
 # Tests the UnsetPropertyCommand for single value property
-create Model MyModel
-cd MyModel
+create Vdb MyVdb
+create Model MyModel ./MyVdb
+cd MyVdb/MyModel
 set property vdb:description "new description"
 unset vdb:description

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/CdCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/CdCommandTest.java
@@ -38,7 +38,9 @@ public class CdCommandTest extends AbstractCommandTest {
 	private static final String CD_COMMAND_ABS3 = "cdCommand_Absolute3.txt"; //$NON-NLS-1$
 	private static final String CD_COMMAND_ABS4 = "cdCommand_Absolute4.txt"; //$NON-NLS-1$
 
-	/**
+    private static final String ALIAS_TEST = "cdCommand_aliases.txt"; //$NON-NLS-1$
+
+    /**
 	 * Test for CdCommand
 	 */
 	public CdCommandTest( ) {
@@ -138,12 +140,22 @@ public class CdCommandTest extends AbstractCommandTest {
 
     @Test
     public void testCdAbsolute4() throws Exception {
-    	setup(CD_COMMAND_ABS4, CdCommand.class);
+        setup(CD_COMMAND_ABS4, CdCommand.class);
 
-    	execute();
+        execute();
 
-    	// Check WorkspaceContext
-    	assertEquals("/workspace/MyVdb/MyModel/Table1", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+        // Check WorkspaceContext
+        assertEquals("/workspace/MyVdb/MyModel/Table1", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testAliases() throws Exception {
+        setup(ALIAS_TEST, CdCommand.class);
+
+        execute();
+
+        // Check WorkspaceContext
+        assertEquals("/workspace/MyVdb", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/CreateCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/CreateCommandTest.java
@@ -2,7 +2,6 @@ package org.komodo.shell;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
 import org.junit.Test;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.vdb.Vdb;
@@ -29,7 +28,7 @@ public class CreateCommandTest extends AbstractCommandTest {
 	private static final String CREATE_COMMAND_6 = "createCommand6.txt"; //$NON-NLS-1$
 	private static final String CREATE_COMMAND_7 = "createCommand7.txt"; //$NON-NLS-1$
 	private static final String CREATE_COMMAND_8 = "createCommand8.txt"; //$NON-NLS-1$
-	
+
 	/**
 	 * Test for CreateCommand
 	 */
@@ -89,31 +88,31 @@ public class CreateCommandTest extends AbstractCommandTest {
     	// verify 2 access patterns
     	assertEquals(2, table.getAccessPatterns(trans).length);
     }
-    
+
     @Test
     public void testCreatesFromWorkspace() throws Exception {
     	setup(CREATE_COMMAND_5, CreateCommand.class);
 
     	execute();
-    	
+
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
-    	
+
     	WorkspaceContext tableContext = ContextUtils.getContextForPath(wsStatus, "/workspace/vdb_test_1/model_1/table_1"); //$NON-NLS-1$
 
     	KomodoObject ko = tableContext.getKomodoObj();
     	UnitOfWork trans = wsStatus.getTransaction();
     	// Verify the komodo class is a Table and is TABLE type
     	assertEquals(KomodoType.TABLE.name(), ko.getTypeIdentifier(trans).name());
-    	
+
     	Table table = (Table)resolveType(trans, ko, Table.class);
-    	
+
     	// verify 3 columns
     	assertEquals(3, table.getColumns(trans).length);
-    	
+
     	// verify PK
     	assertNotNull(table.getPrimaryKey(trans));
     	assertEquals("pk_1", table.getPrimaryKey(trans).getName(trans)); //$NON-NLS-1$
-    	
+
     	// verify 2 access patterns
     	assertEquals(2, table.getAccessPatterns(trans).length);
 
@@ -121,7 +120,7 @@ public class CreateCommandTest extends AbstractCommandTest {
     	//assertEquals(1, table.getForeignKeys(null).length);
 
     }
-    
+
     @Test
     /**
      * Creates at least one of each type of relational object within a Model
@@ -131,25 +130,25 @@ public class CreateCommandTest extends AbstractCommandTest {
     	setup(CREATE_COMMAND_6, CreateCommand.class);
 
     	execute();
-    	
+
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
-    	
+
     	WorkspaceContext tableContext = ContextUtils.getContextForPath(wsStatus, "/workspace/vdb_test_1/model_1/table_1"); //$NON-NLS-1$
 
     	KomodoObject ko = tableContext.getKomodoObj();
     	UnitOfWork trans = wsStatus.getTransaction();
     	// Verify the komodo class is a Table and is TABLE type
     	assertEquals(KomodoType.TABLE.name(), ko.getTypeIdentifier(trans).name());
-    	
+
     	Table table = (Table)resolveType(trans, ko, Table.class);
-    	
+
     	// verify 3 columns
     	assertEquals(3, table.getColumns(trans).length);
-    	
+
     	// verify PK
     	assertNotNull(table.getPrimaryKey(trans));
     	assertEquals("pk_1", table.getPrimaryKey(trans).getName(trans)); //$NON-NLS-1$
-    	
+
     	// verify 2 access patterns
     	assertEquals(2, table.getAccessPatterns(trans).length);
 
@@ -157,7 +156,7 @@ public class CreateCommandTest extends AbstractCommandTest {
     	//assertEquals(1, table.getForeignKeys(null).length);
 
     }
-    
+
     @Test
     /**
      * Creates various types within a relational model
@@ -167,32 +166,32 @@ public class CreateCommandTest extends AbstractCommandTest {
     	setup(CREATE_COMMAND_7, CreateCommand.class);
 
     	execute();
-    	
+
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
-    	
-    	WorkspaceContext modelContext = ContextUtils.getContextForPath(wsStatus, "/workspace/MyModel"); //$NON-NLS-1$
+
+    	WorkspaceContext modelContext = ContextUtils.getContextForPath(wsStatus, "/workspace/MyVdb/MyModel"); //$NON-NLS-1$
     	KomodoObject ko = modelContext.getKomodoObj();
     	UnitOfWork trans = wsStatus.getTransaction();
     	// Verify the komodo class is a Model and is MODEL type
     	assertEquals(KomodoType.MODEL.name(), ko.getTypeIdentifier(trans).name());
 
-    	WorkspaceContext table1Context = ContextUtils.getContextForPath(wsStatus, "/workspace/MyModel/MyTable1"); //$NON-NLS-1$
+    	WorkspaceContext table1Context = ContextUtils.getContextForPath(wsStatus, "/workspace/MyVdb/MyModel/MyTable1"); //$NON-NLS-1$
     	ko = table1Context.getKomodoObj();
     	// Verify the komodo class is a Model and is MODEL type
     	assertEquals(KomodoType.TABLE.name(), ko.getTypeIdentifier(trans).name());
-    	
+
     	Table table1 = (Table)resolveType(trans, ko, Table.class);
-    	
+
     	// verify 3 columns
     	assertEquals(3, table1.getColumns(trans).length);
-    	
+
     	// verify PK
     	assertNotNull(table1.getPrimaryKey(trans));
     	assertEquals("MyPk", table1.getPrimaryKey(trans).getName(trans)); //$NON-NLS-1$
 
     	// verify 1 FK
     	assertEquals(1, table1.getForeignKeys(trans).length);
-    	
+
     	// verify 2 access patterns
     	assertEquals(1, table1.getAccessPatterns(trans).length);
 
@@ -200,7 +199,7 @@ public class CreateCommandTest extends AbstractCommandTest {
     	assertEquals(1, table1.getUniqueConstraints(trans).length);
 
     }
-    
+
     @Test
     /**
      * Creates various types within a VDB
@@ -210,29 +209,29 @@ public class CreateCommandTest extends AbstractCommandTest {
     	setup(CREATE_COMMAND_8, CreateCommand.class);
 
     	execute();
-    	
+
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
-    	
+
     	WorkspaceContext vdbContext = ContextUtils.getContextForPath(wsStatus, "/workspace/MyVdb1"); //$NON-NLS-1$
     	KomodoObject ko = vdbContext.getKomodoObj();
     	UnitOfWork trans = wsStatus.getTransaction();
     	// Verify the komodo class is a Vdb and is VDB type
     	assertEquals(KomodoType.VDB.name(), ko.getTypeIdentifier(trans).name());
-    	
+
     	Vdb vdb = (Vdb)resolveType(trans, ko, Vdb.class);
-    	
+
     	// Verify one translator
     	assertEquals(1, vdb.getTranslators(trans).length);
-    	
+
     	// Verify one DataRole
     	assertEquals(1, vdb.getDataRoles(trans).length);
-    	
+
     	// Verify one Import
     	assertEquals(1, vdb.getImports(trans).length);
-    	
+
     	// Verify one Entry
     	assertEquals(1, vdb.getEntries(trans).length);
-    	
+
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/DeleteCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/DeleteCommandTest.java
@@ -13,7 +13,8 @@ public class DeleteCommandTest  extends AbstractCommandTest {
 	private static final String DELETE_COMMAND_2 = "deleteCommand2.txt"; //$NON-NLS-1$
 	private static final String DELETE_COMMAND_3 = "deleteCommand3.txt"; //$NON-NLS-1$
 	private static final String DELETE_COMMAND_4 = "deleteCommand4.txt"; //$NON-NLS-1$
-	private static final String DELETE_COMMAND_5 = "deleteCommand5.txt"; //$NON-NLS-1$
+    private static final String DELETE_COMMAND_5 = "deleteCommand5.txt"; //$NON-NLS-1$
+    private static final String DELETE_COMMAND_6 = "deleteCommand6.txt"; //$NON-NLS-1$
 
     @Test
     public void testDeleteVdb() throws Exception {
@@ -45,7 +46,7 @@ public class DeleteCommandTest  extends AbstractCommandTest {
     	assertEquals("/workspace/vdb_test_1/model_1", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
     	assertEquals(0, wsStatus.getCurrentContext().getKomodoObj().getChildren(wsStatus.getTransaction()).length);
     }
-    
+
     @Test
     public void testDeleteAbsolutePath1() throws Exception {
     	setup(DELETE_COMMAND_4, DeleteCommand.class);
@@ -53,23 +54,36 @@ public class DeleteCommandTest  extends AbstractCommandTest {
     	execute();
 
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
-    	
+
     	// Model child table was deleted
     	WorkspaceContext context = ContextUtils.getContextForPath(wsStatus, "/workspace/vdb_test_1/model_1"); //$NON-NLS-1$
     	assertEquals(0, context.getKomodoObj().getChildren(wsStatus.getTransaction()).length);
     }
-    
+
     @Test
     public void testDeleteAbsolutePath2() throws Exception {
-    	setup(DELETE_COMMAND_5, DeleteCommand.class);
+        setup(DELETE_COMMAND_5, DeleteCommand.class);
 
-    	execute();
+        execute();
 
-    	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
-    	
-    	// VDB child model was deleted
-    	WorkspaceContext context = ContextUtils.getContextForPath(wsStatus, "/workspace/vdb_test_1"); //$NON-NLS-1$
-    	assertEquals(0, context.getKomodoObj().getChildren(wsStatus.getTransaction()).length);
+        assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+
+        // VDB child model was deleted
+        WorkspaceContext context = ContextUtils.getContextForPath(wsStatus, "/workspace/vdb_test_1"); //$NON-NLS-1$
+        assertEquals(0, context.getKomodoObj().getChildren(wsStatus.getTransaction()).length);
+    }
+
+    @Test
+    public void testDeleteRmAlias() throws Exception {
+        setup(DELETE_COMMAND_6, DeleteCommand.class);
+
+        execute();
+
+        assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+
+        // VDB child model was deleted
+        WorkspaceContext context = ContextUtils.getContextForPath(wsStatus, "/workspace/vdb_test_1"); //$NON-NLS-1$
+        assertEquals(0, context.getKomodoObj().getChildren(wsStatus.getTransaction()).length);
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/ListCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/ListCommandTest.java
@@ -29,7 +29,9 @@ public class ListCommandTest extends AbstractCommandTest {
 
 	private static final String LIST_COMMAND1 = "listCommand1.txt"; //$NON-NLS-1$
 	private static final String LIST_COMMAND2 = "listCommand2.txt"; //$NON-NLS-1$
-	private static final String LIST_COMMAND3 = "listCommand3.txt"; //$NON-NLS-1$
+    private static final String LIST_COMMAND3 = "listCommand3.txt"; //$NON-NLS-1$
+    private static final String LIST_COMMAND4 = "listCommand4.txt"; //$NON-NLS-1$
+    private static final String LIST_COMMAND5 = "listCommand5.txt"; //$NON-NLS-1$
 
 	/**
 	 * Test for ListCommand
@@ -69,9 +71,35 @@ public class ListCommandTest extends AbstractCommandTest {
 
     @Test
     public void testList3() throws Exception {
-    	setup(LIST_COMMAND3, ListCommand.class);
+        setup(LIST_COMMAND3, ListCommand.class);
 
-    	execute();
+        execute();
+
+        // make sure table name and table type appear in output
+        String writerOutput = getCommandOutput();
+        assertTrue( writerOutput.contains( "Table1" ) );
+
+        assertEquals("/workspace/MyVdb/Model1", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testListLsAlias() throws Exception {
+        setup(LIST_COMMAND4, ListCommand.class);
+
+        execute();
+
+        // make sure table name and table type appear in output
+        String writerOutput = getCommandOutput();
+        assertTrue( writerOutput.contains( "Table1" ) );
+
+        assertEquals("/workspace/MyVdb/Model1", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void testListLlAlias() throws Exception {
+        setup(LIST_COMMAND5, ListCommand.class);
+
+        execute();
 
         // make sure table name and table type appear in output
         String writerOutput = getCommandOutput();

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/SetCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/SetCommandTest.java
@@ -1,7 +1,9 @@
 package org.komodo.shell;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import java.io.File;
 import org.junit.Test;
 import org.komodo.relational.model.Table;
@@ -24,7 +26,7 @@ public class SetCommandTest extends AbstractCommandTest {
 	private static final String SET_COMMAND_2 = "setCommand2.txt"; //$NON-NLS-1$
 	private static final String SET_COMMAND_3 = "setCommand3.txt"; //$NON-NLS-1$
 	private static final String SET_COMMAND_4 = "setCommand4.txt"; //$NON-NLS-1$
-	private static final String SET_COMMAND_5 = "setCommand5.txt"; //$NON-NLS-1$
+    private static final String SET_COMMAND_5 = "setCommand5.txt"; //$NON-NLS-1$
 
 	/**
 	 * Test for SetCommand
@@ -39,7 +41,7 @@ public class SetCommandTest extends AbstractCommandTest {
 
     	execute();
 
-    	assertEquals("/workspace/MyModel/MyTable", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+    	assertEquals("/workspace/MyVdb/MyModel/MyTable", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
 
     	KomodoObject ko = wsStatus.getCurrentContext().getKomodoObj();
     	UnitOfWork trans = wsStatus.getTransaction();
@@ -58,7 +60,7 @@ public class SetCommandTest extends AbstractCommandTest {
 
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
 
-    	WorkspaceContext tableContext = ContextUtils.getContextForPath(wsStatus, "/workspace/MyModel/MyTable"); //$NON-NLS-1$
+    	WorkspaceContext tableContext = ContextUtils.getContextForPath(wsStatus, "/workspace/MyVdb/MyModel/MyTable"); //$NON-NLS-1$
     	assertNotNull(tableContext);
 
     	KomodoObject ko = tableContext.getKomodoObj();
@@ -78,7 +80,7 @@ public class SetCommandTest extends AbstractCommandTest {
 
     	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
 
-    	WorkspaceContext tableContext = ContextUtils.getContextForPath(wsStatus, "/workspace/MyModel/MyTable"); //$NON-NLS-1$
+    	WorkspaceContext tableContext = ContextUtils.getContextForPath(wsStatus, "/workspace/MyVdb/MyModel/MyTable"); //$NON-NLS-1$
         assertNotNull(tableContext);
 
     	KomodoObject ko = tableContext.getKomodoObj();
@@ -102,12 +104,37 @@ public class SetCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetRecord() throws Exception {
-    	setup(SET_COMMAND_5, SetCommand.class);
-    	wsStatus.setProperty(WorkspaceStatus.RECORDING_FILE_KEY, "/tmp/recordingFile"); //$NON-NLS-1$
+        setup(SET_COMMAND_5, SetCommand.class);
+        wsStatus.setProperty(WorkspaceStatus.RECORDING_FILE_KEY, "/tmp/recordingFile"); //$NON-NLS-1$
 
-    	execute();
+        execute();
 
-    	assertEquals(true, wsStatus.getRecordingStatus());
+        assertEquals(true, wsStatus.getRecordingStatus());
     }
+
+    @Test
+    public void testResetGlobalProperties() throws Exception {
+        setup( "setCommandResetGlobalProps.txt", SetCommand.class );
+        execute();
+
+        for ( final String propName : WorkspaceStatus.GLOBAL_PROPS.keySet() ) {
+            assertThat( this.wsStatus.getProperties().getProperty( propName ), is( WorkspaceStatus.GLOBAL_PROPS.get( propName ) ) );
+        }
+    }
+
+    @Test
+    public void testSetGlobalProperties() throws Exception {
+        setup( "setCommandGlobalProps.txt", SetCommand.class );
+        execute();
+        assertThat( this.wsStatus.getProperties().getProperty( WorkspaceStatus.EXPORT_DEFAULT_DIR_KEY ), is( "/export/directory" ) );
+        assertThat( this.wsStatus.getProperties().getProperty( WorkspaceStatus.IMPORT_DEFAULT_DIR_KEY ), is( "/import/directory" ) );
+        assertThat( this.wsStatus.getRecordingOutputFile().getAbsolutePath(), is( "/recording/file.txt" ) );
+        assertThat( this.wsStatus.isShowingFullPathInPrompt(), is( true ) );
+        assertThat( this.wsStatus.isShowingFullPathInPrompt(), is( true ) );
+        assertThat( this.wsStatus.isShowingHiddenProperties(), is( true ) );
+        assertThat( this.wsStatus.isShowingPropertyNamePrefixes(), is( true ) );
+        assertThat( this.wsStatus.isShowingTypeInPrompt(), is( false ) );
+    }
+
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/UnsetCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/UnsetCommandTest.java
@@ -26,7 +26,7 @@ public final class UnsetCommandTest extends AbstractCommandTest {
     public void testUnsetSingleValueProperty() throws Exception {
         setup( "unsetCommand1.txt", UnsetPropertyCommand.class );
         execute();
-        assertThat( this.wsStatus.getCurrentContext().getFullName(), is( "/workspace/MyModel" ) );
+        assertThat( this.wsStatus.getCurrentContext().getFullName(), is( "/workspace/MyVdb/MyModel" ) );
 
         final KomodoObject kobject = this.wsStatus.getCurrentContext().getKomodoObj();
         assertThat( kobject.getProperty( this.wsStatus.getTransaction(), VdbLexicon.Vdb.DESCRIPTION ), is( nullValue() ) );


### PR DESCRIPTION
- removed duplicated ArgCheck for transactions
- added global property to show/hide hidden properties (i.e., jcr, mix, etc.). Add KomodoObject.getRawPropertyDescriptors and KomodoObject.hasRawProperty to help implement.
- removed calls to RelationalModelFactory except from within the model objects. Most of this change was in the TypeResolver instances whose create method was changed to use the RelationalObject API instead of the factory. This fixed the issue with the possibility of having more than one primary key being created. Also changed test classes to use the RelationalObject API instead of the factory (though a few scenarios still use the factory).
- added TypeResolver tests
- fixed issues in the DataTypeResultSet and TabularResultSet TypeResolvers
- throwing exception in resolver when adapt fails
- AbstractShellCommand now need a WorkspaceStatus at construction since that is required for the command to work
- global props are persisted and restored from session to session
- added global properties for show/hide object type in prompt, show/hide full path in prompt, show/hide hidden properties, show/hide property namespace prefixes
- added option to the SetCommand to reset global properties to their default values
- added command aliases. aliases are printed out when displaying command help.
- modified command reader so that prompt changes occur when a prompt global property is changed
- moved shell shutdown logic from the ExitCommand to DefaultKomodoShell
- boolean global property values are now being validated to ensure true or false is entered. Tab-completion is implemented to help this.
- built-in commands and discovered commands are now registered the same way in the command factory
- added exit and help commands to the list of available commands (this list is shown when help is entered)
- at startup, the context location from previous session is restored
- added home command that takes user to workspace root
- added AddConstraintColumnCommand to add columns to table constraints by using the column path.