### PR TITLE
Issue 188 RoundTrip Import-Export - - - - problem with namespaced property

### DIFF
--- a/tests/org.komodo.relational.test/META-INF/MANIFEST.MF
+++ b/tests/org.komodo.relational.test/META-INF/MANIFEST.MF
@@ -9,4 +9,5 @@ Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.jboss.tools.locus.mockito;bundle-version="1.9.5",
- org.komodo.test.utils;bundle-version="0.0.1"
+ org.komodo.test.utils;bundle-version="0.0.1",
+ org.komodo.importer;bundle-version="0.0.2"

--- a/tests/org.komodo.relational.test/resources/AzureService-vdb.xml
+++ b/tests/org.komodo.relational.test/resources/AzureService-vdb.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<vdb name="AzureService" version="1">
+  <description>VDB for: AzureService, Version: 1</description>
+  <connection-type>BY_VERSION</connection-type>
+  <property name="{http://teiid.org/rest}auto-generate" value="true"/>
+  <property name="data-service-view" value="SvcView"/>
+  <import-vdb name="SvcSourceVdb_AzurePricesDS" version="1" import-data-policies="true"/>
+  <model name="AzureService" type="VIRTUAL" visible="true">
+    <description></description>
+    <metadata type="DDL"><![CDATA[CREATE VIEW SvcView (RowId integer PRIMARY KEY, ProdCode string,SalePrice bigdecimal) AS 
+SELECT  ROW_NUMBER() OVER (ORDER BY ProdCode) , ProdCode,SalePrice 
+FROM "Prices.dbo.PricesTable";
+
+SET NAMESPACE 'http://teiid.org/rest' AS REST;
+CREATE VIRTUAL PROCEDURE RestProc () RETURNS (result XML)  OPTIONS ("REST:METHOD" 'GET', "REST:URI" 'rest') AS 
+  BEGIN 
+  SELECT XMLELEMENT(NAME Elems, XMLAGG(XMLELEMENT(NAME Elem, XMLFOREST(RowId,ProdCode,SalePrice)))) AS result 
+  FROM SvcView; 
+  END;]]>
+    </metadata>
+  </model>
+</vdb>
+


### PR DESCRIPTION
- Changed VdbNodeVisitor to always print the namespace URI out for properties instead of using the namespace prefix.
- Added importer project as a dependency to the relational test project in order to test VDB roundtrip.
- Added a VDB roundtrip test