### PR TITLE
Issue 179 Shell Should Display Paths Instead Of UUIDs

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/PropertyImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/PropertyImpl.java
@@ -66,7 +66,7 @@ public class PropertyImpl implements Property {
                 case PropertyType.DECIMAL:
                     return value.getDecimal();
                 default:
-                    return value.toString();
+                    return value.getString();
             }
         } catch (final Exception e) {
             throw new KException(Messages.getString(Komodo.UNABLE_TO_CONVERT_VALUE, propertyType), e);

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceContext.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceContext.java
@@ -22,8 +22,9 @@
 package org.komodo.shell.api;
 
 import java.util.List;
-
 import org.komodo.relational.workspace.WorkspaceManager;
+import org.komodo.repository.RepositoryImpl;
+import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
 
@@ -33,8 +34,13 @@ import org.komodo.spi.repository.Repository;
 public interface WorkspaceContext {
 
 	@SuppressWarnings("javadoc")
-	public static final String WORKSPACE_ROOT_DISPLAY_NAME = "workspace"; //$NON-NLS-1$
-	
+	String WORKSPACE_ROOT_DISPLAY_NAME = "workspace"; //$NON-NLS-1$
+
+    /**
+     * The repository workspace root path ending with a slash. Value is {@value} .
+     */
+    String REPO_WS_ROOT_PATH = ( RepositoryImpl.WORKSPACE_ROOT + StringConstants.FORWARD_SLASH );
+
     /**
      * Represents all komodo object types
      */
@@ -72,7 +78,7 @@ public interface WorkspaceContext {
 	 * @throws Exception if error occurs
 	 */
 	WorkspaceManager getWorkspaceManager() throws Exception;
-	
+
 	/**
 	 * Get the parent context
 	 * @return the parent

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceContextImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceContextImpl.java
@@ -33,10 +33,12 @@ import org.komodo.shell.Messages.SHELL;
 import org.komodo.shell.api.WorkspaceContext;
 import org.komodo.shell.api.WorkspaceContextVisitor;
 import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.shell.util.ContextUtils;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Property;
 import org.komodo.spi.repository.PropertyDescriptor;
+import org.komodo.spi.repository.PropertyDescriptor.Type;
 import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 
@@ -300,7 +302,16 @@ public class WorkspaceContextImpl implements WorkspaceContext {
 
         if ( relObj.hasProperty( transaction, propertyName ) ) {
             final Property property = relObj.getProperty( transaction, propertyName );
-            return RepositoryTools.getDisplayValue( transaction, property );
+            final Type type = property.getDescriptor( transaction ).getType();
+            final boolean propIsReference = ( ( Type.REFERENCE == type ) || ( Type.WEAKREFERENCE == type ) );
+            final String displayValue = RepositoryTools.getDisplayValue( transaction, property );
+
+            if ( propIsReference ) {
+                // hide the root komodo directory
+                return displayValue.replaceAll( WorkspaceContext.REPO_WS_ROOT_PATH, ContextUtils.ROOT_OPT3 );
+            }
+
+            return displayValue;
         }
 
         return Messages.getString( SHELL.NO_PROPERTY_VALUE );

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
@@ -93,8 +93,12 @@ public final class AddConstraintColumnCommand extends BuiltInShellCommand {
                 final TableConstraint constraint = ( TableConstraint )kobject;
                 constraint.addColumn( getWorkspaceStatus().getTransaction(), ( Column )column );
 
+                // Commit transaction
+                getWorkspaceStatus().commit("SetCommand"); //$NON-NLS-1$
+
                 print( MESSAGE_INDENT,
                        Messages.getString( "AddConstraintColumnCommand.columnRefAdded", columnPathArg, getContext().getFullName() ) ); //$NON-NLS-1$
+
                 return true;
             } else {
                 print( MESSAGE_INDENT, Messages.getString( "AddConstraintColumnCommand.invalidColumnPath", columnPathArg ) ); //$NON-NLS-1$

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/FindCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/FindCommand.java
@@ -26,12 +26,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.komodo.repository.KomodoTypeRegistry;
-import org.komodo.repository.RepositoryImpl;
 import org.komodo.shell.BuiltInShellCommand;
 import org.komodo.shell.Messages;
+import org.komodo.shell.api.WorkspaceContext;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.shell.util.ContextUtils;
-import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoType;
 
 /**
@@ -46,7 +45,6 @@ public final class FindCommand extends BuiltInShellCommand {
 
     private static final List< KomodoType > NOT_APPLICABLE_TYPES = Arrays.asList( new KomodoType[] { KomodoType.UNKNOWN,
                                                                                                     KomodoType.WORKSPACE } );
-    private static final String REPO_WS_ROOT_PATH = ( RepositoryImpl.WORKSPACE_ROOT + StringConstants.FORWARD_SLASH );
 
     /**
      * @param status
@@ -174,8 +172,8 @@ public final class FindCommand extends BuiltInShellCommand {
             String path = absolutePath;
 
             // should always start with the absolute repository path but check just in case
-            if ( path.startsWith( REPO_WS_ROOT_PATH ) ) {
-                result[i] = ( ContextUtils.ROOT_OPT3 + path.substring( REPO_WS_ROOT_PATH.length() ) );
+            if ( path.startsWith( WorkspaceContext.REPO_WS_ROOT_PATH ) ) {
+                result[i] = ( ContextUtils.ROOT_OPT3 + path.substring( WorkspaceContext.REPO_WS_ROOT_PATH.length() ) );
             } else {
                 result[i] = path;
             }

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PrimaryKeyImplTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/model/internal/PrimaryKeyImplTest.java
@@ -17,13 +17,16 @@ import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
 import org.komodo.relational.internal.RelationalObjectImpl;
+import org.komodo.relational.model.Column;
 import org.komodo.relational.model.PrimaryKey;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
+import org.modeshape.jcr.JcrLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
+import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon.Constraint;
 
 @SuppressWarnings( { "javadoc", "nls" } )
 public final class PrimaryKeyImplTest extends RelationalModelTest {
@@ -38,6 +41,19 @@ public final class PrimaryKeyImplTest extends RelationalModelTest {
         this.table = createTable();
         this.primaryKey = this.table.setPrimaryKey( this.uow, NAME );
         commit();
+    }
+
+    @Test
+    public void shouldAddColumnReference() throws Exception {
+        final Column column = this.table.addColumn( this.uow, "MyColumn" );
+        this.primaryKey.addColumn( this.uow, column );
+        commit();
+
+        assertThat( this.primaryKey.getColumns( this.uow ).length, is( 1 ) );
+        assertThat( this.primaryKey.getColumns( this.uow )[0], is( column ) );
+        assertThat( this.primaryKey.getProperty( this.uow, Constraint.REFERENCES ).getValues( this.uow ).length, is( 1 ) );
+        assertThat( this.primaryKey.getProperty( this.uow, Constraint.REFERENCES ).getValues( this.uow )[0].toString(),
+                    is( column.getRawProperty( this.uow, JcrLexicon.UUID.getString() ).getStringValue( this.uow ) ) );
     }
 
     @Test

--- a/tests/org.komodo.shell.test/resources/showReferences.txt
+++ b/tests/org.komodo.shell.test/resources/showReferences.txt
@@ -1,0 +1,20 @@
+# create three models within workspace.
+create vdb MyVdb
+cd MyVdb
+
+create model MyModel
+cd MyModel
+
+create table MyTable
+cd MyTable
+
+create column colA
+create column colB
+
+create primarykey pk
+cd pk
+
+add-column ../colA
+add-column ../colB
+
+show property teiidddl:tableElementRefs

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/ShowCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/ShowCommandTest.java
@@ -15,7 +15,9 @@
  */
 package org.komodo.shell;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.komodo.shell.commands.core.ShowCommand;
@@ -27,11 +29,13 @@ import org.komodo.shell.commands.core.ShowCommand;
 @SuppressWarnings({"javadoc", "nls"})
 public class ShowCommandTest extends AbstractCommandTest {
 
-	private static final String SHOW_STATUS1 = "showStatus1.txt"; //$NON-NLS-1$
-	private static final String SHOW_STATUS2 = "showStatus2.txt"; //$NON-NLS-1$
-	private static final String SHOW_CHILDREN1 = "showChildren1.txt"; //$NON-NLS-1$
-	private static final String SHOW_CHILDREN2 = "showChildren2.txt"; //$NON-NLS-1$
-	private static final String INDENT = getIndentStr();
+    private static final String SHOW_STATUS1 = "showStatus1.txt";
+    private static final String SHOW_STATUS2 = "showStatus2.txt";
+    private static final String SHOW_CHILDREN1 = "showChildren1.txt";
+    private static final String SHOW_CHILDREN2 = "showChildren2.txt";
+    private static final String SHOW_REFS = "showReferences.txt";
+
+    private static final String INDENT = getIndentStr();
 
 	/**
 	 * Test for StatusCommand
@@ -87,9 +91,9 @@ public class ShowCommandTest extends AbstractCommandTest {
 
     @Test
     public void testShowChildren2() throws Exception {
-    	setup(SHOW_CHILDREN2, ShowCommand.class);
+        setup(SHOW_CHILDREN2, ShowCommand.class);
 
-    	execute();
+        execute();
 
         // make sure model names and model type appear in output
         String writerOutput = getCommandOutput();
@@ -98,6 +102,18 @@ public class ShowCommandTest extends AbstractCommandTest {
         assertTrue( writerOutput.contains( "Model3" ) );
 
         assertEquals("/workspace/MyVdb", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void shouldShowPathsForReferences() throws Exception {
+        setup( SHOW_REFS, ShowCommand.class );
+
+        execute();
+
+        final String writerOutput = getCommandOutput();
+        assertThat( writerOutput.contains( "[/workspace/MyVdb/MyModel/MyTable/colA,/workspace/MyVdb/MyModel/MyTable/colB]" ),
+                    is( true ) );
+        assertThat( wsStatus.getCurrentContext().getFullName(), is( "/workspace/MyVdb/MyModel/MyTable/pk" ) ); //$NON-NLS-1$
     }
 
 }


### PR DESCRIPTION
- RepositoryTools.getDisplayValue now prints the path of an object instead of its UUID
- corrected the way a string JCR value is converted to an Object value
- fixed a bug in AddConstraintColumnCommand where it wasn't committing
- ShowCommand is now sizing the two columns independently of each other