### PR TITLE
improve playCommand messages

### DIFF
--- a/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
@@ -307,6 +307,30 @@ public abstract class BuiltInShellCommand extends AbstractShellCommand {
     	}
         return true;
     }
+    
+	/**
+	 * Validates that the supplied path argument is a readable file.
+	 * @param filePathArg the path to test
+	 * @return 'true' if the path is valid readable file, 'false' if not.
+	 */
+	public boolean validateReadableFileArg(String filePathArg) {
+		String filePath = filePathArg.trim();
+
+        // Check the fileName arg validity
+        File theFile = new File(filePath);
+        if(!theFile.exists()) {
+        	print(CompletionConstants.MESSAGE_INDENT, Messages.getString("BuiltInShellCommand.FileNotFound", filePath)); //$NON-NLS-1$
+        	return false;
+        } else if(!theFile.isFile()) {
+        	print(CompletionConstants.MESSAGE_INDENT, Messages.getString("BuiltInShellCommand.FileArgNotAFile", filePath)); //$NON-NLS-1$
+        	return false;
+        } else if(!theFile.canRead()) {
+        	print(CompletionConstants.MESSAGE_INDENT, Messages.getString("BuiltInShellCommand.FileNotReadable", filePath)); //$NON-NLS-1$
+        	return false;
+        }
+        
+		return true;
+	}
 
 	/**
 	 * Validates whether the supplied path is valid.  If the path is relative this takes into account the

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/PlayCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/PlayCommand.java
@@ -42,6 +42,10 @@ public class PlayCommand  extends BuiltInShellCommand implements StringConstants
 	public boolean execute() throws Exception {
         String fileNameArg = requiredArgument(0, Messages.getString("PlayCommand.InvalidArgMsg_FileName")); //$NON-NLS-1$
 
+        // Validate the supplied path
+        boolean validFile = validateReadableFileArg(fileNameArg);
+        if(!validFile) return false;
+        
         try {
         	playFile(fileNameArg);
             print(CompletionConstants.MESSAGE_INDENT, Messages.getString("PlayCommand.fileExecuted", fileNameArg)); //$NON-NLS-1$

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -20,6 +20,9 @@ BuiltInShellCommand.propertyArg_noPropertyWithThisName=The property "{0}" is not
 BuiltInShellCommand.locationArg_empty=path arg is empty.
 BuiltInShellCommand.typeArg_childTypeNotAllowed=The object type "{0}" is invalid, or not allowed as a child of "{1}".
 BuiltInShellCommand.objectNameNotValid=The name "{0}" is not valid
+BuiltInShellCommand.FileNotFound=The specified file "{0}" was not found.
+BuiltInShellCommand.FileArgNotAFile=The specified file argument "{0}" is not a file.
+BuiltInShellCommand.FileCannotRead=Cannot read the specified file "{0}".
 
 # CdCommand
 CdCommand.examples= \


### PR DESCRIPTION
- adds readable file validation method to BuiltInShellCommand.
- utilize the method in the PlayCommand, to check for readable file existence.