### PR TITLE
adds create property to CreateCommand

### DIFF
--- a/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
@@ -378,11 +378,13 @@ public abstract class BuiltInShellCommand extends AbstractShellCommand {
 	 * If invalid an error message is printed out.
 	 * @param propName the property name
 	 * @param context the workspace context
+	 * @param printMessage specify whether output message printed
 	 * @return 'true' if the property is valid for the context, 'false' if not.
 	 * @exception Exception the exception
 	 */
     public boolean validateProperty( final String propName,
-                                     final WorkspaceContext context ) throws Exception {
+                                     final WorkspaceContext context,
+                                     final boolean printMessage) throws Exception {
         if ( !StringUtils.isEmpty( propName ) ) {
             final List< String > propNames = context.getProperties();
 
@@ -390,9 +392,11 @@ public abstract class BuiltInShellCommand extends AbstractShellCommand {
                  || ( !isShowingPropertyNamePrefixes() && propNames.contains( attachPrefix( context, propName ) ) ) ) {
                 return true;
             }
-
-            print( CompletionConstants.MESSAGE_INDENT,
-                   Messages.getString( "BuiltInShellCommand.propertyArg_noPropertyWithThisName", propName ) ); //$NON-NLS-1$
+            
+            if(printMessage) {
+            	print( CompletionConstants.MESSAGE_INDENT,
+            			Messages.getString( "BuiltInShellCommand.propertyArg_noPropertyWithThisName", propName ) ); //$NON-NLS-1$
+            }
         }
 
         return false;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -110,9 +110,13 @@ public class Messages implements StringConstants {
         MISSING_OBJ_NAME,
         MISSING_OBJ_TYPE,
         MISSING_OPTION_VALUE,
+        MISSING_PROPERTY_NAME,
+        MISSING_PROPERTY_VALUE,
+        PROPERTY_ALREADY_EXISTS,
         MISSING_TRANSLATOR_TYPE,
         NO_DUPLICATES_ALLOWED,
         OBJECT_CREATED,
+        PROPERTY_CREATED,
         PATH_NOT_FOUND,
         TOO_MANY_ARGS,
         TYPE_NOT_VALID;
@@ -129,6 +133,15 @@ public class Messages implements StringConstants {
         NotConnected,
         PingOk,
         PingFail;
+
+        @Override
+        public String toString() {
+            return getEnumName(this) + DOT + name();
+        }
+    }
+
+    public enum SetCommand {
+        TOO_MANY_ARGS;
 
         @Override
         public String toString() {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/SetCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/SetCommand.java
@@ -9,6 +9,8 @@ package org.komodo.shell.commands.core;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
 import static org.komodo.shell.CompletionConstants.NO_APPEND_SEPARATOR;
+import static org.komodo.shell.Messages.SetCommand.TOO_MANY_ARGS;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Date;
@@ -72,6 +74,11 @@ public class SetCommand extends BuiltInShellCommand {
         		// path is optional.  if path is not included, current context is assumed.
         		String pathArg = optionalArgument(3);
 
+                // check for too many args
+                if ( getArguments().size() > 4 ) {
+                    throw new Exception( Messages.getString( TOO_MANY_ARGS, subcmdArg ) );
+                }
+                
                 // Validates SET PROPERTY args
                 if (!validateSetProperty(propNameArg,propValueArg,pathArg)) {
         			return false;
@@ -184,26 +191,26 @@ public class SetCommand extends BuiltInShellCommand {
      * @throws Exception
      */
 	protected boolean validateSetProperty(String propName, String propValue, String contextPath) throws Exception {
+		// Validate the path first if supplied
+		if(!StringUtils.isEmpty(contextPath)) {
+			if (!validatePath(contextPath)) {
+				return false;
+			}
+		}
+		
 		// Get the context for object.  otherwise use current context
         final WorkspaceContext context = StringUtils.isEmpty( contextPath ) ? getContext()
                                                                            : ContextUtils.getContextForPath( getWorkspaceStatus(),
                                                                                                              contextPath );
 
 		// Validate the type is valid for the context
-		if (!validateProperty(propName,context)) {
+		if (!validateProperty(propName,context,true)) {
 			return false;
 		}
 
 		// Validate the property value
 		if (!validatePropertyValue(propName,propValue,context)) {
 			return false;
-		}
-
-		// Validate the path if supplied
-		if(!StringUtils.isEmpty(contextPath)) {
-			if (!validatePath(contextPath)) {
-				return false;
-			}
 		}
 
 		return true;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/UnsetPropertyCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/UnsetPropertyCommand.java
@@ -41,7 +41,7 @@ public class UnsetPropertyCommand extends BuiltInShellCommand {
         try {
             final String propNameArg = requiredArgument( 0, getString( "missingPropertyName" ) ); //$NON-NLS-1$
 
-            if ( !validateProperty( propNameArg, getContext() ) ) {
+            if ( !validateProperty( propNameArg, getContext(), true ) ) {
                 return false;
             }
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -47,8 +47,12 @@ CreateCommand.MISSING_OBJ_NAME = Please specify a name when creating a "{0}".
 CreateCommand.MISSING_OBJ_TYPE = Please specify the type of object to create.
 CreateCommand.MISSING_OPTION_VALUE = Please specify a statement option value.
 CreateCommand.MISSING_TRANSLATOR_TYPE = Please specify the translator type.
+CreateCommand.MISSING_PROPERTY_NAME = Please specify a name when creating a custom property.
+CreateCommand.MISSING_PROPERTY_VALUE = Please specify a value for the custom property.
+CreateCommand.PROPERTY_ALREADY_EXISTS = A custom property with name "{0}" already exists and cannot be created.
 CreateCommand.NO_DUPLICATES_ALLOWED = An object with name "{0}" and type "{1}" already exists at the specified location.
 CreateCommand.OBJECT_CREATED = Successfully created {0} "{1}".
+CreateCommand.PROPERTY_CREATED = Successfully created property "{0}".
 CreateCommand.PATH_NOT_FOUND = An object at path "{0}" could not be found.
 CreateCommand.TOO_MANY_ARGS = FAILED to create the {0}. Too many arguments were used.
 CreateCommand.TYPE_NOT_VALID = "{0}" is not a valid type that can be created.
@@ -232,6 +236,7 @@ SetCommand.onOffArg_invalid=The command arg must be 'on' or 'off'.
 SetCommand.setRecordingStateMsg=Recording set {0} at {1} - File: "{2}"
 SetCommand.recordingFileNotSet=The recording file global property has not been specified.
 SetCommand.recordingFileNotWriteable=Unable to write to the specified recording file: "{0}"
+SetCommand.TOO_MANY_ARGS = FAILED to set {0}. Too many arguments were used.
 
 # ShowCommand
 ShowCommand.examples= \

--- a/tests/org.komodo.shell.test/resources/createCustomProperty.txt
+++ b/tests/org.komodo.shell.test/resources/createCustomProperty.txt
@@ -1,0 +1,4 @@
+# create a VDB, then add a custom property
+create vdb myVDB
+cd myVDB
+create property customProp aValue

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/CreateCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/CreateCommandTest.java
@@ -2,6 +2,7 @@ package org.komodo.shell;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
 import org.junit.Test;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.vdb.Vdb;
@@ -10,6 +11,7 @@ import org.komodo.shell.commands.core.CreateCommand;
 import org.komodo.shell.util.ContextUtils;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Property;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 
 @SuppressWarnings( { "javadoc", "nls" } )
@@ -23,6 +25,7 @@ public class CreateCommandTest extends AbstractCommandTest {
 	private static final String CREATE_COMMAND_6 = "createCommand6.txt"; //$NON-NLS-1$
 	private static final String CREATE_COMMAND_7 = "createCommand7.txt"; //$NON-NLS-1$
 	private static final String CREATE_COMMAND_8 = "createCommand8.txt"; //$NON-NLS-1$
+	private static final String CREATE_COMMAND_9 = "createCustomProperty.txt"; //$NON-NLS-1$
 
 	/**
 	 * Test for CreateCommand
@@ -229,4 +232,31 @@ public class CreateCommandTest extends AbstractCommandTest {
 
     }
 
+    @Test
+    /**
+     * Creates a custom property using the create command
+     * @throws Exception
+     */
+    public void testCreateCustomProperty() throws Exception {
+    	setup(CREATE_COMMAND_9, CreateCommand.class);
+
+    	execute();
+
+    	assertEquals("/workspace/myVDB", wsStatus.getCurrentContext().getFullName()); //$NON-NLS-1$
+
+    	WorkspaceContext vdbContext = ContextUtils.getContextForPath(wsStatus, "/workspace/myVDB"); //$NON-NLS-1$
+    	KomodoObject ko = vdbContext.getKomodoObj();
+    	UnitOfWork trans = wsStatus.getTransaction();
+    	// Verify the komodo class is a Vdb and is VDB type
+    	assertEquals(KomodoType.VDB.name(), ko.getTypeIdentifier(trans).name());
+
+    	Vdb vdb = (Vdb)resolveType(trans, ko, Vdb.class);
+
+    	// Verify the custom property exists
+    	Property customProp = vdb.getProperty(trans, "customProp");
+    	assertNotNull(customProp);
+    	
+    	// Verify the property value
+    	assertEquals("aValue", customProp.getValue(trans));
+    }
 }


### PR DESCRIPTION
- adds ability to create custom properties using create command
- adds unit test for create property
- change validateSetProperty in SetCommand so that path is validated before getting a context based on path.