### PR TITLE
Issue 178 FindCommand Should Have An Object Name Argument

### DIFF
--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
@@ -25,7 +25,6 @@ import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.TableConstraint;
@@ -144,7 +143,7 @@ public final class AddConstraintColumnCommand extends BuiltInShellCommand {
 
             // find columns
             final KomodoObject parent = getContext().getParent().getKomodoObj();
-            final String[] columnPaths = this.findCommand.query( KomodoType.COLUMN, parent.getAbsolutePath() );
+            final String[] columnPaths = this.findCommand.query( KomodoType.COLUMN, parent.getAbsolutePath(), null );
 
             if ( columnPaths.length == 0 ) {
                 return -1;
@@ -159,20 +158,6 @@ public final class AddConstraintColumnCommand extends BuiltInShellCommand {
                     }
                 }
             }
-
-            Collections.sort( candidates, new Comparator< CharSequence >() {
-
-                /**
-                 * {@inheritDoc}
-                 *
-                 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
-                 */
-                @Override
-                public int compare( final CharSequence thisPath,
-                                    final CharSequence thatPath ) {
-                    return thisPath.toString().compareTo( thatPath.toString() );
-                }
-            });
 
             return ( candidates.isEmpty() ? -1 : ( toString().length() + 1 ) );
         }

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
@@ -163,7 +163,7 @@ public class CreateCommand extends BuiltInShellCommand implements StringConstant
             // only occurs on parsing error of arguments and we have no arguments
         }
 
-        final String[] tablePaths = findCmd.query( KomodoType.TABLE, null );
+        final String[] tablePaths = findCmd.query( KomodoType.TABLE, null, null );
 
         if ( tablePaths.length == 0 ) {
             return Collections.emptyList();

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/FindCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/FindCommand.java
@@ -22,7 +22,6 @@
 package org.komodo.shell.commands.core;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -73,8 +72,11 @@ public final class FindCommand extends BuiltInShellCommand {
                 return false;
             }
 
+            // may have a name pattern
+            final String pattern = optionalArgument( 1 );
+
             // query
-            final String[] foundObjectPaths = query( queryType, null );
+            final String[] foundObjectPaths = query( queryType, null, pattern );
 
             // print results
             printResults( queryType, foundObjectPaths );
@@ -145,23 +147,7 @@ public final class FindCommand extends BuiltInShellCommand {
             // print paths of found objects
             final int indent = ( 2 * MESSAGE_INDENT );
 
-            // sort paths
-            final List< String > sorted = new ArrayList< >( Arrays.asList( foundObjectPaths ) );
-            Collections.sort( sorted, new Comparator< String >() {
-
-                /**
-                 * {@inheritDoc}
-                 *
-                 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
-                 */
-                @Override
-                public int compare( final String thisPath,
-                                    final String thatPath ) {
-                    return thisPath.compareTo( thatPath );
-                }
-            } );
-
-            for ( final String path : sorted ) {
+            for ( final String path : foundObjectPaths ) {
                 print( indent, path );
             }
         }
@@ -172,15 +158,18 @@ public final class FindCommand extends BuiltInShellCommand {
      *        the type of object being searched for (cannot be <code>null</code>)
      * @param parentPath
      *        the parent path whose children recursively will be checked (can be empty if searching from the workspace root)
+     * @param pattern
+     *        the regex used to match object names (can be empty if all objects of the given type are being requested)
      * @return the paths of the workspace objects with the matching type (never <code>null</code> but can be empty)
      * @throws Exception
      *         if an error occurs
      */
     protected String[] query( final KomodoType queryType,
-                              final String parentPath ) throws Exception {
+                              final String parentPath,
+                              final String pattern ) throws Exception {
         final String lexiconType = KomodoTypeRegistry.getInstance().getIdentifier( queryType ).getLexiconType();
         final String[] searchResults = getContext().getWorkspaceManager().findByType( getWorkspaceStatus().getTransaction(),
-                                                                                      lexiconType, parentPath );
+                                                                                      lexiconType, parentPath, pattern );
 
         if ( searchResults.length == 0 ) {
             return searchResults;

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/RelationalModelTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/RelationalModelTest.java
@@ -61,19 +61,19 @@ public class RelationalModelTest extends AbstractLocalRepositoryTest {
     }
 
     protected Vdb createVdb( final String vdbName,
-                             final String vdbPath ) throws Exception {
-        return createVdb(vdbName, null, vdbPath);
+                             final String originalFilePath ) throws Exception {
+        return createVdb(vdbName, null, originalFilePath);
     }
 
     protected Vdb createVdb( final String vdbName,
                              final KomodoObject parent,
-                             final String vdbPath ) throws Exception {
+                             final String originalFilePath ) throws Exception {
         final WorkspaceManager mgr = WorkspaceManager.getInstance( _repo );
-        final Vdb vdb = mgr.createVdb( this.uow, parent, vdbName, vdbPath );
+        final Vdb vdb = mgr.createVdb( this.uow, parent, vdbName, originalFilePath );
 
         assertThat( vdb.getPrimaryType( this.uow ).getName(), is( VdbLexicon.Vdb.VIRTUAL_DATABASE ) );
         assertThat( vdb.getName( this.uow ), is( vdbName ) );
-        assertThat( vdb.getOriginalFilePath( this.uow ), is( vdbPath ) );
+        assertThat( vdb.getOriginalFilePath( this.uow ), is( originalFilePath ) );
         return vdb;
     }
 

--- a/tests/org.komodo.relational.test/src/org/komodo/relational/workspace/WorkspaceManagerTest.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/workspace/WorkspaceManagerTest.java
@@ -137,7 +137,7 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
 
         commit(); // must save before running a query
 
-        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, StringConstants.EMPTY_STRING ).length,
+        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, StringConstants.EMPTY_STRING, null ).length,
                     is( suffix ) );
     }
 
