### PR TITLE
Issue 180 Add A RemoveConstraintColumnCommand To The Shell

### DIFF
--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TableConstraintImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/TableConstraintImpl.java
@@ -146,20 +146,20 @@ abstract class TableConstraintImpl extends RelationalChildRestrictedObject imple
         }
 
         boolean found = false;
-        final Column[] updated = new Column[ current.length - 1 ];
+        final String[] updatedRefs = new String[ current.length - 1 ];
         int i = 0;
 
         for ( final Column column : current ) {
             if ( column.equals( columnToRemove ) ) {
                 found = true;
             } else {
-                updated[i] = column;
+                updatedRefs[i] = column.getRawProperty( transaction, JcrLexicon.UUID.getString() ).getStringValue( transaction );
                 ++i;
             }
         }
 
         if ( found ) {
-            setProperty( transaction, Constraint.REFERENCES, ( Object[] )updated );
+            setProperty( transaction, Constraint.REFERENCES, ( Object[] )updatedRefs );
         } else {
             throw new KException( Messages.getString( Relational.REFERENCED_COLUMN_NOT_FOUND, columnId ) );
         }

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -27,8 +27,9 @@ import java.util.ResourceBundle;
 import org.komodo.spi.constants.StringConstants;
 
 /**
- *
+ * Localized messages for the Shell plugin.
  */
