### PR TITLE
Modifies importer and exposes import DDL in cli

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/ObjectImpl.java
@@ -1312,14 +1312,17 @@ public class ObjectImpl implements KomodoObject, StringConstants {
                           newName );
         }
 
+        // If the supplied newName is not an absolute path, assume its a simple name and append the parent absolute path
+        String newPath = newName;
+        if(!newPath.startsWith(FORWARD_SLASH)) {
+        	newPath = getParent( transaction ).getAbsolutePath();
+        	if(!newPath.endsWith(FORWARD_SLASH)) {
+        		newPath += FORWARD_SLASH;
+        	}
+        	newPath += newName;
+        }
+         
         try {
-            String newPath = getParent( transaction ).getAbsolutePath();
-
-            if (!newPath.endsWith( FORWARD_SLASH )) {
-                newPath += FORWARD_SLASH;
-            }
-
-            newPath += newName;
             getSession( transaction ).move( getAbsolutePath(), newPath );
             this.path = newPath;
             // TODO seems like index could change also

--- a/plugins/org.komodo.importer/src/org/komodo/importer/ImportMessages.java
+++ b/plugins/org.komodo.importer/src/org/komodo/importer/ImportMessages.java
@@ -26,7 +26,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
 import org.komodo.spi.constants.StringConstants;
+import org.modeshape.common.text.Position;
+import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlParsingException;
 
 /**
  * ImportMessages
@@ -69,6 +72,33 @@ public class ImportMessages implements StringConstants {
         this.unhandledTypeCountMap = null;
     }
 
+    /**
+     * Add an error message based on the supplied exception.
+     * @param exception the exception
+     */
+    public void addErrorMessage(Throwable exception) {
+    	while (exception.getCause() != null) {
+    		//
+    		// Zero down to the root cause of the exception
+    		//
+    		exception = exception.getCause();
+    	}
+
+    	String message = exception.getLocalizedMessage();
+    	if (exception instanceof TeiidDdlParsingException) {
+    		TeiidDdlParsingException teiidEx = (TeiidDdlParsingException) exception;
+    		Position position = teiidEx.getPosition();
+
+    		message = Messages.getString(Messages.IMPORTER.teiidParserException,
+    				teiidEx.getMessage(),
+    				position.getLine(),
+    				position.getColumn());
+    	}
+
+    	errorMessages.add(message);
+    }
+
+    
     /**
      * Add an error message
      * @param message the error message
@@ -279,6 +309,20 @@ public class ImportMessages implements StringConstants {
      */
     public void setParseErrorIndex(int index) {
         this.parseErrorIndex = index;
+    }
+    
+    @Override
+    public String toString() {
+    	List<String> allMessages = getAllMessages();
+    	if(allMessages.size()==0) {
+    		return "No Import Messages"; //$NON-NLS-1$
+    	}
+    	StringBuilder sb = new StringBuilder();
+    	for(String message : allMessages) {
+    		sb.append(message);
+    		sb.append('\n');
+    	}
+    	return sb.toString();
     }
 
 }

--- a/plugins/org.komodo.shell-api/META-INF/MANIFEST.MF
+++ b/plugins/org.komodo.shell-api/META-INF/MANIFEST.MF
@@ -11,4 +11,5 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.komodo.spi;bundle-version="0.0.1",
  org.komodo.relational;bundle-version="0.0.1",
  org.komodo.utils;bundle-version="0.0.1",
- org.komodo.core
+ org.komodo.core,
+ org.komodo.importer;bundle-version="0.0.2"

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/AbstractShellCommand.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/AbstractShellCommand.java
@@ -16,10 +16,12 @@
 package org.komodo.shell.api;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import org.komodo.shell.api.Messages.SHELLAPI;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.utils.ArgCheck;
