### PR TITLE
Fixes Issue 183 NPE At Shell Startup And Created Separate Data Locations For Various Ways To Run Shell

### DIFF
--- a/plugins/libs/org.komodo.modeshape.lib/src/org/komodo/modeshape/lib/LogConfigurator.java
+++ b/plugins/libs/org.komodo.modeshape.lib/src/org/komodo/modeshape/lib/LogConfigurator.java
@@ -22,6 +22,9 @@
 package org.komodo.modeshape.lib;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.logging.Level;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -67,7 +70,7 @@ public class LogConfigurator {
 
     private static final String REF = "ref"; //$NON-NLS-1$
 
-    private String logPath = System.getProperty("user.home") + File.separator + ".komodo" + File.separator + "komodo.log"; //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+    private String logPath;
 
     private String level = "INFO"; //$NON-NLS-1$
 
@@ -87,6 +90,24 @@ public class LogConfigurator {
     }
 
     private void initContext() throws Exception {
+        // get default log file path if necessary
+        if ( ( this.logPath == null ) || this.logPath.isEmpty() ) {
+            String tempPath = System.getProperty( "komodo.dataDir" ); //$NON-NLS-1$
+            tempPath += File.separator + "komodo.log"; //$NON-NLS-1$
+            this.logPath = tempPath;
+        }
+
+        // make sure log file exists
+        final Path logFilePath = Paths.get( this.logPath );
+
+        if ( !Files.exists( logFilePath ) ) {
+            if ( !Files.exists( logFilePath.getParent() ) ) {
+                Files.createDirectories( logFilePath.getParent() );
+            }
+
+            Files.createFile( logFilePath );
+        }
+
         ILoggerFactory factory = LoggerFactory.getILoggerFactory();
         if (factory instanceof LoggerContext) {
             LoggerContext context = (LoggerContext)LoggerFactory.getILoggerFactory();

--- a/plugins/org.komodo.core/.classpath
+++ b/plugins/org.komodo.core/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.komodo.core/META-INF/MANIFEST.MF
+++ b/plugins/org.komodo.core/META-INF/MANIFEST.MF
@@ -16,3 +16,5 @@ Require-Bundle: org.komodo.spi;bundle-version="0.0.1",
  org.komodo.modeshape.teiid.sql.sequencer;bundle-version="0.0.1",
  org.komodo.utils;bundle-version="0.0.1"
 Eclipse-RegisterBuddy: org.komodo.modeshape.lib
+Bundle-ClassPath: resources/,
+ .

--- a/plugins/org.komodo.core/src/org/komodo/core/KEngine.java
+++ b/plugins/org.komodo.core/src/org/komodo/core/KEngine.java
@@ -36,11 +36,13 @@ import org.komodo.repository.LocalRepository;
 import org.komodo.spi.KErrorHandler;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.constants.SystemConstants;
 import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.RepositoryClient;
 import org.komodo.spi.repository.RepositoryClientEvent;
 import org.komodo.utils.ArgCheck;
 import org.komodo.utils.KLog;
+import org.komodo.utils.StringUtils;
 
 /**
  * The Komodo engine. It is responsible for persisting and retriever user session data and Teiid artifacts.
@@ -72,6 +74,12 @@ public final class KEngine implements RepositoryClient, StringConstants {
     private KomodoErrorHandler errorHandler = new KomodoErrorHandler();
 
     private KEngine() {
+        // Initialize default data directory system property if necessary
+        if ( StringUtils.isBlank( System.getProperty( SystemConstants.ENGINE_DATA_DIR ) ) ) {
+            final String defaultValue = ( System.getProperty( "user.home", "/" ) + "/.komodo" ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            System.setProperty( SystemConstants.ENGINE_DATA_DIR, defaultValue );
+        }
+
         // Initialise the logging system
         try {
             LogConfigurator.getInstance();
@@ -105,7 +113,7 @@ public final class KEngine implements RepositoryClient, StringConstants {
      * 1. Call this with a valid repository before calling {{@link #start()}
      * 2. When tests are completed, shutdown the engine
      * 3. Call this again with a value of null to clear the default repository field
-     * 
+     *
      * @param repository the default repository
      * @throws Exception if an error occurs
      */

--- a/plugins/org.komodo.core/src/org/komodo/repository/local-repository-config.json
+++ b/plugins/org.komodo.core/src/org/komodo/repository/local-repository-config.json
@@ -26,14 +26,14 @@
         "binaryStorage" : {
             "minimumBinarySizeInBytes" : 4096,
             "minimumStringSize" : 4096,
-            "directory": "${user.home}/.komodo/storage/content/binaries",
+            "directory": "${komodo.dataDir}/storage/content/binaries",
             "type" : "file"
         }
     },
     "indexProviders" : {
         "local" : {
             "classname" : "org.modeshape.jcr.index.local.LocalIndexProvider",
-            "directory" : "${user.home}/.komodo/indexes"
+            "directory" : "${komodo.dataDir}/indexes"
         }
     },
     "indexes" : {

--- a/plugins/org.komodo.core/src/org/komodo/repository/local-repository-infinispan-config.xml
+++ b/plugins/org.komodo.core/src/org/komodo/repository/local-repository-infinispan-config.xml
@@ -12,8 +12,8 @@
             <persistence passivation="false">
                 <leveldb-store xmlns="urn:infinispan:config:store:leveldb:7.2"
                     purge="false"
-                    path="${user.home}/.komodo/db/data">
-                    <expiration path="${user.home}/.komodo/db/expired"/>
+                    path="${komodo.dataDir}/db/data">
+                    <expiration path="${komodo.dataDir}/db/expired"/>
                     <implementation type="JAVA"/>
                 </leveldb-store>
             </persistence>

--- a/plugins/org.komodo.eclipse.shell/komodo-eclipse-linux.launch
+++ b/plugins/org.komodo.eclipse.shell/komodo-eclipse-linux.launch
@@ -17,7 +17,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms256m -Xmx512m -XX:MaxPermSize=128m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms256m -Xmx512m -XX:MaxPermSize=128m -Dkomodo.dataDir=${workspace_loc}/.komodo -Dvdbbuilder.dataDir=${workspace_loc}/.komodo/vdbbuilder"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.komodo.eclipse.shell.KomodoShell"/>
 <booleanAttribute key="show_selected_only" value="false"/>

--- a/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
@@ -42,7 +42,6 @@ import org.komodo.relational.teiid.Teiid;
 import org.komodo.relational.teiid.internal.TeiidImpl;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.vdb.internal.VdbImpl;
-import org.komodo.repository.LocalRepository;
 import org.komodo.repository.RepositoryImpl;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
@@ -104,7 +103,7 @@ public class WorkspaceManager extends RelationalObjectImpl {
         if ( instance == null ) {
             // We must create a transaction here so that it can be passed on to the constructor. Since the
             // node associated with the WorkspaceManager always exists we don't have to create it.
-            final UnitOfWork uow = repository.createTransaction( "createWorkspaceManager", true, null ); //$NON-NLS-1$
+            final UnitOfWork uow = repository.createTransaction( "createWorkspaceManager", false, null ); //$NON-NLS-1$
             instance = new WorkspaceManager( uow, repository );
             uow.commit();
 
@@ -140,12 +139,11 @@ public class WorkspaceManager extends RelationalObjectImpl {
     }
 
     /**
-     * Primarily used in tests to remove the workspace manager instance
-     * from the instances cache.
+     * Primarily used in tests to remove the workspace manager instance from the instances cache.
      *
      * @param repository remove instance with given repository
      */
-    public static void uncacheInstance(LocalRepository repository) {
+    public static void uncacheInstance(final Repository repository) {
         if (repository == null)
             return;
 
@@ -154,6 +152,13 @@ public class WorkspaceManager extends RelationalObjectImpl {
 
     private WorkspaceManager(UnitOfWork uow, Repository repository ) throws KException {
         super(uow, repository, RepositoryImpl.WORKSPACE_ROOT);
+
+        { // TODO should not need this when GitHub Issue 184 is resolved
+          // make sure workspace node and environment node exists
+            repository.komodoEnvironment( uow );
+            repository.komodoWorkspace( uow );
+        }
+
         repository.addObserver(new RepositoryObserver() {
 
             @Override

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoShell.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoShell.java
@@ -26,6 +26,7 @@ import java.io.PrintStream;
 import java.io.Writer;
 import org.komodo.core.KEngine;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.constants.SystemConstants;
 
 /**
  *
@@ -48,12 +49,21 @@ public interface KomodoShell extends StringConstants {
     PrintStream getOutputStream();
 
     /**
-     * The directory where the shell saves user settings, preferences, or any other data needed to restore a user session.The
-     * <code>${user.home}/.komodo</code> directory is the default location.
+     * The directory where the shell saves user settings, preferences, or any other data needed to restore a user session.
      *
      * @return the shell's workspace directory (never empty)
+     * @see SystemConstants#VDB_BUILDER_DATA_DIR
      */
     String getShellDataLocation();
+
+    /**
+     * Must be called before the shell is running.
+     *
+     * @param dataDirectory
+     *        the directory where the shell can persist preferences, settings, etc. (can be empty if the default location should
+     *        be used)
+     */
+    void setShellDataLocation( final String dataDirectory );
 
     /**
      *

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
@@ -79,9 +79,9 @@ public interface WorkspaceStatus extends StringConstants {
 
         // add default values for EVERY property
         {
-            put( EXPORT_DEFAULT_DIR_KEY, StringConstants.EMPTY_STRING );
-            put( IMPORT_DEFAULT_DIR_KEY, StringConstants.EMPTY_STRING );
-            put( RECORDING_FILE_KEY, StringConstants.EMPTY_STRING );
+            put( EXPORT_DEFAULT_DIR_KEY, "." ); //$NON-NLS-1$
+            put( IMPORT_DEFAULT_DIR_KEY, "." ); //$NON-NLS-1$
+            put( RECORDING_FILE_KEY, "./commandOutput.txt" ); //$NON-NLS-1$
             put( SHOW_FULL_PATH_IN_PROMPT_KEY, Boolean.FALSE.toString() );
             put( SHOW_HIDDEN_PROPERTIES_KEY, Boolean.FALSE.toString() );
             put( SHOW_PROP_NAME_PREFIX_KEY, Boolean.FALSE.toString() );

--- a/plugins/org.komodo.shell/src/org/komodo/shell/AbstractShellCommandReader.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/AbstractShellCommandReader.java
@@ -29,6 +29,7 @@ import java.io.Writer;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.komodo.shell.Messages.SHELL;
 import org.komodo.shell.api.Arguments;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.WorkspaceStatus;
@@ -217,10 +218,17 @@ public abstract class AbstractShellCommandReader implements ShellCommandReader {
         // see if full path should be displayed
         String path = null;
 
-        if ( getWorkspaceStatus().isShowingFullPathInPrompt() ) {
-            path = getWorkspaceStatus().getCurrentContext().getFullName();
-        } else {
-            path = getWorkspaceStatus().getCurrentContext().getName();
+        try {
+            if ( getWorkspaceStatus().isShowingFullPathInPrompt() ) {
+                path = getWorkspaceStatus().getCurrentContext().getFullName();
+            } else {
+                path = getWorkspaceStatus().getCurrentContext().getName();
+            }
+        } catch ( final Exception e ) {
+            // problem getting context name
+            path = Messages.getString( SHELL.PATH_NOT_FOUND,
+                                       getWorkspaceStatus().getCurrentContext().getKomodoObj().getAbsolutePath() );
+            return Messages.getString( Messages.SHELL.PROMPT, path );
         }
 
         assert ( path != null );

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -45,6 +45,7 @@ public class Messages implements StringConstants {
         PROMPT_WITH_TYPE,
         CHILD_NAME_HEADER,
         CHILD_TYPE_HEADER,
+        PATH_NOT_FOUND,
         PROPERTY_NAME_HEADER,
         PROPERTY_VALUE_HEADER,
         NO_PROPERTY_VALUE,

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
@@ -469,6 +469,11 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
 
         if (!StringUtils.isBlank( savedPath )) {
             this.currentContext = ContextUtils.getContextForPath( this, savedPath );
+
+            // saved path no longer exists so set context to workspace root
+            if ( this.currentContext == null ) {
+                this.currentContext = getWorkspaceContext();
+            }
         }
     }
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
@@ -26,6 +26,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -478,14 +481,22 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
     }
 
     private void saveProperties() throws Exception {
-        final String propFileName = this.shell.getShellDataLocation();
-        final File propFile = new File( propFileName, PROPERTIES_FILE_NAME );
+        final String shellDataDir = this.shell.getShellDataLocation();
+        final Path propFile = Paths.get( shellDataDir, PROPERTIES_FILE_NAME );
+
+        if ( !Files.exists( propFile ) ) {
+            if ( !Files.exists( propFile.getParent() ) ) {
+                Files.createDirectories( propFile.getParent() );
+            }
+
+            Files.createFile( propFile );
+        }
 
         // save current context path
         this.wsProperties.setProperty( SAVED_CONTEXT_PATH, this.currentContext.getFullName() );
 
         // save
-        this.wsProperties.store( new FileOutputStream( propFile.getAbsolutePath() ), null );
+        this.wsProperties.store( new FileOutputStream( propFile.toString() ), null );
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/ExitCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/ExitCommand.java
@@ -49,8 +49,8 @@ public class ExitCommand extends BuiltInShellCommand {
 	 */
 	@Override
 	public boolean execute() throws Exception {
-		print(CompletionConstants.MESSAGE_INDENT,Messages.getString(SHELL.GOOD_BYE));
 		getWorkspaceStatus().getShell().exit();
+        print(CompletionConstants.MESSAGE_INDENT,Messages.getString(SHELL.GOOD_BYE));
         return true;
 	}
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -276,6 +276,7 @@ UseTeiidCommand.teiidSetOk=Teiid '{0}' set as current instance with connection s
 UseTeiidCommand.noTeiidWithName=No teiid instance found that matches the name or id: {0}
 
 # This message have SHELL enum definitions in Messages
+SHELL.PATH_NOT_FOUND = "** {0} not found **
 SHELL.INVALID_GLOBAL_PROPERTY_NAME = "{0}" is not a valid global property name.
 SHELL.INVALID_BOOLEAN_GLOBAL_PROPERTY_VALUE = "{0}" is not a valid value for global property "{1}." Enter either a "true" or "false" as the value.
 SHELL.PROMPT = [{0}]

--- a/plugins/org.komodo.spi/src/org/komodo/spi/constants/SystemConstants.java
+++ b/plugins/org.komodo.spi/src/org/komodo/spi/constants/SystemConstants.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.spi.constants;
+
+/**
+ * Constants associated with the Komodo system and environment.
+ */
+public interface SystemConstants {
+
+    /**
+     * The environmental variable that can be set with the directory the Komodo engine will use while running. Default is
+     * <code>${user.home}/.komodo</code>.
+     */
+    String ENGINE_DATA_DIR = "komodo.dataDir"; //$NON-NLS-1$
+
+    /**
+     * The Komodo log file name.
+     */
+    String LOG_FILE_NAME = StringConstants.KOMODO + StringConstants.DOT + StringConstants.LOG;
+
+    /**
+     * The environmental variable that can be set with the directory VDB Builder will use while running. Default is
+     * <code>${user.home}/.komodo/vdbbuilder</code>
+     */
+    String VDB_BUILDER_DATA_DIR = "vdbbuilder.dataDir"; //$NON-NLS-1$
+
+}

--- a/plugins/org.komodo.utils/src/org/komodo/utils/KLog.java
+++ b/plugins/org.komodo.utils/src/org/komodo/utils/KLog.java
@@ -23,6 +23,9 @@ package org.komodo.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.logging.FileHandler;
@@ -30,6 +33,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.constants.SystemConstants;
 import org.komodo.spi.logging.KLogger;
 
 /**
@@ -41,8 +45,7 @@ public class KLog implements KLogger {
 
         private final Logger logger;
 
-        private String logPath = System.getProperty("user.home") + //$NON-NLS-1$
-                                                        File.separator + DOT_KOMODO + File.separator + KOMODO + DOT + LOG;
+        private String logPath;
 
         private FileHandler logPathHandler;
 
@@ -60,6 +63,23 @@ public class KLog implements KLogger {
         }
 
         private void initLogger() throws IOException {
+            // construct default log file path if necessary
+            if ( StringUtils.isBlank( this.logPath ) ) {
+                this.logPath = System.getProperty( SystemConstants.ENGINE_DATA_DIR );
+                this.logPath += File.separator + SystemConstants.LOG_FILE_NAME;
+            }
+
+            // make sure log file exists
+            final Path logFilePath = Paths.get( this.logPath );
+
+            if ( !Files.exists( logFilePath ) ) {
+                if ( !Files.exists( logFilePath.getParent() ) ) {
+                    Files.createDirectories( logFilePath.getParent() );
+                }
+
+                Files.createFile( logFilePath );
+            }
+
             dispose();
 
             //

--- a/tests/org.komodo.modeshape.teiid.sql.sequencer.test/data/test-repository-config.json
+++ b/tests/org.komodo.modeshape.teiid.sql.sequencer.test/data/test-repository-config.json
@@ -21,7 +21,7 @@
     "indexProviders" : {
         "local" : {
             "classname" : "org.modeshape.jcr.index.local.LocalIndexProvider",
-            "directory" : "${user.home}/.komodo/indexes"
+            "directory" : "${komodo.dataDir}/indexes"
         }
     },
     "indexes" : {

--- a/tests/org.komodo.modeshape.vdb.test/data/test-repository-config.json
+++ b/tests/org.komodo.modeshape.vdb.test/data/test-repository-config.json
@@ -20,7 +20,7 @@
     "indexProviders" : {
         "local" : {
             "classname" : "org.modeshape.jcr.index.local.LocalIndexProvider",
-            "directory" : "${user.home}/.komodo/indexes"
+            "directory" : "${komodo.dataDir}/indexes"
         }
     },
     "indexes" : {

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
@@ -56,6 +56,7 @@ import org.komodo.relational.workspace.WorkspaceManagerTest;
     ParameterImplTest.class,
     PrimaryKeyImplTest.class,
     PushdownFunctionImplTest.class,
+    RelationalObjectImplTest.class,
     ResultSetColumnImplTest.class,
     StatementOptionImplTest.class,
     StoredProcedureImplTest.class,

--- a/tests/org.komodo.test.utils/src/org/komodo/test/utils/AbstractLocalRepositoryTest.java
+++ b/tests/org.komodo.test.utils/src/org/komodo/test/utils/AbstractLocalRepositoryTest.java
@@ -311,4 +311,5 @@ public abstract class AbstractLocalRepositoryTest extends AbstractLoggingTest im
 
         return sb.toString();
     }
+
 }

--- a/tests/org.komodo.test.utils/src/org/komodo/test/utils/AbstractLoggingTest.java
+++ b/tests/org.komodo.test.utils/src/org/komodo/test/utils/AbstractLoggingTest.java
@@ -23,8 +23,13 @@ package org.komodo.test.utils;
 
 import static org.junit.Assert.assertEquals;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.komodo.modeshape.lib.LogConfigurator;
+import org.komodo.spi.constants.SystemConstants;
+import org.komodo.utils.FileUtils;
 import org.komodo.utils.KLog;
 
 /**
@@ -33,6 +38,8 @@ import org.komodo.utils.KLog;
  */
 @SuppressWarnings( {"nls", "javadoc"} )
 public abstract class AbstractLoggingTest {
+
+    private static Path _dataDirectory;
 
     private static File configureLogPath(KLog logger) throws Exception {
         File newLogFile = File.createTempFile("TestKLog", ".log");
@@ -44,6 +51,10 @@ public abstract class AbstractLoggingTest {
         assertEquals(newLogFile.getAbsolutePath(), logger.getLogPath());
 
         return newLogFile;
+    }
+
+    protected static Path getLoggingDirectory() {
+        return _dataDirectory;
     }
 
     /**
@@ -58,8 +69,19 @@ public abstract class AbstractLoggingTest {
 
     @BeforeClass
     public static void initLogging() throws Exception {
+        // create data directory for engine logging
+        _dataDirectory = Files.createTempDirectory( "KomodoEngineDataDir" );
+        System.setProperty( SystemConstants.ENGINE_DATA_DIR, _dataDirectory.toString() );
+
         // Initialises logging and reduces modeshape logging from DEBUG to INFO
         LogConfigurator.getInstance();
         configureLogPath(KLog.getLogger());
     }
+
+    @AfterClass
+    public static void shutdown() throws Exception {
+        FileUtils.removeDirectoryAndChildren( _dataDirectory.toFile() );
+    }
+
 }
+

--- a/tests/org.komodo.test.utils/src/org/komodo/test/utils/test-local-repository-in-memory-config.json
+++ b/tests/org.komodo.test.utils/src/org/komodo/test/utils/test-local-repository-in-memory-config.json
@@ -24,7 +24,7 @@
     "indexProviders" : {
         "local" : {
             "classname" : "org.modeshape.jcr.index.local.LocalIndexProvider",
-            "directory" : "${user.home}/.komodo/indexes"
+            "directory" : "${komodo.dataDir}/indexes"
         }
     },
     "indexes" : {

--- a/tests/org.komodo.utils.test/src/org/komodo/utils/test/TestKLog.java
+++ b/tests/org.komodo.utils.test/src/org/komodo/utils/test/TestKLog.java
@@ -3,17 +3,17 @@
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- * 
+ *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -29,9 +29,15 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.komodo.spi.constants.SystemConstants;
+import org.komodo.utils.FileUtils;
 import org.komodo.utils.KLog;
 
 /**
@@ -39,6 +45,20 @@ import org.komodo.utils.KLog;
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 public class TestKLog {
+
+    private static Path _dataDirectory;
+
+    @BeforeClass
+    public static void initDataDirectory() throws Exception {
+        // create data directory for engine logging
+        _dataDirectory = Files.createTempDirectory( "KomodoEngineDataDir" );
+        System.setProperty( SystemConstants.ENGINE_DATA_DIR, _dataDirectory.toString() );
+    }
+
+    @AfterClass
+    public static void removeDataDirectory() throws Exception {
+        FileUtils.removeDirectoryAndChildren( _dataDirectory.toFile() );
+    }
 
     private KLog logger;
 
@@ -72,9 +92,7 @@ public class TestKLog {
     }
 
     private String retrieveLogContents(File newLogFile) throws Exception {
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new FileReader(newLogFile));
+        try ( BufferedReader reader = new BufferedReader( new FileReader( newLogFile ) ) ) {
             StringBuilder builder = new StringBuilder();
             String line;
             while((line = reader.readLine()) != null) {
@@ -83,9 +101,6 @@ public class TestKLog {
             }
 
             return builder.toString();
-        } finally {
-            if (reader != null)
-                reader.close();
         }
     }
 


### PR DESCRIPTION
The issue was caused by the repository initial content not being read in by ModeShape. This is a class path issue that still needs to be solved. This PR is a workaround for when the NPE and infinite loop occurs because of that content not available at startup. This only occurs in the kit.

Also created separate data directories for each of the ways the shell can be run (kit, Eclipse run configuration, JUnit tests). Now each way has there own location and can't be corrupted by the other ways. 