### PR TITLE
hides Model modelDefinition property by default

### DIFF
--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/ModelImpl.java
@@ -10,7 +10,9 @@ package org.komodo.relational.model.internal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import org.komodo.core.KomodoLexicon;
 import org.komodo.modeshape.visitor.DdlNodeVisitor;
+import org.komodo.relational.ExcludeQNamesFilter;
 import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.internal.AdapterFactory;
@@ -62,6 +64,11 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
                                                                       UserDefinedFunction.IDENTIFIER, View.IDENTIFIER,
                                                                       VirtualProcedure.IDENTIFIER };
 
+    /**
+     * A filter to exclude specific properties.
+     */
+    private static final Filter PROPS_FILTER = new ExcludeQNamesFilter( KomodoLexicon.VdbModel.MODEL_DEFINITION );
+    
     /**
      * The resolver of a {@link Model}.
      */
@@ -152,6 +159,12 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
                       final Repository repository,
                       final String workspacePath ) throws KException {
         super( uow, repository, workspacePath );
+        
+        // add in filter to hide the model definition type
+        final Filter[] updatedFilters = new Filter[ DEFAULT_FILTERS.length + 1 ];
+        System.arraycopy( DEFAULT_FILTERS, 0, updatedFilters, 0, DEFAULT_FILTERS.length );
+        updatedFilters[ DEFAULT_FILTERS.length ] = PROPS_FILTER;
+        setFilters( updatedFilters );
     }
 
     @Override

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -130,6 +130,7 @@ public class Messages implements StringConstants {
     public enum ExportCommand {
         InvalidArgMsgObjectName,
         InvalidArgMsgOutputFileName,
+        Failure,
         ObjectExported,
         NoContentExported,
         CannotExportObjectDoesNotExist,

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
@@ -23,6 +23,7 @@ package org.komodo.shell.commands.core;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.komodo.relational.model.Column;
@@ -146,10 +147,14 @@ public final class AddConstraintColumnCommand extends BuiltInShellCommand {
                 return -1;
             }
 
-            for ( final String path : columnPaths ) {
-                if ( ( noLastArg ) || ( path.toUpperCase().startsWith( lastArgument.toUpperCase() ) ) ) {
-                    candidates.add( path );
-                }
+            if(noLastArg) {
+            	candidates.addAll(Arrays.asList(columnPaths));
+            } else {
+            	for (String item : Arrays.asList(columnPaths)) {
+            		if (item.toUpperCase().startsWith(lastArgument.toUpperCase())) {
+            			candidates.add(item);
+            		}
+            	}
             }
 
             return 0;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ExportCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ExportCommand.java
@@ -47,8 +47,8 @@ public class ExportCommand extends BuiltInShellCommand implements StringConstant
      */
     @Override
     public boolean execute() throws Exception {
-        String objPathArg = requiredArgument(0, Messages.getString("ExportCommand.InvalidArgMsg_ObjectName")); //$NON-NLS-1$
-        String filePathArg = requiredArgument(1, Messages.getString("ExportCommand.InvalidArgMsg_OutputFileName")); //$NON-NLS-1$
+        String objPathArg = requiredArgument(0, Messages.getString(Messages.ExportCommand.InvalidArgMsgObjectName)); 
+        String filePathArg = requiredArgument(1, Messages.getString(Messages.ExportCommand.InvalidArgMsgOutputFileName));
 
         if(!validateObjectPath(objPathArg)) {
         	return false;
@@ -60,7 +60,7 @@ public class ExportCommand extends BuiltInShellCommand implements StringConstant
         try {
         	export(objPathArg, filePathArg);
         } catch (Exception e) {
-            print(CompletionConstants.MESSAGE_INDENT, Messages.getString("ExportCommand.Failure", objPathArg)); //$NON-NLS-1$
+            print(CompletionConstants.MESSAGE_INDENT, Messages.getString(Messages.ExportCommand.Failure, objPathArg));
             print(CompletionConstants.MESSAGE_INDENT, TAB + e.getMessage());
             return false;
         }
@@ -93,18 +93,18 @@ public class ExportCommand extends BuiltInShellCommand implements StringConstant
         // Get the context for export
         WorkspaceContext contextToExport = ContextUtils.getContextForPath(wsStatus, objPath);
         if (contextToExport == null)
-            throw new Exception(Messages.getString("ExportCommand.cannotExport_objectDoesNotExist", objPath)); //$NON-NLS-1$
+        	throw new Exception(Messages.getString(Messages.ExportCommand.CannotExportObjectDoesNotExist, objPath)); 
 
         KomodoObject objToExport = contextToExport.getKomodoObj();
 
         if( objToExport == null ) {
-        	throw new Exception(Messages.getString("ExportCommand.cannotExport_objectDoesNotExist", objPath)); //$NON-NLS-1$
+        	throw new Exception(Messages.getString(Messages.ExportCommand.CannotExportObjectDoesNotExist, objPath)); 
         }
 
         // Check for file location and name
         File theFile = new File(fileNameAndLocation);
         if( theFile.exists()) {
-        	throw new Exception(Messages.getString("ExportCommand.cannotExport_fileAlreadyExists", fileNameAndLocation)); //$NON-NLS-1$
+        	throw new Exception(Messages.getString(Messages.ExportCommand.CannotExportFileAlreadyExists, fileNameAndLocation)); 
         }
 
         // Check object type

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ShowCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ShowCommand.java
@@ -61,6 +61,7 @@ public class ShowCommand extends BuiltInShellCommand implements StringConstants 
     public static final String NAME = "show"; //$NON-NLS-1$
 
     private static final int DEFAULT_WIDTH = 25;
+    private static final int MAX_PROPERTY_VALUE_WIDTH = 100;  // Limit on the value column width
     private static final String SUBCMD_PROPERTIES = "properties"; //$NON-NLS-1$
 
     /**
@@ -190,6 +191,11 @@ public class ShowCommand extends BuiltInShellCommand implements StringConstants 
             }
 
             sorted.put( name, value );
+        }
+        
+        // Puts a hard limit on value column width - some may be extremely long.  (The entire value will still be printed)
+        if(maxValueWidth>MAX_PROPERTY_VALUE_WIDTH) {
+        	maxValueWidth = MAX_PROPERTY_VALUE_WIDTH;
         }
 
         // Print properties header
@@ -397,7 +403,13 @@ public class ShowCommand extends BuiltInShellCommand implements StringConstants 
 
         // Get the value for the supplied property
         final String propValue = context.getPropertyValue( propertyName );
-        final int maxValueWidth = Math.max( DEFAULT_WIDTH, propValue.length() );
+        int maxValueWidth = Math.max( DEFAULT_WIDTH, propValue.length() );
+
+        // Puts a hard limit on value column width - some may be extremely long.  (The entire value will still be printed)
+        if(maxValueWidth>MAX_PROPERTY_VALUE_WIDTH) {
+        	maxValueWidth = MAX_PROPERTY_VALUE_WIDTH;
+        }
+        
         final String format = getFormat( maxNameWidth, maxValueWidth );
 
         // Print properties header

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -103,6 +103,7 @@ ExportCommand.usage=export <object_path> <file_name>
 ExportCommand.help=exports a VDB or model to a file.
 ExportCommand.InvalidArgMsg_ObjectName=Please specify the name of the object to export.
 ExportCommand.InvalidArgMsg_OutputFileName=Please specify the file name.
+ExportCommand.Failure = Export command FAILED for "{0}".  Please ensure the object is valid, then retry.
 ExportCommand.ObjectExported=Successfully exported "{0}" to "{1}" file
 ExportCommand.NoContentExported=No content was exported from the object {0}
 ExportCommand.CannotExportObjectDoesNotExist=Cannot export. The object [{0}] does not exist
@@ -152,7 +153,7 @@ ImportCommand.InvalidArgMsg_ModelName=Please specify a model name.
 ImportCommand.ModelImportSuccessMsg=Successfully imported model {0} from file {1}.
 ImportCommand.VdbImportSuccessMsg=Successfully imported VDB from file {0}.
 ImportCommand.InvalidSubCommand=Invalid sub-command, must be "model" or "vdb".
-ImportCommand.ImportFailedMsg=Failed to import from file {0}.
+ImportCommand.ImportFailedMsg=\nFailed to import from file {0}.
 ImportCommand.childTypeNotAllowed=The object type "{0}" is not allowed as a child of "{1}".
 ImportCommand.cannotImport_wouldCreateDuplicate=Cannot import "{0}" - a "{1}" with that name already exists.
 

--- a/tests/org.komodo.shell.test/resources/importVdb7.txt
+++ b/tests/org.komodo.shell.test/resources/importVdb7.txt
@@ -1,0 +1,4 @@
+# import VDB importProps-vdb.xml
+#
+import vdb ./resources/vdbs/BQT2_ALL_TYPES_TABLE-vdb.xml
+show children

--- a/tests/org.komodo.shell.test/resources/vdbs/BQT2_ALL_TYPES_TABLE-vdb.xml
+++ b/tests/org.komodo.shell.test/resources/vdbs/BQT2_ALL_TYPES_TABLE-vdb.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<vdb name="BQT2_ALL_TYPES_TABLE" version="1">
+<description/>
+<property name="validationDateTime" value="Mon Jul 06 10:05:02 CDT 2015"/>
+<property name="validationVersion" value="8.7.1"/>
+<model name="BQT2_SQLSS2000">
+<source connection-jndi-name="BQT2_SQLSS2000" name="BQT2_SQLSS2000" translator-name="sqlserver"/>
+<metadata type="DDL"><![CDATA[
+CREATE FOREIGN TABLE ALL_TYPES (
+	type_int integer OPTIONS(NAMEINSOURCE '"type_int"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_integer integer OPTIONS(NAMEINSOURCE '"type_integer"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_smallint short OPTIONS(NAMEINSOURCE '"type_smallint"', NATIVE_TYPE 'smallint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_tinyint byte OPTIONS(NAMEINSOURCE '"type_tinyint"', NATIVE_TYPE 'tinyint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_decimal bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_decimal_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_decimal_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_double_precision float OPTIONS(NAMEINSOURCE '"type_double_precision"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_float float OPTIONS(NAMEINSOURCE '"type_float"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_float_10 float OPTIONS(NAMEINSOURCE '"type_float_10"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_numeric bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_numeric_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_numeric_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_real float OPTIONS(NAMEINSOURCE '"type_real"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_bit boolean OPTIONS(NAMEINSOURCE '"type_bit"', NATIVE_TYPE 'bit', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_character char(1) OPTIONS(NAMEINSOURCE '"type_character"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+	type_character_10 string(10) OPTIONS(NAMEINSOURCE '"type_character_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+	type_char char(1) OPTIONS(NAMEINSOURCE '"type_char"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+	type_char_10 string(10) OPTIONS(NAMEINSOURCE '"type_char_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+	type_nchar string(1) OPTIONS(NAMEINSOURCE '"type_nchar"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+	type_nchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_nchar_10"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+	type_varchar string(1) OPTIONS(NAMEINSOURCE '"type_varchar"', NATIVE_TYPE 'varchar'),
+	type_varchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_varchar_10"', NATIVE_TYPE 'varchar'),
+	type_long_nvarchar string(1) OPTIONS(NAMEINSOURCE '"type_long_nvarchar"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+	type_long_nvarchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_long_nvarchar_10"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+	type_text clob(2147483647) OPTIONS(NAMEINSOURCE '"type_text"', NATIVE_TYPE 'text', CASE_SENSITIVE false, SEARCHABLE 'LIKE_ONLY'),
+	type_money bigdecimal OPTIONS(NAMEINSOURCE '"type_money"', NATIVE_TYPE 'money', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_smallmoney bigdecimal OPTIONS(NAMEINSOURCE '"type_smallmoney"', NATIVE_TYPE 'smallmoney', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_datetime timestamp OPTIONS(NAMEINSOURCE '"type_datetime"', NATIVE_TYPE 'datetime', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+	type_binary object(1) OPTIONS(NAMEINSOURCE '"type_binary"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+	type_binary_2 object(2) OPTIONS(NAMEINSOURCE '"type_binary_2"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+	type_image blob(2147483647) OPTIONS(NAMEINSOURCE '"type_image"', NATIVE_TYPE 'image', CASE_SENSITIVE false, SEARCHABLE 'UNSEARCHABLE'),
+	type_varbinary string(0) OPTIONS(NAMEINSOURCE '"type_varbinary"', NATIVE_TYPE 'varbinary', CASE_SENSITIVE false, SEARCHABLE 'ALL_EXCEPT_LIKE')
+) OPTIONS(NAMEINSOURCE '"bqt2"."BQT2"."ALL_TYPES"')
+
+]]></metadata>
+</model>
+</vdb>

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/ImportCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/ImportCommandTest.java
@@ -32,6 +32,7 @@ public class ImportCommandTest extends AbstractCommandTest {
 	private static final String IMPORT_VDB4 = "importVdb4.txt"; 
 	private static final String IMPORT_VDB5 = "importVdb5.txt"; 
 	private static final String IMPORT_VDB6 = "importVdb6.txt"; 
+	private static final String IMPORT_VDB7 = "importVdb7.txt"; 
 
 	/**
 	 * Test for CreateCommand
@@ -391,5 +392,250 @@ public class ImportCommandTest extends AbstractCommandTest {
 //			assertThat(theModelSource.getTranslatorName(trans), is("salesforce"));
 //			assertThat(theModelSource.getJndiName(trans), is("java:/SalesforceDS"));
 //		}
+    }
+    
+    /**
+     * Import VDB7 - BQT2_ALL_TYPES_TABLE-vdb.xml
+     * @throws Exception
+     */
+    @Test
+    public void testImportVdb7() throws Exception {
+    	setup(IMPORT_VDB7, ImportCommand.class);
+
+//    	execute();
+//
+//    	assertEquals("/workspace", wsStatus.getCurrentContext().getFullName()); 
+//
+//    	WorkspaceContext vdbContext = ContextUtils.getContextForPath(wsStatus, "/workspace/BQT2_ALL_TYPES_TABLE"); 
+//    	assertNotNull(vdbContext);
+//
+//    	KomodoObject ko = vdbContext.getKomodoObj();
+//    	UnitOfWork trans = wsStatus.getTransaction();
+//    	
+//    	// Verify the komodo class is a Vdb and is VDB type
+//    	assertEquals(KomodoType.VDB.name(), ko.getTypeIdentifier(trans).name());
+//
+//    	Vdb vdb = (Vdb)resolveType(trans, ko, Vdb.class);
+//    	
+//        // Check VDB version
+//        assertThat(vdb.getVersion(trans), is(1));
+//
+//    	// Check VDB connectionType property
+//    	Property prop = vdb.getProperty(trans, "vdb:connectionType");
+//    	String connectionValue = prop.getStringValue(trans);
+//        assertEquals("BY_VERSION", connectionValue);
+//    	
+//        // Check validationDateTime property
+//    	prop = vdb.getProperty(trans, "validationDateTime");
+//    	String dtValue = prop.getStringValue(trans);
+//        assertEquals("Mon Jul 06 10:05:02 CDT 2015", dtValue);
+//
+//        // Check validationVersion property
+//    	prop = vdb.getProperty(trans, "validationVersion");
+//    	String validationVersionValue = prop.getStringValue(trans);
+//        assertEquals("8.7.1", validationVersionValue);
+//        
+//        
+//		{ // Check model
+//			final Model[] models = vdb.getModels(trans);
+//			assertThat(models.length, is(1));
+//			
+//			final Model theModel = models[0];
+//			assertThat(theModel.getName(trans), is("BQT2_SQLSS2000"));
+//			assertThat(theModel.getModelType(trans), is(Model.Type.PHYSICAL));
+//			
+//			// Check model source
+//			ModelSource[] modelSources = theModel.getSources(trans);
+//			assertThat(modelSources.length, is(1));
+//			ModelSource theModelSource = modelSources[0];
+//			assertThat(theModelSource.getTranslatorName(trans), is("sqlserver"));
+//			assertThat(theModelSource.getJndiName(trans), is("BQT2_SQLSS2000"));
+//			
+//			Table[] tables = theModel.getTables(trans);
+//			assertThat(tables.length, is(1));
+//			Table theTable = tables[0];
+//			assertThat(theTable.getName(trans), is("ALL_TYPES"));
+//			String nis = theTable.getNameInSource(trans);
+//			assertThat(nis, is("\"bqt2\".\"BQT2\".\"ALL_TYPES\""));
+//			
+//			Column[] columns = theTable.getColumns(trans);
+//			assertThat(columns.length, is(33));
+//
+//			// check column names
+//			assertThat(columns[0].getName(trans),is("type_int"));  //type_int integer OPTIONS(NAMEINSOURCE '"type_int"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[1].getName(trans),is("type_integer"));  //type_integer integer OPTIONS(NAMEINSOURCE '"type_integer"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[2].getName(trans),is("type_smallint"));  //type_smallint short OPTIONS(NAMEINSOURCE '"type_smallint"', NATIVE_TYPE 'smallint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[3].getName(trans),is("type_tinyint"));  //type_tinyint byte OPTIONS(NAMEINSOURCE '"type_tinyint"', NATIVE_TYPE 'tinyint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[4].getName(trans),is("type_decimal"));  //type_decimal bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[5].getName(trans),is("type_decimal_5"));  //type_decimal_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[6].getName(trans),is("type_decimal_5_5"));  //type_decimal_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[7].getName(trans),is("type_double_precision"));  //type_double_precision float OPTIONS(NAMEINSOURCE '"type_double_precision"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[8].getName(trans),is("type_float"));  //type_float float OPTIONS(NAMEINSOURCE '"type_float"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[9].getName(trans),is("type_float_10"));  //type_float_10 float OPTIONS(NAMEINSOURCE '"type_float_10"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[10].getName(trans),is("type_numeric"));  //type_numeric bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[11].getName(trans),is("type_numeric_5"));  //type_numeric_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[12].getName(trans),is("type_numeric_5_5"));  //type_numeric_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[13].getName(trans),is("type_real"));  //type_real float OPTIONS(NAMEINSOURCE '"type_real"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[14].getName(trans),is("type_bit"));  //type_bit boolean OPTIONS(NAMEINSOURCE '"type_bit"', NATIVE_TYPE 'bit', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[15].getName(trans),is("type_character"));  //type_character char(1) OPTIONS(NAMEINSOURCE '"type_character"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[16].getName(trans),is("type_character_10"));  //type_character_10 string(10) OPTIONS(NAMEINSOURCE '"type_character_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[17].getName(trans),is("type_char"));  //type_char char(1) OPTIONS(NAMEINSOURCE '"type_char"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[18].getName(trans),is("type_char_10"));  //type_char_10 string(10) OPTIONS(NAMEINSOURCE '"type_char_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[19].getName(trans),is("type_nchar"));  //type_nchar string(1) OPTIONS(NAMEINSOURCE '"type_nchar"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[20].getName(trans),is("type_nchar_10"));  //type_nchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_nchar_10"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[21].getName(trans),is("type_varchar"));  //type_varchar string(1) OPTIONS(NAMEINSOURCE '"type_varchar"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[22].getName(trans),is("type_varchar_10"));  //type_varchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_varchar_10"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[23].getName(trans),is("type_long_nvarchar"));  //type_long_nvarchar string(1) OPTIONS(NAMEINSOURCE '"type_long_nvarchar"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[24].getName(trans),is("type_long_nvarchar_10"));  //type_long_nvarchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_long_nvarchar_10"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[25].getName(trans),is("type_text"));  //type_text clob(2147483647) OPTIONS(NAMEINSOURCE '"type_text"', NATIVE_TYPE 'text', CASE_SENSITIVE false, SEARCHABLE 'LIKE_ONLY'),
+//			assertThat(columns[26].getName(trans),is("type_money"));  //type_money bigdecimal OPTIONS(NAMEINSOURCE '"type_money"', NATIVE_TYPE 'money', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[27].getName(trans),is("type_smallmoney"));  //type_smallmoney bigdecimal OPTIONS(NAMEINSOURCE '"type_smallmoney"', NATIVE_TYPE 'smallmoney', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[28].getName(trans),is("type_datetime"));  //type_datetime timestamp OPTIONS(NAMEINSOURCE '"type_datetime"', NATIVE_TYPE 'datetime', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[29].getName(trans),is("type_binary"));  //type_binary object(1) OPTIONS(NAMEINSOURCE '"type_binary"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[30].getName(trans),is("type_binary_2"));  //type_binary_2 object(2) OPTIONS(NAMEINSOURCE '"type_binary_2"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[31].getName(trans),is("type_image"));  //type_image blob(2147483647) OPTIONS(NAMEINSOURCE '"type_image"', NATIVE_TYPE 'image', CASE_SENSITIVE false, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[32].getName(trans),is("type_varbinary"));  //type_varbinary string(0) OPTIONS(NAMEINSOURCE '"type_varbinary"', NATIVE_TYPE 'varbinary', CASE_SENSITIVE false, SEARCHABLE 'ALL_EXCEPT_LIKE')
+//			
+//			// check column name in source
+//			assertThat(columns[0].getNameInSource(trans),is("\"type_int\""));  //type_int integer OPTIONS(NAMEINSOURCE '"type_int"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[1].getNameInSource(trans),is("\"type_integer\""));  //type_integer integer OPTIONS(NAMEINSOURCE '"type_integer"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[2].getNameInSource(trans),is("\"type_smallint\""));  //type_smallint short OPTIONS(NAMEINSOURCE '"type_smallint"', NATIVE_TYPE 'smallint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[3].getNameInSource(trans),is("\"type_tinyint\""));  //type_tinyint byte OPTIONS(NAMEINSOURCE '"type_tinyint"', NATIVE_TYPE 'tinyint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[4].getNameInSource(trans),is("\"type_decimal\""));  //type_decimal bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[5].getNameInSource(trans),is("\"type_decimal_5\""));  //type_decimal_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[6].getNameInSource(trans),is("\"type_decimal_5_5\""));  //type_decimal_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[7].getNameInSource(trans),is("\"type_double_precision\""));  //type_double_precision float OPTIONS(NAMEINSOURCE '"type_double_precision"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[8].getNameInSource(trans),is("\"type_float\""));  //type_float float OPTIONS(NAMEINSOURCE '"type_float"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[9].getNameInSource(trans),is("\"type_float_10\""));  //type_float_10 float OPTIONS(NAMEINSOURCE '"type_float_10"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[10].getNameInSource(trans),is("\"type_numeric\""));  //type_numeric bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[11].getNameInSource(trans),is("\"type_numeric_5\""));  //type_numeric_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[12].getNameInSource(trans),is("\"type_numeric_5_5\""));  //type_numeric_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[13].getNameInSource(trans),is("\"type_real\""));  //type_real float OPTIONS(NAMEINSOURCE '"type_real"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[14].getNameInSource(trans),is("\"type_bit\""));  //type_bit boolean OPTIONS(NAMEINSOURCE '"type_bit"', NATIVE_TYPE 'bit', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[15].getNameInSource(trans),is("\"type_character\""));  //type_character char(1) OPTIONS(NAMEINSOURCE '"type_character"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[16].getNameInSource(trans),is("\"type_character_10\""));  //type_character_10 string(10) OPTIONS(NAMEINSOURCE '"type_character_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[17].getNameInSource(trans),is("\"type_char\""));  //type_char char(1) OPTIONS(NAMEINSOURCE '"type_char"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[18].getNameInSource(trans),is("\"type_char_10\""));  //type_char_10 string(10) OPTIONS(NAMEINSOURCE '"type_char_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[19].getNameInSource(trans),is("\"type_nchar\""));  //type_nchar string(1) OPTIONS(NAMEINSOURCE '"type_nchar"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[20].getNameInSource(trans),is("\"type_nchar_10\""));  //type_nchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_nchar_10"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[21].getNameInSource(trans),is("\"type_varchar\""));  //type_varchar string(1) OPTIONS(NAMEINSOURCE '"type_varchar"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[22].getNameInSource(trans),is("\"type_varchar_10\""));  //type_varchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_varchar_10"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[23].getNameInSource(trans),is("\"type_long_nvarchar\""));  //type_long_nvarchar string(1) OPTIONS(NAMEINSOURCE '"type_long_nvarchar"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[24].getNameInSource(trans),is("\"type_long_nvarchar_10\""));  //type_long_nvarchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_long_nvarchar_10"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[25].getNameInSource(trans),is("\"type_text\""));  //type_text clob(2147483647) OPTIONS(NAMEINSOURCE '"type_text"', NATIVE_TYPE 'text', CASE_SENSITIVE false, SEARCHABLE 'LIKE_ONLY'),
+//			assertThat(columns[26].getNameInSource(trans),is("\"type_money\""));  //type_money bigdecimal OPTIONS(NAMEINSOURCE '"type_money"', NATIVE_TYPE 'money', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[27].getNameInSource(trans),is("\"type_smallmoney\""));  //type_smallmoney bigdecimal OPTIONS(NAMEINSOURCE '"type_smallmoney"', NATIVE_TYPE 'smallmoney', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[28].getNameInSource(trans),is("\"type_datetime\""));  //type_datetime timestamp OPTIONS(NAMEINSOURCE '"type_datetime"', NATIVE_TYPE 'datetime', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[29].getNameInSource(trans),is("\"type_binary\""));  //type_binary object(1) OPTIONS(NAMEINSOURCE '"type_binary"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[30].getNameInSource(trans),is("\"type_binary_2\""));  //type_binary_2 object(2) OPTIONS(NAMEINSOURCE '"type_binary_2"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[31].getNameInSource(trans),is("\"type_image\""));  //type_image blob(2147483647) OPTIONS(NAMEINSOURCE '"type_image"', NATIVE_TYPE 'image', CASE_SENSITIVE false, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[32].getNameInSource(trans),is("\"type_varbinary\""));  //type_varbinary string(0) OPTIONS(NAMEINSOURCE '"type_varbinary"', NATIVE_TYPE 'varbinary', CASE_SENSITIVE false, SEARCHABLE 'ALL_EXCEPT_LIKE')
+//
+//			// check datatype names
+//			assertThat(columns[0].getDatatypeName(trans).toLowerCase(), is("integer"));  //type_int integer OPTIONS(NAMEINSOURCE '"type_int"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[1].getDatatypeName(trans).toLowerCase(), is("integer"));  //type_integer integer OPTIONS(NAMEINSOURCE '"type_integer"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[2].getDatatypeName(trans).toLowerCase(), is("short"));  //type_smallint short OPTIONS(NAMEINSOURCE '"type_smallint"', NATIVE_TYPE 'smallint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[3].getDatatypeName(trans).toLowerCase(), is("byte"));  //type_tinyint byte OPTIONS(NAMEINSOURCE '"type_tinyint"', NATIVE_TYPE 'tinyint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[4].getDatatypeName(trans).toLowerCase(), is("bigdecimal"));  //type_decimal bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[5].getDatatypeName(trans).toLowerCase(), is("bigdecimal"));  //type_decimal_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[6].getDatatypeName(trans).toLowerCase(), is("bigdecimal"));  //type_decimal_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[7].getDatatypeName(trans).toLowerCase(), is("float"));  //type_double_precision float OPTIONS(NAMEINSOURCE '"type_double_precision"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[8].getDatatypeName(trans).toLowerCase(), is("float"));  //type_float float OPTIONS(NAMEINSOURCE '"type_float"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[9].getDatatypeName(trans).toLowerCase(), is("float"));  //type_float_10 float OPTIONS(NAMEINSOURCE '"type_float_10"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[10].getDatatypeName(trans).toLowerCase(), is("bigdecimal"));  //type_numeric bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[11].getDatatypeName(trans).toLowerCase(), is("bigdecimal"));  //type_numeric_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[12].getDatatypeName(trans).toLowerCase(), is("bigdecimal"));  //type_numeric_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[13].getDatatypeName(trans).toLowerCase(), is("float"));  //type_real float OPTIONS(NAMEINSOURCE '"type_real"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[14].getDatatypeName(trans).toLowerCase(), is("boolean"));  //type_bit boolean OPTIONS(NAMEINSOURCE '"type_bit"', NATIVE_TYPE 'bit', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[15].getDatatypeName(trans).toLowerCase(), is("char"));  //type_character char(1) OPTIONS(NAMEINSOURCE '"type_character"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[16].getDatatypeName(trans).toLowerCase(), is("string"));  //type_character_10 string(10) OPTIONS(NAMEINSOURCE '"type_character_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[17].getDatatypeName(trans).toLowerCase(), is("char"));  //type_char char(1) OPTIONS(NAMEINSOURCE '"type_char"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[18].getDatatypeName(trans).toLowerCase(), is("string"));  //type_char_10 string(10) OPTIONS(NAMEINSOURCE '"type_char_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[19].getDatatypeName(trans).toLowerCase(), is("string"));  //type_nchar string(1) OPTIONS(NAMEINSOURCE '"type_nchar"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[20].getDatatypeName(trans).toLowerCase(), is("string"));  //type_nchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_nchar_10"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[21].getDatatypeName(trans).toLowerCase(), is("string"));  //type_varchar string(1) OPTIONS(NAMEINSOURCE '"type_varchar"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[22].getDatatypeName(trans).toLowerCase(), is("string"));  //type_varchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_varchar_10"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[23].getDatatypeName(trans).toLowerCase(), is("string"));  //type_long_nvarchar string(1) OPTIONS(NAMEINSOURCE '"type_long_nvarchar"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[24].getDatatypeName(trans).toLowerCase(), is("string"));  //type_long_nvarchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_long_nvarchar_10"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[25].getDatatypeName(trans).toLowerCase(), is("clob"));  //type_text clob(2147483647) OPTIONS(NAMEINSOURCE '"type_text"', NATIVE_TYPE 'text', CASE_SENSITIVE false, SEARCHABLE 'LIKE_ONLY'),
+//			assertThat(columns[26].getDatatypeName(trans).toLowerCase(), is("bigdecimal"));  //type_money bigdecimal OPTIONS(NAMEINSOURCE '"type_money"', NATIVE_TYPE 'money', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[27].getDatatypeName(trans).toLowerCase(), is("bigdecimal"));  //type_smallmoney bigdecimal OPTIONS(NAMEINSOURCE '"type_smallmoney"', NATIVE_TYPE 'smallmoney', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[28].getDatatypeName(trans).toLowerCase(), is("timestamp"));  //type_datetime timestamp OPTIONS(NAMEINSOURCE '"type_datetime"', NATIVE_TYPE 'datetime', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[29].getDatatypeName(trans).toLowerCase(), is("object"));  //type_binary object(1) OPTIONS(NAMEINSOURCE '"type_binary"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[30].getDatatypeName(trans).toLowerCase(), is("object"));  //type_binary_2 object(2) OPTIONS(NAMEINSOURCE '"type_binary_2"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[31].getDatatypeName(trans).toLowerCase(), is("blob"));  //type_image blob(2147483647) OPTIONS(NAMEINSOURCE '"type_image"', NATIVE_TYPE 'image', CASE_SENSITIVE false, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[32].getDatatypeName(trans).toLowerCase(), is("string"));  //type_varbinary string(0) OPTIONS(NAMEINSOURCE '"type_varbinary"', NATIVE_TYPE 'varbinary', CASE_SENSITIVE false, SEARCHABLE 'ALL_EXCEPT_LIKE')
+//
+//			// check native types
+//			assertThat(columns[0].getNativeType(trans).toLowerCase(), is("int"));  //type_int integer OPTIONS(NAMEINSOURCE '"type_int"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[1].getNativeType(trans).toLowerCase(), is("int"));  //type_integer integer OPTIONS(NAMEINSOURCE '"type_integer"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[2].getNativeType(trans).toLowerCase(), is("smallint"));  //type_smallint short OPTIONS(NAMEINSOURCE '"type_smallint"', NATIVE_TYPE 'smallint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[3].getNativeType(trans).toLowerCase(), is("tinyint"));  //type_tinyint byte OPTIONS(NAMEINSOURCE '"type_tinyint"', NATIVE_TYPE 'tinyint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[4].getNativeType(trans).toLowerCase(), is("decimal"));  //type_decimal bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[5].getNativeType(trans).toLowerCase(), is("decimal"));  //type_decimal_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[6].getNativeType(trans).toLowerCase(), is("decimal"));  //type_decimal_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[7].getNativeType(trans).toLowerCase(), is("float"));  //type_double_precision float OPTIONS(NAMEINSOURCE '"type_double_precision"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[8].getNativeType(trans).toLowerCase(), is("float"));  //type_float float OPTIONS(NAMEINSOURCE '"type_float"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[9].getNativeType(trans).toLowerCase(), is("real"));  //type_float_10 float OPTIONS(NAMEINSOURCE '"type_float_10"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[10].getNativeType(trans).toLowerCase(), is("numeric"));  //type_numeric bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[11].getNativeType(trans).toLowerCase(), is("numeric"));  //type_numeric_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[12].getNativeType(trans).toLowerCase(), is("numeric"));  //type_numeric_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[13].getNativeType(trans).toLowerCase(), is("real"));  //type_real float OPTIONS(NAMEINSOURCE '"type_real"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[14].getNativeType(trans).toLowerCase(), is("bit"));  //type_bit boolean OPTIONS(NAMEINSOURCE '"type_bit"', NATIVE_TYPE 'bit', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[15].getNativeType(trans).toLowerCase(), is("char"));  //type_character char(1) OPTIONS(NAMEINSOURCE '"type_character"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[16].getNativeType(trans).toLowerCase(), is("char"));  //type_character_10 string(10) OPTIONS(NAMEINSOURCE '"type_character_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[17].getNativeType(trans).toLowerCase(), is("char"));  //type_char char(1) OPTIONS(NAMEINSOURCE '"type_char"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[18].getNativeType(trans).toLowerCase(), is("char"));  //type_char_10 string(10) OPTIONS(NAMEINSOURCE '"type_char_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[19].getNativeType(trans).toLowerCase(), is("nchar"));  //type_nchar string(1) OPTIONS(NAMEINSOURCE '"type_nchar"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[20].getNativeType(trans).toLowerCase(), is("nchar"));  //type_nchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_nchar_10"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[21].getNativeType(trans).toLowerCase(), is("varchar"));  //type_varchar string(1) OPTIONS(NAMEINSOURCE '"type_varchar"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[22].getNativeType(trans).toLowerCase(), is("varchar"));  //type_varchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_varchar_10"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[23].getNativeType(trans).toLowerCase(), is("nvarchar"));  //type_long_nvarchar string(1) OPTIONS(NAMEINSOURCE '"type_long_nvarchar"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[24].getNativeType(trans).toLowerCase(), is("nvarchar"));  //type_long_nvarchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_long_nvarchar_10"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[25].getNativeType(trans).toLowerCase(), is("text"));  //type_text clob(2147483647) OPTIONS(NAMEINSOURCE '"type_text"', NATIVE_TYPE 'text', CASE_SENSITIVE false, SEARCHABLE 'LIKE_ONLY'),
+//			assertThat(columns[26].getNativeType(trans).toLowerCase(), is("money"));  //type_money bigdecimal OPTIONS(NAMEINSOURCE '"type_money"', NATIVE_TYPE 'money', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[27].getNativeType(trans).toLowerCase(), is("smallmoney"));  //type_smallmoney bigdecimal OPTIONS(NAMEINSOURCE '"type_smallmoney"', NATIVE_TYPE 'smallmoney', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[28].getNativeType(trans).toLowerCase(), is("datetime"));  //type_datetime timestamp OPTIONS(NAMEINSOURCE '"type_datetime"', NATIVE_TYPE 'datetime', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[29].getNativeType(trans).toLowerCase(), is("binary"));  //type_binary object(1) OPTIONS(NAMEINSOURCE '"type_binary"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[30].getNativeType(trans).toLowerCase(), is("binary"));  //type_binary_2 object(2) OPTIONS(NAMEINSOURCE '"type_binary_2"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[31].getNativeType(trans).toLowerCase(), is("image"));  //type_image blob(2147483647) OPTIONS(NAMEINSOURCE '"type_image"', NATIVE_TYPE 'image', CASE_SENSITIVE false, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[32].getNativeType(trans).toLowerCase(), is("varbinary"));  //type_varbinary string(0) OPTIONS(NAMEINSOURCE '"type_varbinary"', NATIVE_TYPE 'varbinary', CASE_SENSITIVE false, SEARCHABLE 'ALL_EXCEPT_LIKE')
+//
+//			// check lengths
+//			assertThat(columns[0].getLength(trans), is(Long.valueOf(0)));  //type_int integer OPTIONS(NAMEINSOURCE '"type_int"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[1].getLength(trans), is(Long.valueOf(0)));  //type_integer integer OPTIONS(NAMEINSOURCE '"type_integer"', NATIVE_TYPE 'int', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[2].getLength(trans), is(Long.valueOf(0)));  //type_smallint short OPTIONS(NAMEINSOURCE '"type_smallint"', NATIVE_TYPE 'smallint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[3].getLength(trans), is(Long.valueOf(0)));  //type_tinyint byte OPTIONS(NAMEINSOURCE '"type_tinyint"', NATIVE_TYPE 'tinyint', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[4].getLength(trans), is(Long.valueOf(0)));  //type_decimal bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[5].getLength(trans), is(Long.valueOf(0)));  //type_decimal_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[6].getLength(trans), is(Long.valueOf(0)));  //type_decimal_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_decimal_5_5"', NATIVE_TYPE 'decimal', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[7].getLength(trans), is(Long.valueOf(0)));  //type_double_precision float OPTIONS(NAMEINSOURCE '"type_double_precision"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[8].getLength(trans), is(Long.valueOf(0)));  //type_float float OPTIONS(NAMEINSOURCE '"type_float"', NATIVE_TYPE 'float', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[9].getLength(trans), is(Long.valueOf(0)));  //type_float_10 float OPTIONS(NAMEINSOURCE '"type_float_10"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[10].getLength(trans), is(Long.valueOf(0)));  //type_numeric bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[11].getLength(trans), is(Long.valueOf(0)));  //type_numeric_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[12].getLength(trans), is(Long.valueOf(0)));  //type_numeric_5_5 bigdecimal OPTIONS(NAMEINSOURCE '"type_numeric_5_5"', NATIVE_TYPE 'numeric', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[13].getLength(trans), is(Long.valueOf(0)));  //type_real float OPTIONS(NAMEINSOURCE '"type_real"', NATIVE_TYPE 'real', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[14].getLength(trans), is(Long.valueOf(0)));  //type_bit boolean OPTIONS(NAMEINSOURCE '"type_bit"', NATIVE_TYPE 'bit', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[15].getLength(trans), is(Long.valueOf(1)));  //type_character char(1) OPTIONS(NAMEINSOURCE '"type_character"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[16].getLength(trans), is(Long.valueOf(10)));  //type_character_10 string(10) OPTIONS(NAMEINSOURCE '"type_character_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[17].getLength(trans), is(Long.valueOf(1)));  //type_char char(1) OPTIONS(NAMEINSOURCE '"type_char"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[18].getLength(trans), is(Long.valueOf(10)));  //type_char_10 string(10) OPTIONS(NAMEINSOURCE '"type_char_10"', NATIVE_TYPE 'char', FIXED_LENGTH true),
+//			assertThat(columns[19].getLength(trans), is(Long.valueOf(1)));  //type_nchar string(1) OPTIONS(NAMEINSOURCE '"type_nchar"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[20].getLength(trans), is(Long.valueOf(10)));  //type_nchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_nchar_10"', NATIVE_TYPE 'nchar', FIXED_LENGTH true),
+//			assertThat(columns[21].getLength(trans), is(Long.valueOf(1)));  //type_varchar string(1) OPTIONS(NAMEINSOURCE '"type_varchar"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[22].getLength(trans), is(Long.valueOf(10)));  //type_varchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_varchar_10"', NATIVE_TYPE 'varchar'),
+//			assertThat(columns[23].getLength(trans), is(Long.valueOf(1)));  //type_long_nvarchar string(1) OPTIONS(NAMEINSOURCE '"type_long_nvarchar"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[24].getLength(trans), is(Long.valueOf(10)));  //type_long_nvarchar_10 string(10) OPTIONS(NAMEINSOURCE '"type_long_nvarchar_10"', NATIVE_TYPE 'nvarchar', FIXED_LENGTH true),
+//			assertThat(columns[25].getLength(trans), is(Long.valueOf(2147483647)));  //type_text clob(2147483647) OPTIONS(NAMEINSOURCE '"type_text"', NATIVE_TYPE 'text', CASE_SENSITIVE false, SEARCHABLE 'LIKE_ONLY'),
+//			assertThat(columns[26].getLength(trans), is(Long.valueOf(0)));  //type_money bigdecimal OPTIONS(NAMEINSOURCE '"type_money"', NATIVE_TYPE 'money', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[27].getLength(trans), is(Long.valueOf(0)));  //type_smallmoney bigdecimal OPTIONS(NAMEINSOURCE '"type_smallmoney"', NATIVE_TYPE 'smallmoney', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[28].getLength(trans), is(Long.valueOf(0)));  //type_datetime timestamp OPTIONS(NAMEINSOURCE '"type_datetime"', NATIVE_TYPE 'datetime', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'ALL_EXCEPT_LIKE'),
+//			assertThat(columns[29].getLength(trans), is(Long.valueOf(1)));  //type_binary object(1) OPTIONS(NAMEINSOURCE '"type_binary"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[30].getLength(trans), is(Long.valueOf(2)));  //type_binary_2 object(2) OPTIONS(NAMEINSOURCE '"type_binary_2"', NATIVE_TYPE 'binary', CASE_SENSITIVE false, FIXED_LENGTH true, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[31].getLength(trans), is(Long.valueOf(2147483647)));  //type_image blob(2147483647) OPTIONS(NAMEINSOURCE '"type_image"', NATIVE_TYPE 'image', CASE_SENSITIVE false, SEARCHABLE 'UNSEARCHABLE'),
+//			assertThat(columns[32].getLength(trans), is(Long.valueOf(0)));  //type_varbinary string(0) OPTIONS(NAMEINSOURCE '"type_varbinary"', NATIVE_TYPE 'varbinary', CASE_SENSITIVE false, SEARCHABLE 'ALL_EXCEPT_LIKE')
+//		}
+		
     }
 }


### PR DESCRIPTION
- modelDefinition property is now hidden by default
- now setting max value column width in ShowCommand
- minor fixes to messages in ExportCommand 
- added another import unit test (BQT table with all types) 