@@ -49,6 +51,7 @@ public abstract class AbstractShellCommand implements ShellCommand {
     public AbstractShellCommand( final WorkspaceStatus status ) {
         ArgCheck.isNotNull( status, "status" ); //$NON-NLS-1$
         this.wsStatus = status;
+        this.writer = new PrintWriter(System.out);
     }
 
 	/**
@@ -156,22 +159,20 @@ public abstract class AbstractShellCommand implements ShellCommand {
 	 */
 	@Override
 	public void print(int indent,String formattedMessage, Object... params) {
+		if(this.writer==null) return;
+		
 		ArgCheck.isNonNegative(indent, Messages.getString(SHELLAPI.negative_indent_supplied));
 		StringBuffer sb = new StringBuffer();
 		for(int i=0; i<indent; i++) {
 			sb.append(StringConstants.SPACE);
 		}
 		String msg = String.format(formattedMessage, params);
-		if (writer != null) {
-			try {
-				writer.write(sb.toString()+msg);
-				writer.write('\n');
-				writer.flush();
-			} catch (IOException e) {
-			    e.printStackTrace();
-			    System.out.println(msg);
-			}
-		} else {
+		try {
+			writer.write(sb.toString()+msg);
+			writer.write('\n');
+			writer.flush();
+		} catch (IOException e) {
+			e.printStackTrace();
 			System.out.println(msg);
 		}
 	}

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
@@ -28,7 +28,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+
 import org.komodo.core.KEngine;
+import org.komodo.importer.ImportMessages;
 import org.komodo.relational.teiid.Teiid;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.Repository.UnitOfWork;
@@ -246,6 +248,14 @@ public interface WorkspaceStatus extends StringConstants {
      */
     void commit(String source) throws Exception;
 
+    /**
+     * Commit
+     * @param source identifier for commit
+     * @param importMessages collects import messages
+     * @throws Exception
+     */
+	void commitImport( final String source, ImportMessages importMessages ) throws Exception;
+    
     /**
      * Rolls back any unsaved changes.
      *

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -163,18 +163,45 @@ public class Messages implements StringConstants {
             return getEnumName(this) + DOT + name();
         }
     }
+    
+    public enum ImportCommand {
+    	InvalidArgMsg_SubCommand,
+    	InvalidArgMsg_FileName,
+    	InvalidArgMsg_ModelName,
+    	InvalidTargetPath,
+    	DdlImportInProgressMsg,
+    	VdbImportInProgressMsg,
+    	DdlImportSuccessMsg,
+    	VdbImportSuccessMsg,
+    	InvalidSubCommand,
+    	ImportFailedMsg,
+    	childTypeNotAllowed,
+    	InvalidDDLParentType,
+    	ErrorCreatingTempNode,
+    	DeleteTempContextFailedMsg,
+    	cannotImport_wouldCreateDuplicate;
+
+    	@Override
+    	public String toString() {
+    		return getEnumName(this) + DOT + name();
+    	}
+    }
 
     public enum ExportCommand {
-        InvalidArgMsgObjectName,
+    	InvalidArgMsgSubCommand,
+    	InvalidArgMsgObjectName,
         InvalidArgMsgOutputFileName,
         Failure,
         ObjectExported,
         NoContentExported,
+        ObjectNotAVdb,
         CannotExportObjectDoesNotExist,
+        CannotExportObjectNotExportable,
         CannotExportFileAlreadyExists,
         CannotExportProblemWithVdb,
         CannotExportProblemWithModel,
-        CannotExportProblemWithSchema;
+        CannotExportProblemWithSchema,
+        ExportOfTypeNotSupported;
 
         @Override
         public String toString() {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/DeleteCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/DeleteCommand.java
@@ -79,12 +79,6 @@ public class DeleteCommand extends BuiltInShellCommand implements StringConstant
 			return false;
 		}
 
-		// The context for the delete must be *below* the current context.
-		if(!ContextUtils.isContextBelow(getWorkspaceStatus().getCurrentContext(),contextToDelete)) {
-            print(CompletionConstants.MESSAGE_INDENT,Messages.getString("DeleteCommand.contextMustBeBelowCurrent",contextToDelete.getFullName())); //$NON-NLS-1$
-			return false;
-		}
-
 		return true;
 	}
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/FindCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/FindCommand.java
@@ -63,18 +63,18 @@ public final class FindCommand extends BuiltInShellCommand {
      */
     @Override
     public boolean execute() throws Exception {
+        final String typeArg = requiredArgument( 0, Messages.getString( "FindCommand.MissingTypeArg" ) ); //$NON-NLS-1$
+        final KomodoType queryType = getQueryType( typeArg );
+
+        if ( queryType == null ) {
+            print( MESSAGE_INDENT, Messages.getString( "FindCommand.InvalidType", typeArg ) ); //$NON-NLS-1$
+            return false;
+        }
+
+        // may have a name pattern
+        final String pattern = optionalArgument( 1 );
+
         try {
-            final String typeArg = requiredArgument( 0, Messages.getString( "FindCommand.MissingTypeArg" ) ); //$NON-NLS-1$
-            final KomodoType queryType = getQueryType( typeArg );
-
-            if ( queryType == null ) {
-                print( MESSAGE_INDENT, Messages.getString( "FindCommand.InvalidType", typeArg ) ); //$NON-NLS-1$
-                return false;
-            }
-
-            // may have a name pattern
-            final String pattern = optionalArgument( 1 );
-
             // query
             final String[] foundObjectPaths = query( queryType, null, pattern );
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -99,26 +99,32 @@ ExitCommand.help = exits VDB Builder.
 ExportCommand.examples= \
 \t export model_1 /home/output/model_1.ddl \n \
 \t export my_vdb /home/output/my_vdb.xml
-ExportCommand.usage=export <object_path> <file_name>
+ExportCommand.usage=export <vdb | ddl> <object_path> <file_name>
 ExportCommand.help=exports a VDB or model to a file.
-ExportCommand.InvalidArgMsg_ObjectName=Please specify the name of the object to export.
-ExportCommand.InvalidArgMsg_OutputFileName=Please specify the file name.
+ExportCommand.InvalidArgMsgSubCommand=Please specify a sub-command.
+ExportCommand.InvalidArgMsgObjectName=Please specify the name of the object to export.
+ExportCommand.InvalidArgMsgOutputFileName=Please specify the file name.
 ExportCommand.Failure = Export command FAILED for "{0}".  Please ensure the object is valid, then retry.
 ExportCommand.ObjectExported=Successfully exported "{0}" to "{1}" file
 ExportCommand.NoContentExported=No content was exported from the object {0}
+ExportCommand.ObjectNotAVdb=The supplied object "{0}" is not a VDB.
 ExportCommand.CannotExportObjectDoesNotExist=Cannot export. The object [{0}] does not exist
+ExportCommand.CannotExportObjectNotExportable=Cannot export.  The object [{0}] does not support export.
 ExportCommand.CannotExportFileAlreadyExists=Cannot export. The file [{0}] already exists
 ExportCommand.CannotExportProblemWithVdb=Problem with VDB. Could not export.
 ExportCommand.CannotExportProblemWithModel=Problem with model. Could not export.
 ExportCommand.CannotExportProblemWithSchema=Problem with schema. Could not export.
+ExportCommand.ExportOfTypeNotSupported=Export of type "{0}" is currently not supported.
 
 # FindCommand
 FindCommand.examples= \
 \t find Vdb \n \
 \t find Model \n \
 \t find VdbDataRole \n \
-\t find Column
-FindCommand.usage = find <object_type>
+\t find Column \n \
+\t find Column a* \n \
+\t find Column test*
+FindCommand.usage = find <object_type> [search pattern]
 FindCommand.help = display the paths of workspace objects of a specified object type.
 FindCommand.helpTypesHeading = The valid object types are the following:
 FindCommand.Failure = Find command FAILED. {0}
@@ -146,15 +152,21 @@ ImportCommand.examples= \
 \t import ddl ./myFile.ddl myModel \n \
 \t import vdb ./myVdb.xml
 ImportCommand.usage=import <ddl | vdb> <file_name> [parent_path]
-ImportCommand.help=import a DDL or VDB file into the workspace.
+ImportCommand.help=import a DDL file or VDB file.  Note that importing DDL into a model or schema will replace existing content.
 ImportCommand.InvalidArgMsg_SubCommand=Please specify a sub-command (model).
 ImportCommand.InvalidArgMsg_FileName=Please specify a DDL file name.
+ImportCommand.InvalidTargetPath=The supplied target path "{0}" is not valid.
 ImportCommand.InvalidArgMsg_ModelName=Please specify a model name.
-ImportCommand.ModelImportSuccessMsg=Successfully imported model {0} from file {1}.
+ImportCommand.DdlImportInProgressMsg=Importing the DDL from file "{0}"...
+ImportCommand.VdbImportInProgressMsg=Importing the VDB file "{0}"...
+ImportCommand.DdlImportSuccessMsg=Successfully imported DDL from file {0}.
 ImportCommand.VdbImportSuccessMsg=Successfully imported VDB from file {0}.
 ImportCommand.InvalidSubCommand=Invalid sub-command, must be "model" or "vdb".
 ImportCommand.ImportFailedMsg=\nFailed to import from file {0}.
 ImportCommand.childTypeNotAllowed=The object type "{0}" is not allowed as a child of "{1}".
+ImportCommand.InvalidDDLParentType=Invalid parent type - can only import DDL into a Model or Schema.
+ImportCommand.ErrorCreatingTempNode=Could not create the temporary import node "{0}".
+ImportCommand.DeleteTempContextFailedMsg=Error deleting the temporary import node "{0}".
 ImportCommand.cannotImport_wouldCreateDuplicate=Cannot import "{0}" - a "{1}" with that name already exists.
 
 # ListCommand
@@ -208,6 +220,7 @@ RenameCommand.ObjectRenamed=Successfully renamed "{0}" to "{1}"
 RenameCommand.Failure=FAILED to rename the {0} object.
 RenameCommand.cannotRename_wouldCreateDuplicate=Cannot rename to "{0}" - an object with that name already exists.
 RenameCommand.cannotRename_objectDoesNotExist = Rename failed because object at path "{0}" does not exist.
+RenameCommand.cannotRename_targetContextDoesNotExist = Rename failed because the target location "{0}" does not exist.
 
 # SetCommand
 SetCommand.examples= \
@@ -320,7 +333,7 @@ SHELL.EXITING=Exiting VDB Builder shell due to an error.
 SHELL.INVALID_ARG=Invalid argument:  {0}
 SHELL.USAGE=Usage:
 SHELL.SHUTTING_DOWN=VDB Builder shell shutting down...
-SHELL.DONE=done.
+SHELL.DONE=done.\n
 SHELL.InvalidArgMsg_EntryPath=Please include an entry path (relative archive path).
 SHELL.ENTRY_PATH=  Entry Path
 SHELL.ENTRY_LIST_SUMMARY=  {0} entries

--- a/plugins/org.komodo.shell/src/org/komodo/shell/util/ContextUtils.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/util/ContextUtils.java
@@ -96,8 +96,7 @@ public class ContextUtils implements StringConstants {
 
 	/**
 	 * Get the workspace context for the specified path.  The path can be either an absolute path, or relative
-	 * to the current context.
-	 * separated by the PATH_SEPARATOR, for example 'table1/col1'.  or it could be single path.
+	 * to the current context.  The path is separated by the PATH_SEPARATOR, for example 'table1/col1'.
 	 * @param workspaceStatus the workspace status
 	 * @param path the supplied path
 	 * @return the context at the specified path, null if not found.
@@ -335,8 +334,25 @@ public class ContextUtils implements StringConstants {
 	 * @param path the supplied path
 	 * @return the array of path segments
 	 */
-	private static String[] getPathSegments(String path) {
+	public static String[] getPathSegments(String path) {
 		return path.split(PATH_SEPARATOR);
+	}
+
+	/**
+	 * Builds a path from the specified segments, starting at the root and including nLevels
+	 * @param pathSegments the array of segments
+	 * @param nLevels number of levels to include
+	 * @return the path
+	 */
+	public static String getPath(String[] pathSegments, int nLevels) {
+		StringBuilder sb = new StringBuilder();
+		for(int i=0; i<nLevels; i++) {
+			if(i!=0) {
+				sb.append(PATH_SEPARATOR);
+			}
+			sb.append(pathSegments[i]);
+		}
+		return sb.toString();
 	}
 
 }

--- a/tests/org.komodo.importer.test/src/org/komodo/importer/AbstractImporterTest.java
+++ b/tests/org.komodo.importer.test/src/org/komodo/importer/AbstractImporterTest.java
@@ -24,14 +24,15 @@ package org.komodo.importer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.modeshape.jcr.api.JcrConstants.JCR_MIXIN_TYPES;
 import static org.modeshape.jcr.api.JcrConstants.JCR_PRIMARY_TYPE;
+
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Property;
 import org.komodo.spi.repository.Repository;
@@ -47,57 +48,54 @@ import org.modeshape.jcr.api.JcrConstants;
 @SuppressWarnings( {"nls"} )
 public abstract class AbstractImporterTest extends AbstractLocalRepositoryTest {
 
-    protected static final String DATA_DIRECTORY = File.separator + "data"; //$NON-NLS-1$
+    protected static final String DATA_DIRECTORY = File.separator + "data";
 
-    protected static final String VDB_DIRECTORY = DATA_DIRECTORY + File.separator + "vdb"; //$NON-NLS-1$
+    protected static final String VDB_DIRECTORY = DATA_DIRECTORY + File.separator + "vdb";
 
-    protected static final String BOOKS_DIRECTORY = DATA_DIRECTORY + File.separator + "books"; //$NON-NLS-1$
+    protected static final String BOOKS_DIRECTORY = DATA_DIRECTORY + File.separator + "books";
 
-    protected static final String DDL_DIRECTORY = DATA_DIRECTORY + File.separator + "ddl"; //$NON-NLS-1$
+    protected static final String DDL_DIRECTORY = DATA_DIRECTORY + File.separator + "ddl";
 
-    protected abstract KomodoObject runImporter(Repository repository,
+    protected abstract void runImporter(Repository repository,
                                                 InputStream inputStream,
-                                                ImportType importType,
+                                                KomodoObject parentObject,
                                                 ImportOptions importOptions,
-                                                ImportMessages importMessages);
+                                                ImportMessages importMessages) throws Exception;
 
-    protected abstract KomodoObject runImporter(Repository repository,
+    protected abstract void runImporter(Repository repository,
                                                 File file,
-                                                ImportType importType,
+                                                KomodoObject parentObject,
                                                 ImportOptions importOptions,
-                                                ImportMessages importMessages);
-
-    protected KomodoObject runImporter(Repository repository, Object content,
-                                                                 ImportType importType, ImportOptions importOptions,
-                                                                 ImportMessages importMessages) {
+                                                ImportMessages importMessages) throws Exception;
+    
+    protected void runImporter(Repository repository, Object content,
+                                                                 KomodoObject parentObject, ImportOptions importOptions,
+                                                                 ImportMessages importMessages) throws Exception {
         if (content instanceof File)
-            return runImporter(repository, (File) content, importType, importOptions, importMessages);
+            runImporter(repository, (File) content, parentObject, importOptions, importMessages);
         else if (content instanceof InputStream)
-            return runImporter(repository, (InputStream) content, importType, importOptions, importMessages);
+            runImporter(repository, (InputStream) content, parentObject, importOptions, importMessages);
 
-        fail("Content should be a file or input stream");
-        return null;
     }
 
-    protected KomodoObject executeImporter(Object content, ImportType importType,
+    protected void executeImporter(Object content, KomodoObject parentObject,
                                                                         ImportOptions importOptions,
                                                                         ImportMessages importMessages)
                                                                         throws Exception {
         assertNotNull(_repo);
         assertNotNull(content);
-        assertNotNull(importType);
+        assertNotNull(parentObject);
         assertNotNull(importOptions);
         assertNotNull(importMessages);
 
-        KomodoObject kObject = runImporter(_repo, content, importType, importOptions, importMessages);
+        runImporter(_repo, content, parentObject, importOptions, importMessages);
+        
         if (importMessages.hasError()) {
             KLog.getLogger().debug(importMessages.errorMessagesToString());
-            return kObject;
         }
 
-        traverse(_repo.createTransaction("traverse-imported-nodes", true, null), kObject.getAbsolutePath());
+        traverse(this.uow, parentObject.getAbsolutePath());
 
-        return kObject;
     }
 
     protected String enc(String input) throws Exception {

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/ExportCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/ExportCommandTest.java
@@ -159,7 +159,7 @@ public class ExportCommandTest extends AbstractCommandTest {
             createInitialTransaction();
             writer = new FileWriter(exportCmdFile);
             String path = convertToContextPath(tweetVdb);
-            writer.write("export " + path + SPACE + exportDest.getAbsolutePath() + NEW_LINE);
+            writer.write("export vdb " + path + SPACE + exportDest.getAbsolutePath() + NEW_LINE);
             writer.close();
 
             //
@@ -226,7 +226,7 @@ public class ExportCommandTest extends AbstractCommandTest {
             writer = new FileWriter(exportCmdFile);
             writer.write("cd /workspace" + NEW_LINE);
             writer.write("cd " + tweetVdb.getName(uow) + NEW_LINE);
-            writer.write("export twitterview " + exportDest.getAbsolutePath() + NEW_LINE);
+            writer.write("export ddl twitterview " + exportDest.getAbsolutePath() + NEW_LINE);
             writer.close();
 
             //
@@ -283,7 +283,7 @@ public class ExportCommandTest extends AbstractCommandTest {
             createInitialTransaction();
             writer = new FileWriter(exportCmdFile);
             String path = convertToContextPath(allElementsVdb);
-            writer.write("export " + path + SPACE + exportDest.getAbsolutePath() + NEW_LINE);
+            writer.write("export vdb " + path + SPACE + exportDest.getAbsolutePath() + NEW_LINE);
             writer.close();
 
             //
@@ -350,7 +350,7 @@ public class ExportCommandTest extends AbstractCommandTest {
             writer = new FileWriter(exportCmdFile);
             writer.write("cd /workspace" + NEW_LINE);
             writer.write("cd " + allElementsVdb.getName(uow) + NEW_LINE);
-            writer.write("export model-one " + exportDest.getAbsolutePath() + NEW_LINE);
+            writer.write("export ddl model-one " + exportDest.getAbsolutePath() + NEW_LINE);
             writer.close();
 
             //
@@ -410,7 +410,7 @@ public class ExportCommandTest extends AbstractCommandTest {
             writer = new FileWriter(exportCmdFile);
             writer.write("cd /workspace" + NEW_LINE);
             writer.write("cd " + allElementsVdb.getName(uow) + NEW_LINE);
-            writer.write("export model-two " + exportDest.getAbsolutePath() + NEW_LINE);
+            writer.write("export ddl model-two " + exportDest.getAbsolutePath() + NEW_LINE);
             writer.close();
 
             //
@@ -471,7 +471,7 @@ public class ExportCommandTest extends AbstractCommandTest {
             createInitialTransaction();
             writer = new FileWriter(exportCmdFile);
             String path = convertToContextPath(exampleSchema);
-            writer.write("export " + path + SPACE + exportDest.getAbsolutePath() + NEW_LINE);
+            writer.write("export ddl " + path + SPACE + exportDest.getAbsolutePath() + NEW_LINE);
             writer.close();
 
             //


### PR DESCRIPTION
- Changes the importer interface to pass in the target object under which the imported content will be placed.
- Transaction is now passed into importer - the client is responsible for transaction commits etc.
- Updated Importer unit tests
- Import ddl capability added to ImportCommand
- ExportCommand args changed to specify ddl vs vdb exports
- ImportMessages new method added to allow adding error based on exception
- AbstractShellCommand now has a default Writer.  User can now set command output to null to turn off messages for a command.
- ObjectImpl rename changed - was assuming the renamed object was staying under the same parent, but rename to a different location should be allowed.
- Changed RenameCommand to allow rename to a different location.