### PR TITLE
Change FindCommand query to a static method

### DIFF
--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/AddConstraintColumnCommand.java
@@ -30,11 +30,9 @@ import org.komodo.relational.model.Column;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.shell.BuiltInShellCommand;
 import org.komodo.shell.Messages;
-import org.komodo.shell.api.Arguments;
 import org.komodo.shell.api.WorkspaceContext;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.shell.util.ContextUtils;
-import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Repository;
@@ -50,22 +48,12 @@ public final class AddConstraintColumnCommand extends BuiltInShellCommand {
      */
     public static final String NAME = "add-column"; //$NON-NLS-1$
 
-    private final FindCommand findCommand;
-
     /**
      * @param status
      *        the workspace status (cannot be <code>null</code>)
      */
     public AddConstraintColumnCommand( final WorkspaceStatus status ) {
         super( status, NAME );
-        this.findCommand = new FindCommand( status );
-        this.findCommand.setOutput( getWriter() );
-
-        try {
-            this.findCommand.setArguments( new Arguments( StringConstants.EMPTY_STRING ) );
-        } catch ( final Exception e ) {
-            // only occurs on parsing error of arguments and we have no arguments
-        }
     }
 
     /**
@@ -155,7 +143,7 @@ public final class AddConstraintColumnCommand extends BuiltInShellCommand {
 
             // find columns
             final KomodoObject parent = getContext().getParent().getKomodoObj();
-            final String[] columnPaths = this.findCommand.query( KomodoType.COLUMN, parent.getAbsolutePath(), null );
+            final String[] columnPaths = FindCommand.query( getWorkspaceStatus(), KomodoType.COLUMN, parent.getAbsolutePath(), null );
 
             if ( columnPaths.length == 0 ) {
                 return -1;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
@@ -36,7 +36,6 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.BuiltInShellCommand;
 import org.komodo.shell.FindWorkspaceNodeVisitor;
 import org.komodo.shell.Messages;
-import org.komodo.shell.api.Arguments;
 import org.komodo.shell.api.WorkspaceContext;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.shell.util.ContextUtils;
@@ -153,17 +152,8 @@ public class CreateCommand extends BuiltInShellCommand implements StringConstant
         return wkspManager.create( uow, parent, objName, type, properties );
     }
 
-    private List< String > findPossibleTablesForForeignKey() throws Exception {
-        final FindCommand findCmd = new FindCommand( getWorkspaceStatus() );
-        findCmd.setOutput( getWriter() );
-
-        try {
-            findCmd.setArguments( new Arguments( StringConstants.EMPTY_STRING ) );
-        } catch ( final Exception e ) {
-            // only occurs on parsing error of arguments and we have no arguments
-        }
-
-        final String[] tablePaths = findCmd.query( KomodoType.TABLE, null, null );
+    private List< String > findTables() throws Exception {
+        final String[] tablePaths = FindCommand.query( getWorkspaceStatus(), KomodoType.TABLE, null, null );
 
         if ( tablePaths.length == 0 ) {
             return Collections.emptyList();
@@ -469,7 +459,7 @@ public class CreateCommand extends BuiltInShellCommand implements StringConstant
             // foreign key requires referenced table path
             if ( typeArg.equals( KomodoType.FOREIGN_KEY.getType().toUpperCase() ) ) {
                 // find all tables not including the current parent object
-                final List< String > tablePaths = findPossibleTablesForForeignKey();
+                final List< String > tablePaths = findTables();
 
                 if ( !tablePaths.isEmpty() ) {
                     for ( final String path : tablePaths ) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/CreateCommand.java
@@ -26,7 +26,6 @@ import static org.komodo.shell.Messages.CreateCommand.PROPERTY_ALREADY_EXISTS;
 import static org.komodo.shell.Messages.CreateCommand.PROPERTY_CREATED;
 import static org.komodo.shell.Messages.CreateCommand.TOO_MANY_ARGS;
 import static org.komodo.shell.Messages.CreateCommand.TYPE_NOT_VALID;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -150,24 +149,6 @@ public class CreateCommand extends BuiltInShellCommand implements StringConstant
         }
 
         return wkspManager.create( uow, parent, objName, type, properties );
-    }
-
-    private List< String > findTables() throws Exception {
-        final String[] tablePaths = FindCommand.query( getWorkspaceStatus(), KomodoType.TABLE, null, null );
-
-        if ( tablePaths.length == 0 ) {
-            return Collections.emptyList();
-        }
-
-        final List< String > result = new ArrayList< >( tablePaths.length );
-
-        // add display path of each table path
-        for ( final String path : tablePaths ) {
-            final String displayPath = ContextUtils.convertPathToDisplayPath( path );
-            result.add( displayPath );
-        }
-
-        return result;
     }
 
     private KomodoObject create( final String objType,
@@ -459,13 +440,11 @@ public class CreateCommand extends BuiltInShellCommand implements StringConstant
             // foreign key requires referenced table path
             if ( typeArg.equals( KomodoType.FOREIGN_KEY.getType().toUpperCase() ) ) {
                 // find all tables not including the current parent object
-                final List< String > tablePaths = findTables();
+                final String[] tablePaths = FindCommand.query( getWorkspaceStatus(), KomodoType.TABLE, null, null );
 
-                if ( !tablePaths.isEmpty() ) {
-                    for ( final String path : tablePaths ) {
-                        if ( StringUtils.isBlank( lastArgument ) || ( path.startsWith( lastArgument ) ) ) {
-                            candidates.add( path );
-                        }
+                for ( final String path : tablePaths ) {
+                    if ( StringUtils.isBlank( lastArgument ) || ( path.startsWith( lastArgument ) ) ) {
+                        candidates.add( path );
                     }
                 }
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/SetCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/core/SetCommand.java
@@ -331,17 +331,7 @@ public class SetCommand extends BuiltInShellCommand {
                         }
                     }
                 } else if ( Constraint.TABLE_REFERENCE.equals( propertyName ) ) {
-                    // provide paths for all tables except the parent table
-                    final FindCommand findCmd = new FindCommand( getWorkspaceStatus() );
-                    findCmd.setOutput( getWriter() );
-
-                    try {
-                        findCmd.setArguments( new Arguments( StringConstants.EMPTY_STRING ) );
-                    } catch ( final Exception e ) {
-                        // only occurs on parsing error of arguments and we have no arguments
-                    }
-
-                    final String[] tablePaths = findCmd.query( KomodoType.TABLE, null, null );
+                    final String[] tablePaths = FindCommand.query( getWorkspaceStatus(), KomodoType.TABLE, null, null );
 
                     if ( tablePaths.length != 0 ) {
                         // do not include the parent table of the foreign key
@@ -350,12 +340,10 @@ public class SetCommand extends BuiltInShellCommand {
                         int i = 0;
                         boolean found = false;
 
-                        for ( final String path : tablePaths ) {
-                            final String displayPath = ContextUtils.convertPathToDisplayPath( path );
-
+                        for ( final String tablePath : tablePaths ) {
                             if ( found ) {
-                                possibleValues[ i++ ] = displayPath;
-                            } else if ( currentTablePath.equals( displayPath ) ) {
+                                possibleValues[ i++ ] = tablePath;
+                            } else if ( currentTablePath.equals( tablePath ) ) {
                                 found = true;
                             }
                         }


### PR DESCRIPTION
- Changes FindCommand.query to a static method so that clients do not need to construct a FindCommand to use.
- utilizes ContextUtils.convertPathToDisplayPath in the method
- use the new static method in CreateCommand and AddConstraintColumnCommand