### PR TITLE
Issue 211 cli - PrimaryKey path issues

### DIFF
--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/AbstractShellCommand.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/AbstractShellCommand.java
@@ -36,6 +36,7 @@ public abstract class AbstractShellCommand implements ShellCommand {
 
 	private final WorkspaceStatus wsStatus;
 	private Arguments arguments;
+	private boolean autoCommit = true;
 	private Writer writer;
 	protected List<String> validWsContextTypes = Collections.emptyList();
 
@@ -200,5 +201,22 @@ public abstract class AbstractShellCommand implements ShellCommand {
 	public int tabCompletion(String lastArgument, List<CharSequence> candidates) throws Exception {
 		return -1;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @see org.komodo.shell.api.ShellCommand#isAutoCommit()
+	 */
+	@Override
+	public boolean isAutoCommit() {
+	    return this.autoCommit;
+	}
+
+	/**
+     * @param newAutoCommit the flag indicating if the command should commit the transaction after executing
+     */
+    public void setAutoCommit( final boolean newAutoCommit ) {
+        this.autoCommit = newAutoCommit;
+    }
 
 }

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
@@ -30,6 +30,11 @@ import java.util.List;
 public interface ShellCommand {
 
     /**
+     * @return <code>true</code> if the command should commit the transaction after execution
+     */
+    boolean isAutoCommit();
+
+    /**
      * @return the command name (never empty)
      */
     public String getName();

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -141,6 +141,8 @@ public class Messages implements StringConstants {
     }
 
     public enum SetCommand {
+
+        ADD_TABLE_CONSTRAINT_COLUMN_FAILED,
         TOO_MANY_ARGS;
 
         @Override

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
@@ -97,7 +97,9 @@ public final class AddConstraintColumnCommand extends BuiltInShellCommand {
                 constraint.addColumn( getWorkspaceStatus().getTransaction(), ( Column )column );
 
                 // Commit transaction
-                getWorkspaceStatus().commit("AddConstraintColumnCommand"); //$NON-NLS-1$
+                if ( isAutoCommit() ) {
+                    getWorkspaceStatus().commit( AddConstraintColumnCommand.class.getSimpleName() );
+                }
 
                 print( MESSAGE_INDENT,
                        Messages.getString( "AddConstraintColumnCommand.columnRefAdded", columnPathArg, getContext().getFullName() ) ); //$NON-NLS-1$

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
@@ -102,7 +102,9 @@ public class CreateCommand extends BuiltInShellCommand implements StringConstant
             final KomodoObject kobject = create( typeArg, optionalArgs );
 
             // Commit transaction
-            getWorkspaceStatus().commit( CreateCommand.class.getSimpleName() );
+            if ( isAutoCommit() ) {
+                getWorkspaceStatus().commit( CreateCommand.class.getSimpleName() );
+            }
 
             if( PROPERTY.equals(typeArg.toLowerCase()) ) {
                 final String typeName = requiredArgument( 1, Messages.getString( MISSING_OBJ_TYPE ) );

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/DeleteCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/DeleteCommand.java
@@ -48,7 +48,9 @@ public class DeleteCommand extends BuiltInShellCommand implements StringConstant
         	// Delete
             delete(objPathArg);
             // Commit transaction
-            getWorkspaceStatus().commit("DeleteCommand"); //$NON-NLS-1$
+            if ( isAutoCommit() ) {
+                getWorkspaceStatus().commit( DeleteCommand.class.getSimpleName() );
+            }
             // Print message
             print(CompletionConstants.MESSAGE_INDENT, Messages.getString("DeleteCommand.ObjectDeleted", objPathArg)); //$NON-NLS-1$
         } catch (Exception e) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ImportCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/ImportCommand.java
@@ -123,7 +123,10 @@ public class ImportCommand extends BuiltInShellCommand {
             	// OK to keep VDB - rename it to vdbName
             	if(okToImport) {
             		vdbObject.rename(wsStatus.getTransaction(), vdbName);
-                    wsStatus.commit("ImportCommand"); //$NON-NLS-1$
+
+                    if ( isAutoCommit() ) {
+                        wsStatus.commit( ImportCommand.class.getSimpleName() );
+                    }
 
                     print(CompletionConstants.MESSAGE_INDENT, Messages.getString("ImportCommand.VdbImportSuccessMsg", fileNameArg)); //$NON-NLS-1$
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/RemoveConstraintColumnCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/RemoveConstraintColumnCommand.java
@@ -85,7 +85,9 @@ public final class RemoveConstraintColumnCommand extends BuiltInShellCommand {
                 constraint.removeColumn( getWorkspaceStatus().getTransaction(), ( Column )column );
 
                 // Commit transaction
-                getWorkspaceStatus().commit( RemoveConstraintColumnCommand.class.getSimpleName() );
+                if ( isAutoCommit() ) {
+                    getWorkspaceStatus().commit( RemoveConstraintColumnCommand.class.getSimpleName() );
+                }
 
                 print( MESSAGE_INDENT, Messages.getString( COLUMN_REF_REMOVED, columnPathArg, getContext().getFullName() ) );
                 return true;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/RenameCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/RenameCommand.java
@@ -60,7 +60,9 @@ public class RenameCommand extends BuiltInShellCommand implements StringConstant
         	// Rename
             rename(objNameArg, newName);
             // Commit transaction
-            getWorkspaceStatus().commit("RenameCommand"); //$NON-NLS-1$
+            if ( isAutoCommit() ) {
+                getWorkspaceStatus().commit( RenameCommand.class.getSimpleName() );
+            }
             // Print message
             print(CompletionConstants.MESSAGE_INDENT, Messages.getString("RenameCommand.ObjectRenamed", objNameArg, newName)); //$NON-NLS-1$
         } catch (Exception e) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/UnsetPropertyCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/UnsetPropertyCommand.java
@@ -48,12 +48,14 @@ public class UnsetPropertyCommand extends BuiltInShellCommand {
 
             final WorkspaceContext context = getContext();
 
-            // Set the property
+            // remove the property by setting its value to null
             final String propertyName = ( !isShowingPropertyNamePrefixes() ? attachPrefix( context, propNameArg ) : propNameArg );
             context.setPropertyValue( propertyName, null );
 
             // Commit transaction
-            getWorkspaceStatus().commit( getClass().getSimpleName() );
+            if ( isAutoCommit() ) {
+                getWorkspaceStatus().commit( UnsetPropertyCommand.class.getSimpleName() );
+            }
 
             // Print message
             print( MESSAGE_INDENT, getString( "propertyUnset", propNameArg ) ); //$NON-NLS-1$

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -240,6 +240,7 @@ SetCommand.onOffArg_invalid=The command arg must be 'on' or 'off'.
 SetCommand.setRecordingStateMsg=Recording set {0} at {1} - File: "{2}"
 SetCommand.recordingFileNotSet=The recording file global property has not been specified.
 SetCommand.recordingFileNotWriteable=Unable to write to the specified recording file: "{0}"
+SetCommand.ADD_TABLE_CONSTRAINT_COLUMN_FAILED = Unable to add column to table constraint. Failed command: {0}
 SetCommand.TOO_MANY_ARGS = FAILED to set {0}. Too many arguments were used.
 
 # ShowCommand

--- a/tests/org.komodo.shell.test/resources/replacePrimaryKeyColumns.txt
+++ b/tests/org.komodo.shell.test/resources/replacePrimaryKeyColumns.txt
@@ -1,0 +1,22 @@
+create vdb MyVdb
+cd MyVdb
+
+create model MyModel
+cd MyModel
+
+create table MyTable
+cd MyTable
+
+create column FirstName
+create column MiddleName
+create column LastName
+
+create primarykey pk 
+cd pk
+
+# add a column to primary key
+add-column /workspace/MyVdb/MyModel/MyTable/FirstName
+add-column ../MiddleName
+
+# replace existing column
+set property teiidddl:tableElementRefs ../LastName

--- a/tests/org.komodo.shell.test/resources/setPrimaryKeyColumns.txt
+++ b/tests/org.komodo.shell.test/resources/setPrimaryKeyColumns.txt
@@ -1,0 +1,16 @@
+create vdb MyVdb
+cd MyVdb
+
+create model MyModel
+cd MyModel
+
+create table MyTable
+cd MyTable
+
+create column FirstName
+create column LastName
+
+create primarykey pk 
+cd pk
+
+set property teiidddl:tableElementRefs ../FirstName,/workspace/MyVdb/MyModel/MyTable/LastName


### PR DESCRIPTION
- Changed SetCommand so that it internally calls AddConstraintColumnCommand for each path. Paths are comma-separated.
- added autoCommit flag to ShellCommand. This allows commands to be chained and to be part of the same transaction. Defaults to true.