@@ -161,8 +161,33 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
 
         commit(); // must save before running a query
 
-        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, parent.getAbsolutePath() ).length,
+        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, parent.getAbsolutePath(), null ).length,
                     is( expected ) );
+    }
+
+    @Test
+    public void shouldFindMatchingObjects() throws Exception {
+        // create at workspace root
+        createVdb( "blah" );
+        createVdb( "elvis" );
+        createVdb( "sledge" );
+
+        // create under a folder
+        final KomodoObject parent = _repo.add( this.uow, null, "folder", null );
+        createVdb( "john", parent, VDB_PATH );
+        createVdb( "paul", parent, VDB_PATH );
+        createVdb( "george", parent, VDB_PATH );
+        createVdb( "ringo", parent, VDB_PATH );
+
+        commit(); // must save before running a query
+
+        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, null, null ).length, is( 7 ) );
+        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, null, "*" ).length, is( 7 ) );
+        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, null, "blah" ).length, is( 1 ) );
+        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, null, "*e" ).length, is( 2 ) );
+        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, null, "*o*" ).length, is( 3 ) );
+        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, null, "pa%l" ).length, is( 1 ) );
+        assertThat( this.wsMgr.findByType( this.uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, null, "a*" ).length, is( 0 ) );
     }
 
     @Test
@@ -226,7 +251,7 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
 
     @Test( expected = Exception.class )
     public void shouldNotAllowEmptyTypeWhenFindingObjects() throws Exception {
-        this.wsMgr.findByType(this.uow, StringConstants.EMPTY_STRING, "/my/path");
+        this.wsMgr.findByType( this.uow, StringConstants.EMPTY_STRING, "/my/path", null );
     }
 
     @Test( expected = Exception.class )
@@ -241,7 +266,7 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
 
     @Test( expected = Exception.class )
     public void shouldNotAllowNullTypeWhenFindingObjects() throws Exception {
-        this.wsMgr.findByType(this.uow, null, "/my/path");
+        this.wsMgr.findByType( this.uow, null, "/my/path", null );
     }
 
     @Test( expected = Exception.class )


### PR DESCRIPTION
Changed FindCommand so that it now has an optional argument that is a regex for matching an object's name. Fix for #178.