+@SuppressWarnings( "javadoc" )
 public class Messages implements StringConstants {
 
     private static final String BUNDLE_NAME = Messages.class.getPackage().getName()
@@ -37,7 +38,6 @@ public class Messages implements StringConstants {
 
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
 
-    @SuppressWarnings( "javadoc" )
     public enum SHELL {
         ERROR_LOADING_PROPERTIES,
         INVALID_GLOBAL_PROPERTY_NAME,
@@ -101,7 +101,6 @@ public class Messages implements StringConstants {
     	}
     }
 
-    @SuppressWarnings( "javadoc" )
     public enum StatusCommand {
         Separator,
         Connected,
@@ -115,7 +114,6 @@ public class Messages implements StringConstants {
         }
     }
 
-    @SuppressWarnings( "javadoc" )
     public enum ShowCommand {
         Separator,
         Connected,
@@ -129,7 +127,6 @@ public class Messages implements StringConstants {
         }
     }
 
-    @SuppressWarnings( "javadoc" )
     public enum ExportCommand {
         InvalidArgMsgObjectName,
         InvalidArgMsgOutputFileName,
@@ -145,6 +142,29 @@ public class Messages implements StringConstants {
         public String toString() {
             return getEnumName(this) + DOT + name();
         }
+    }
+
+    /**
+     * Localized messages of the {@link RemoveConstraintColumnCommand}.
+     */
+    public enum RemoveConstraintColumnCommand {
+
+        COLUMN_REF_REMOVED,
+        COLUMN_PATH_NOT_FOUND,
+        ERROR,
+        INVALID_COLUMN_PATH,
+        MISSING_COLUMN_PATH_ARG;
+
+        /**
+         * {@inheritDoc}
+         *
+         * @see java.lang.Enum#toString()
+         */
+        @Override
+        public String toString() {
+            return getEnumName( this ) + DOT + name();
+        }
+
     }
 
     private static String getEnumName(Enum<?> enumValue) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/ShellCommandFactory.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/ShellCommandFactory.java
@@ -25,11 +25,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.TreeMap;
 import javax.xml.namespace.QName;
 import org.komodo.core.KEngine;
@@ -49,6 +47,7 @@ import org.komodo.shell.commands.core.HomeCommand;
 import org.komodo.shell.commands.core.ImportCommand;
 import org.komodo.shell.commands.core.ListCommand;
 import org.komodo.shell.commands.core.PlayCommand;
+import org.komodo.shell.commands.core.RemoveConstraintColumnCommand;
 import org.komodo.shell.commands.core.RenameCommand;
 import org.komodo.shell.commands.core.SetCommand;
 import org.komodo.shell.commands.core.ShowCommand;
@@ -91,29 +90,25 @@ public class ShellCommandFactory {
 	 */
     private void registerCommands() throws Exception {
         // register built-in commands
-        final Set< Class< ? extends ShellCommand >> builtInCommands = new HashSet<>();
-        builtInCommands.add( AddConstraintColumnCommand.class );
-        builtInCommands.add( CdCommand.class );
-        builtInCommands.add( CreateCommand.class );
-        builtInCommands.add( DeleteCommand.class );
-        builtInCommands.add( ExitCommand.class );
-        builtInCommands.add( ExportCommand.class );
-        builtInCommands.add( FindCommand.class );
-        builtInCommands.add( HelpCommand.class );
-        builtInCommands.add( HomeCommand.class );
-        builtInCommands.add( ImportCommand.class );
-        builtInCommands.add( ListCommand.class );
-        // builtInCommands.add( NavigateCommand.class );
-        builtInCommands.add( PlayCommand.class );
-        builtInCommands.add( RenameCommand.class );
-        builtInCommands.add( SetCommand.class );
-        builtInCommands.add( ShowCommand.class );
-        builtInCommands.add( UnsetPropertyCommand.class );
-        // builtInCommands.add( UseTeiidCommand.class );
-
-        for ( final Class< ? extends ShellCommand > commandClass : builtInCommands ) {
-            registerCommand( commandClass );
-        }
+        registerCommand( AddConstraintColumnCommand.class );
+        registerCommand( CdCommand.class );
+        registerCommand( CreateCommand.class );
+        registerCommand( DeleteCommand.class );
+        registerCommand( ExitCommand.class );
+        registerCommand( ExportCommand.class );
+        registerCommand( FindCommand.class );
+        registerCommand( HelpCommand.class );
+        registerCommand( HomeCommand.class );
+        registerCommand( ImportCommand.class );
+        registerCommand( ListCommand.class );
+        // registerCommand( NavigateCommand.class );
+        registerCommand( PlayCommand.class );
+        registerCommand( RemoveConstraintColumnCommand.class );
+        registerCommand( RenameCommand.class );
+        registerCommand( SetCommand.class );
+        registerCommand( ShowCommand.class );
+        registerCommand( UnsetPropertyCommand.class );
+        // registerCommand( UseTeiidCommand.class );
 
         // register any commands contributed by command providers
         discoverContributedCommands();

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -6,14 +6,13 @@ AddConstraintColumnCommand.examples= \
 \t add-column /workspace/MyVdb/MyModel/MyTable/MyColumn
 AddConstraintColumnCommand.usage = add-column <column-path>
 AddConstraintColumnCommand.help = adds a column reference to the table constraint (i.e., primary key, unique constraint, access pattern, foreign key, or index). \n\n \
-\tNote 1: Use the "find Column" command to find the paths of all the columns in your workspace.\n \
+\tNote 1: Use the "find Column" command to find the paths of columns in your workspace.\n \
 \tNote 2: You can also use tab completion to get a list of the column paths.
 AddConstraintColumnCommand.columnRefAdded = The reference to the column at "{0}" has been added to the table constraint "{1}".
-AddConstraintColumnCommand.columnPathNotFound = The specified column path of "{0}" cannot be found in the workspace. Use the "find Column" command to find all the column paths.
+AddConstraintColumnCommand.columnPathNotFound = The specified column path of "{0}" cannot be found in the workspace. Use the "find Column" command to find column paths.
 AddConstraintColumnCommand.error = Failed to add column to the constraint.
 AddConstraintColumnCommand.invalidColumnPath = The path at "{0}" is not a path to a column.
 AddConstraintColumnCommand.missingColumnPathArg = Please specify the workspace path of the column you wish to reference in this constraint.
-AddConstraintColumnCommand.success = Successfully added a reference to column "{0}" to this constraint.
 
 # BuiltInCommand
 BuiltInShellCommand.locationArg_noContextWithThisName=The specified path "{0}" is not valid
@@ -181,6 +180,19 @@ PlayCommand.InvalidArgMsg_FileName=Please specify the command file name.
 PlayCommand.fileExecuted=All commands in file {0} have been executed.
 PlayCommand.Failure=Failed to execute all commands in file {0}
 PlayCommand.CommandFailure=Failed to execute the {0} command
+
+# RemoveConstraintColumnCommand
+RemoveConstraintColumnCommand.examples= \
+\t remove-column /workspace/MyVdb/MyModel/MyTable/MyColumn
+RemoveConstraintColumnCommand.usage = remove-column <column-path>
+RemoveConstraintColumnCommand.help = removes a column reference from the table constraint (i.e., primary key, unique constraint, access pattern, foreign key, or index). \n\n \
+\tNote 1: Use the "find Column" command to find the paths of columns in your workspace.\n \
+\tNote 2: You can also use tab completion to get a list of the column paths.
+RemoveConstraintColumnCommand.COLUMN_REF_REMOVED = The reference to the column at "{0}" has been removed from the table constraint "{1}".
+RemoveConstraintColumnCommand.COLUMN_PATH_NOT_FOUND = The specified column path of "{0}" cannot be found in the workspace. Use the "find Column" command to find column paths.
+RemoveConstraintColumnCommand.ERROR = Failed to remove column from the constraint.
+RemoveConstraintColumnCommand.INVALID_COLUMN_PATH = The path at "{0}" is not a path to a column.
+RemoveConstraintColumnCommand.MISSING_COLUMN_PATH_ARG = Please specify the workspace path of the column whose reference you wish to remove from this constraint.
 
 # RenameCommand
 RenameCommand.examples= \

--- a/tests/org.komodo.shell.test/resources/addColumnsToPrimaryKey.txt
+++ b/tests/org.komodo.shell.test/resources/addColumnsToPrimaryKey.txt
@@ -1,0 +1,17 @@
+create vdb MyVdb
+cd MyVdb
+
+create model MyModel
+cd MyModel
+
+create table MyTable
+cd MyTable
+
+create column column_1
+create column column_2
+
+create primarykey pk
+cd pk
+
+add-column ../column_1
+add-column ../column_2

--- a/tests/org.komodo.shell.test/resources/removeColumnFromPrimaryKey.txt
+++ b/tests/org.komodo.shell.test/resources/removeColumnFromPrimaryKey.txt
@@ -1,0 +1,19 @@
+create vdb MyVdb
+cd MyVdb
+
+create model MyModel
+cd MyModel
+
+create table MyTable
+cd MyTable
+
+create column column_1
+create column column_2
+
+create primarykey pk
+cd pk
+
+add-column ../column_1
+add-column ../column_2
+
+remove-column ../column_1

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/AbstractCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/AbstractCommandTest.java
@@ -25,6 +25,7 @@ import org.komodo.spi.constants.SystemConstants;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.repository.Repository.UnitOfWork.State;
 import org.komodo.spi.repository.RepositoryClient;
 import org.komodo.test.utils.AbstractLocalRepositoryTest;
 import org.komodo.utils.FileUtils;
@@ -155,6 +156,11 @@ public abstract class AbstractCommandTest extends AbstractLocalRepositoryTest {
         try {
             if ( !this.playCmd.execute() ) {
                 Assert.fail( "Command " + this.testedCommandClass.getName() + " execution failed.\n" + this.writer.toString() ); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+
+            // make a transaction available to tests after the playback is over
+            if ( this.uow.getState() == State.COMMITTED ) {
+                this.uow = createTransaction( "postPlaybackExecute" );
             }
         } catch ( InvalidCommandArgumentException e ) {
             Assert.fail( "Failed - invalid command: " + e.getMessage() ); //$NON-NLS-1$

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/AddConstraintColumnCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/AddConstraintColumnCommandTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.shell;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+import java.util.Arrays;
+import org.junit.Test;
+import org.komodo.relational.model.Column;
+import org.komodo.relational.model.PrimaryKey;
+import org.komodo.shell.api.WorkspaceContext;
+import org.komodo.shell.commands.core.AddConstraintColumnCommand;
+
+/**
+ * Test for the {@link AddConstraintColumnCommand}.
+ */
+@SuppressWarnings( { "javadoc", "nls" } )
+public final class AddConstraintColumnCommandTest extends AbstractCommandTest {
+
+    private static final String ADD_COLUMNS_TO_PRIMARY_KEY = "addColumnsToPrimaryKey.txt"; //$NON-NLS-1$
+
+    @Test
+    public void shouldAddColumnReferencesToPrimaryKey() throws Exception {
+        setup( ADD_COLUMNS_TO_PRIMARY_KEY, AddConstraintColumnCommand.class );
+
+        execute();
+
+        final WorkspaceContext context = this.wsStatus.getCurrentContext();
+        assertThat( context.getFullName(), is( "/workspace/MyVdb/MyModel/MyTable/pk" ) );
+        assertThat( context.getKomodoObj(), is( instanceOf( PrimaryKey.class ) ) );
+
+        final PrimaryKey pk = ( PrimaryKey )context.getKomodoObj();
+        final Column[] refCols = pk.getColumns( this.uow );
+        assertThat( refCols.length, is( 2 ) );
+
+        final String[] refColNames = new String[] { refCols[0].getName( this.uow ), refCols[1].getName( this.uow ) };
+        assertThat( Arrays.asList( refColNames ), hasItems( "column_1", "column_2" ) );
+    }
+
+}

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/AllTests.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/AllTests.java
@@ -7,9 +7,10 @@ import org.junit.runners.Suite;
  * All Tests for CommandLine
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ CdCommandTest.class, CreateCommandTest.class, DeleteCommandTest.class, ExportCommandTest.class,
-                      ImportCommandTest.class, PlayCommandTest.class, ListCommandTest.class,
-                      SetCommandTest.class, ShowCommandTest.class, UnsetCommandTest.class })
+@Suite.SuiteClasses( { AddConstraintColumnCommandTest.class, CdCommandTest.class, CreateCommandTest.class,
+                      DeleteCommandTest.class, ExportCommandTest.class, ImportCommandTest.class, ListCommandTest.class,
+                      PlayCommandTest.class, RemoveConstraintColumnCommandTest.class, SetCommandTest.class,
+                      ShowCommandTest.class, UnsetCommandTest.class } )
 public class AllTests {
     // nothing to do
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/RemoveConstraintColumnCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/RemoveConstraintColumnCommandTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.shell;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+import java.util.Arrays;
+import org.junit.Test;
+import org.komodo.relational.model.Column;
+import org.komodo.relational.model.PrimaryKey;
+import org.komodo.shell.api.WorkspaceContext;
+import org.komodo.shell.commands.core.RemoveConstraintColumnCommand;
+
+/**
+ * Test for the {@link RemoveConstraintColumnCommand}.
+ */
+@SuppressWarnings( { "javadoc", "nls" } )
+public final class RemoveConstraintColumnCommandTest extends AbstractCommandTest {
+
+    private static final String REMOVE_COLUMN_FLOM_PRIMARY_KEY = "removeColumnFromPrimaryKey.txt"; //$NON-NLS-1$
+
+    @Test
+    public void shouldRemoveColumnReferenceFromPrimaryKey() throws Exception {
+        setup( REMOVE_COLUMN_FLOM_PRIMARY_KEY, RemoveConstraintColumnCommand.class );
+
+        execute();
+
+        final WorkspaceContext context = this.wsStatus.getCurrentContext();
+        assertThat( context.getFullName(), is( "/workspace/MyVdb/MyModel/MyTable/pk" ) );
+        assertThat( context.getKomodoObj(), is( instanceOf( PrimaryKey.class ) ) );
+
+        final PrimaryKey pk = ( PrimaryKey )context.getKomodoObj();
+        final Column[] refCols = pk.getColumns( this.uow );
+        assertThat( refCols.length, is( 1 ) );
+
+        final String[] refColNames = new String[] { refCols[0].getName( this.uow ) };
+        assertThat( Arrays.asList( refColNames ), hasItem( "column_2" ) );
+    }
+
+}

--- a/tests/org.komodo.test.utils/src/org/komodo/test/utils/AbstractLocalRepositoryTest.java
+++ b/tests/org.komodo.test.utils/src/org/komodo/test/utils/AbstractLocalRepositoryTest.java
@@ -219,6 +219,11 @@ public abstract class AbstractLocalRepositoryTest extends AbstractLoggingTest im
                                         callback );
     }
 
+    protected UnitOfWork createTransaction( final String name ) throws Exception {
+        this.callback = new SynchronousCallback();
+        return createTransaction( name, this.callback );
+    }
+
     protected UnitOfWork createTransaction(SynchronousCallback callback) throws Exception {
         return this.createTransaction( this.name.getMethodName() + '-' + this.txCount++, callback );
     }


### PR DESCRIPTION
- Add RemoveConstraintColumnCommand which takes a path of a column as an argument
- fixed a bug in TableConstraintImpl that was incorrectly setting column references after removing a column
- added a way in AbstractCommandTest that tests can still use the test transaction after playback of commands