### PR TITLE
Initial migration of vdb-builder raml specification into komodo

### DIFF
--- a/documentation/api/rest/README.md
+++ b/documentation/api/rest/README.md
@@ -1,0 +1,20 @@
+# RAML Specification for vdb-builder
+This details the Rest API available from the vdb-builder engine.
+
+# Converting to HTML
+Whilst the raml document is fairly easy-to-read, the html version provides a far better point-and-click environment.
+
+To convert to html:
+
+* Download and install *npm*.
+
+* Install *raml2html* using the command (as root or Administrator):
+```
+npm install -g raml2html
+```
+
+* Execute raml2html on the raml file:
+```
+raml2html vdb-builder.raml > vdb-builder.html
+```
+

--- a/documentation/api/rest/json/vdbs.json
+++ b/documentation/api/rest/json/vdbs.json
@@ -1,0 +1,46 @@
+{
+    "vdbs": [
+        {
+            "id": "Portfolio",
+            "description": "The Portfolio Vdb",
+            "_links": [
+                {
+                    "rel": "self",
+                    "href": "/vdbs/Portfolio"
+                },
+                {
+                    "rel": "content",
+                    "href": "/vdb/Portfolio"
+                }
+            ]
+        },
+        {
+            "id": "tweet-example",
+            "description": "The Twitter Vdb",
+            "_links": [
+                {
+                    "rel": "self",
+                    "href": "/vdbs/tweet-example"
+                },
+                {
+                    "rel": "content",
+                    "href": "/vdb/tweet-example"
+                }
+            ]
+        },
+        {
+            "id": "MyPartsVDB_Dynamic",
+            "description": "The Parts Vdb",
+            "_links": [
+                {
+                    "rel": "self",
+                    "href": "/vdbs/MyPartsVDB_Dynamic"
+                },
+                {
+                    "rel": "content",
+                    "href": "/vdb/MyPartsVDB_Dynamic"
+                }
+            ]
+        }
+    ]
+}

--- a/documentation/api/rest/json/vdbsContent.json
+++ b/documentation/api/rest/json/vdbsContent.json
@@ -1,0 +1,4944 @@
+{
+"vdb": [
+	{
+		"id" : "Portfolio",
+		"data-path" : "/tko:komodo/tko:workspace/Portfolio",
+		"type" : "Vdb",
+		"vdb:connectionType" : "BY_VERSION",
+		"vdb:preview" : "false",
+		"vdb:name" : "Portfolio",
+		"vdb:description" : "The Portfolio Dynamic VDB",
+		"vdb:version" : 1,
+		"UseConnectorMetadata" : "true",
+		"_links" : [
+			{
+				"rel" : "self",
+				"href" : "/vdb/Portfolio"
+			}
+		],
+		"has-children" : "true",
+		"MarketData" : {
+			"id" : "MarketData",
+			"data-path" : "/tko:komodo/tko:workspace/Portfolio/MarketData",
+			"type" : "Model",
+			"vdb:metadataType" : "DDL",
+			"vdb:visible" : "true",
+			"mmcore:modelType" : "PHYSICAL",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/Portfolio/MarketData"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/Portfolio"
+				}
+			],
+			"has-children" : "true",
+			"vdb:sources" : {
+				"id" : "vdb:sources",
+				"data-path" : "/tko:komodo/tko:workspace/Portfolio/MarketData/vdb:sources",
+				"type" : "VdbSchema",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/Portfolio/MarketData/vdb:sources"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/Portfolio/MarketData"
+					}
+				],
+				"has-children" : "true",
+				"text-connector" : {
+					"id" : "text-connector",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/MarketData/vdb:sources/text-connector",
+					"type" : "VdbModelSource",
+					"vdb:sourceTranslator" : "file",
+					"vdb:sourceJndiName" : "java:/marketdata-file",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/MarketData/vdb:sources/text-connector"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/MarketData/vdb:sources"
+						}
+					],
+					"has-children" : "false"
+				}
+			}
+		},
+		"Accounts" : {
+			"id" : "Accounts",
+			"data-path" : "/tko:komodo/tko:workspace/Portfolio/Accounts",
+			"type" : "Model",
+			"vdb:metadataType" : "DDL",
+			"vdb:visible" : "true",
+			"mmcore:modelType" : "PHYSICAL",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/Portfolio/Accounts"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/Portfolio"
+				}
+			],
+			"has-children" : "true",
+			"vdb:sources" : {
+				"id" : "vdb:sources",
+				"data-path" : "/tko:komodo/tko:workspace/Portfolio/Accounts/vdb:sources",
+				"type" : "VdbSchema",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/Portfolio/Accounts/vdb:sources"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/Portfolio/Accounts"
+					}
+				],
+				"has-children" : "true",
+				"h2-connector" : {
+					"id" : "h2-connector",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/Accounts/vdb:sources/h2-connector",
+					"type" : "VdbModelSource",
+					"vdb:sourceTranslator" : "h2",
+					"vdb:sourceJndiName" : "java:/accounts-ds",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/Accounts/vdb:sources/h2-connector"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/Accounts/vdb:sources"
+						}
+					],
+					"has-children" : "false"
+				}
+			}
+		},
+		"PersonalValuations" : {
+			"id" : "PersonalValuations",
+			"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations",
+			"type" : "Model",
+			"vdb:metadataType" : "DDL",
+			"vdb:visible" : "true",
+			"mmcore:modelType" : "PHYSICAL",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/Portfolio/PersonalValuations"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/Portfolio"
+				}
+			],
+			"has-children" : "true",
+			"vdb:sources" : {
+				"id" : "vdb:sources",
+				"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/vdb:sources",
+				"type" : "VdbSchema",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/Portfolio/PersonalValuations/vdb:sources"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/Portfolio/PersonalValuations"
+					}
+				],
+				"has-children" : "true",
+				"excelconnector" : {
+					"id" : "excelconnector",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/vdb:sources/excelconnector",
+					"type" : "VdbModelSource",
+					"vdb:sourceTranslator" : "excel",
+					"vdb:sourceJndiName" : "java:/excel-file",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/PersonalValuations/vdb:sources/excelconnector"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/PersonalValuations/vdb:sources"
+						}
+					],
+					"has-children" : "false"
+				}
+			},
+			"teiid_excel" : {
+				"id" : "teiid_excel",
+				"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/teiid_excel",
+				"type" : "DdlSchema",
+				"teiidddl:uri" : "http://www.teiid.org/translator/excel/2014",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/Portfolio/PersonalValuations/teiid_excel"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/Portfolio/PersonalValuations"
+					}
+				],
+				"has-children" : "false"
+			},
+			"Sheet1" : {
+				"id" : "Sheet1",
+				"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1",
+				"type" : "Table",
+				"teiidddl:schemaElementType" : "FOREIGN",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/Portfolio/PersonalValuations/Sheet1"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/Portfolio/PersonalValuations"
+					}
+				],
+				"has-children" : "true",
+				"ROW_ID" : {
+					"id" : "ROW_ID",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/ROW_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "INTEGER",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ROW_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1"
+						}
+					],
+					"has-children" : "true",
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/ROW_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "All_Except_Like",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ROW_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ROW_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"ns001:CELL_NUMBER" : {
+						"id" : "ns001:CELL_NUMBER",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/ROW_ID/ns001:CELL_NUMBER",
+						"type" : "StatementOption",
+						"ddl:value" : "ROW_ID",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ROW_ID/ns001:CELL_NUMBER"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ROW_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"ACCOUNT_ID" : {
+					"id" : "ACCOUNT_ID",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/ACCOUNT_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "INTEGER",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ACCOUNT_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1"
+						}
+					],
+					"has-children" : "true",
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/ACCOUNT_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Unsearchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ACCOUNT_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ACCOUNT_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"ns001:CELL_NUMBER" : {
+						"id" : "ns001:CELL_NUMBER",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/ACCOUNT_ID/ns001:CELL_NUMBER",
+						"type" : "StatementOption",
+						"ddl:value" : "1",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ACCOUNT_ID/ns001:CELL_NUMBER"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ACCOUNT_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PRODUCT_TYPE" : {
+					"id" : "PRODUCT_TYPE",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/PRODUCT_TYPE",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_TYPE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1"
+						}
+					],
+					"has-children" : "true",
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/PRODUCT_TYPE/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Unsearchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_TYPE/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_TYPE"
+							}
+						],
+						"has-children" : "false"
+					},
+					"ns001:CELL_NUMBER" : {
+						"id" : "ns001:CELL_NUMBER",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/PRODUCT_TYPE/ns001:CELL_NUMBER",
+						"type" : "StatementOption",
+						"ddl:value" : "2",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_TYPE/ns001:CELL_NUMBER"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_TYPE"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PRODUCT_VALUE" : {
+					"id" : "PRODUCT_VALUE",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/PRODUCT_VALUE",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_VALUE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1"
+						}
+					],
+					"has-children" : "true",
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/PRODUCT_VALUE/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Unsearchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_VALUE/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_VALUE"
+							}
+						],
+						"has-children" : "false"
+					},
+					"ns001:CELL_NUMBER" : {
+						"id" : "ns001:CELL_NUMBER",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/PRODUCT_VALUE/ns001:CELL_NUMBER",
+						"type" : "StatementOption",
+						"ddl:value" : "3",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_VALUE/ns001:CELL_NUMBER"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PRODUCT_VALUE"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PK0" : {
+					"id" : "PK0",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/PK0",
+					"type" : "PrimaryKey",
+					"teiidddl:tableElementRefs" : ["fab41c9d-c577-4355-b79a-55df84d9f218"],
+					"teiidddl:constraintType" : "PRIMARY KEY",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/PK0"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1"
+						}
+					],
+					"has-children" : "false"
+				},
+				"ns001:FILE" : {
+					"id" : "ns001:FILE",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/ns001:FILE",
+					"type" : "StatementOption",
+					"ddl:value" : "otherholdings.xls",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ns001:FILE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1"
+						}
+					],
+					"has-children" : "false"
+				},
+				"ns001:FIRST_DATA_ROW_NUMBER" : {
+					"id" : "ns001:FIRST_DATA_ROW_NUMBER",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/PersonalValuations/Sheet1/ns001:FIRST_DATA_ROW_NUMBER",
+					"type" : "StatementOption",
+					"ddl:value" : "2",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1/ns001:FIRST_DATA_ROW_NUMBER"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/PersonalValuations/Sheet1"
+						}
+					],
+					"has-children" : "false"
+				}
+			}
+		},
+		"Stocks" : {
+			"id" : "Stocks",
+			"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks",
+			"type" : "Model",
+			"vdb:metadataType" : "DDL",
+			"vdb:visible" : "true",
+			"mmcore:modelType" : "VIRTUAL",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/Portfolio/Stocks"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/Portfolio"
+				}
+			],
+			"has-children" : "true",
+			"StockPrices" : {
+				"id" : "StockPrices",
+				"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices",
+				"type" : "View",
+				"teiidddl:schemaElementType" : "VIRTUAL",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/Portfolio/Stocks/StockPrices"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/Portfolio/Stocks"
+					}
+				],
+				"has-children" : "true",
+				"symbol" : {
+					"id" : "symbol",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/symbol",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/Stocks/StockPrices/symbol"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/Stocks/StockPrices"
+						}
+					],
+					"has-children" : "false"
+				},
+				"price" : {
+					"id" : "price",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/price",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/Stocks/StockPrices/price"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/Stocks/StockPrices"
+						}
+					],
+					"has-children" : "false"
+				},
+				"tsql:query" : {
+					"id" : "tsql:query",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query",
+					"type" : "TsqlSchema",
+					"tsql:teiidVersion" : "8.6.0",
+					"tsql:type" : 1,
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/Stocks/StockPrices"
+						}
+					],
+					"has-children" : "true",
+					"tsql:from" : {
+						"id" : "tsql:from",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:from",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:table" : "false",
+							"tsql:name" : "f",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:command" : {
+								"id" : "tsql:command",
+								"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:command",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:type" : 6,
+								"tsql:procedureName" : "MarketData.getTextFiles",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:command"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "true",
+								"tsql:parameters" : {
+									"id" : "tsql:parameters",
+									"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters",
+									"type" : "TsqlSchema",
+									"tsql:parameterType" : 1,
+									"tsql:teiidVersion" : "8.6.0",
+									"tsql:index" : 1,
+									"_links" : [
+										{
+											"rel" : "self",
+											"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters"
+										},
+										{
+											"rel" : "parent",
+											"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:command"
+										}
+									],
+									"has-children" : "true",
+									"tsql:expression" : {
+										"id" : "tsql:expression",
+										"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression",
+										"type" : "TsqlSchema",
+										"tsql:teiidVersion" : "8.6.0",
+										"tsql:typeClass" : "STRING",
+										"tsql:value" : "*.txt",
+										"_links" : [
+											{
+												"rel" : "self",
+												"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression"
+											},
+											{
+												"rel" : "parent",
+												"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters"
+											}
+										],
+										"has-children" : "false"
+									}
+								}
+							}
+						},
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses[2]",
+							"type" : "TsqlSchema",
+							"tsql:escape" : "false",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:usingRowDelimiter" : "true",
+							"tsql:header" : 1,
+							"tsql:name" : "SP",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:columns" : {
+								"id" : "tsql:columns",
+								"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses[2]/tsql:columns",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:type" : "string",
+								"tsql:name" : "symbol",
+								"tsql:noTrim" : "false",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:columns"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							},
+							"tsql:columns" : {
+								"id" : "tsql:columns",
+								"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses[2]/tsql:columns[2]",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:type" : "bigdecimal",
+								"tsql:name" : "price",
+								"tsql:noTrim" : "false",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:columns"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							},
+							"tsql:file" : {
+								"id" : "tsql:file",
+								"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses[2]/tsql:file",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:shortName" : "f.file",
+								"tsql:name" : "f.file",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses/tsql:file"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							}
+						}
+					},
+					"tsql:select" : {
+						"id" : "tsql:select",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:select",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"tsql:distinct" : "false",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:select"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:select/tsql:symbols",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "SP.symbol",
+							"tsql:name" : "SP.symbol",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/StockPrices/tsql:query/tsql:select/tsql:symbols[2]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "SP.price",
+							"tsql:name" : "SP.price",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/StockPrices/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						}
+					}
+				}
+			},
+			"Stock" : {
+				"id" : "Stock",
+				"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock",
+				"type" : "View",
+				"teiidddl:schemaElementType" : "VIRTUAL",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/Portfolio/Stocks/Stock"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/Portfolio/Stocks"
+					}
+				],
+				"has-children" : "true",
+				"product_id" : {
+					"id" : "product_id",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/product_id",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "INTEGER",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/Stocks/Stock/product_id"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/Stocks/Stock"
+						}
+					],
+					"has-children" : "false"
+				},
+				"symbol" : {
+					"id" : "symbol",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/symbol",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/Stocks/Stock/symbol"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/Stocks/Stock"
+						}
+					],
+					"has-children" : "false"
+				},
+				"price" : {
+					"id" : "price",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/price",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/Stocks/Stock/price"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/Stocks/Stock"
+						}
+					],
+					"has-children" : "false"
+				},
+				"company_name" : {
+					"id" : "company_name",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/company_name",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "VARCHAR",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 256,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/Stocks/Stock/company_name"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/Stocks/Stock"
+						}
+					],
+					"has-children" : "false"
+				},
+				"tsql:query" : {
+					"id" : "tsql:query",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query",
+					"type" : "TsqlSchema",
+					"tsql:teiidVersion" : "8.6.0",
+					"tsql:type" : 1,
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/Stocks/Stock"
+						}
+					],
+					"has-children" : "true",
+					"tsql:from" : {
+						"id" : "tsql:from",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:from",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:from"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:group" : {
+								"id" : "tsql:group",
+								"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses/tsql:group",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:shortName" : "S",
+								"tsql:name" : "S",
+								"tsql:definition" : "StockPrices",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses/tsql:group"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							}
+						},
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses[2]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:group" : {
+								"id" : "tsql:group",
+								"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses[2]/tsql:group",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:shortName" : "A",
+								"tsql:name" : "A",
+								"tsql:definition" : "Accounts.PRODUCT",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses/tsql:group"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							}
+						}
+					},
+					"tsql:criteria" : {
+						"id" : "tsql:criteria",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:criteria",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"tsql:typeClass" : "BOOLEAN",
+						"tsql:operator" : "EQ",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:criteria"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:rightExpression" : {
+							"id" : "tsql:rightExpression",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:criteria/tsql:rightExpression",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "A.SYMBOL",
+							"tsql:name" : "A.SYMBOL",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:criteria/tsql:rightExpression"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:criteria"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:leftExpression" : {
+							"id" : "tsql:leftExpression",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:criteria/tsql:leftExpression",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "S.symbol",
+							"tsql:name" : "S.symbol",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:criteria/tsql:leftExpression"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:criteria"
+								}
+							],
+							"has-children" : "false"
+						}
+					},
+					"tsql:select" : {
+						"id" : "tsql:select",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:select",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"tsql:distinct" : "false",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:select"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:select/tsql:symbols",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "A.ID",
+							"tsql:name" : "A.ID",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:select/tsql:symbols[2]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "S.symbol",
+							"tsql:name" : "S.symbol",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:select/tsql:symbols[3]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "S.price",
+							"tsql:name" : "S.price",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/Stocks/Stock/tsql:query/tsql:select/tsql:symbols[4]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "A.COMPANY_NAME",
+							"tsql:name" : "A.COMPANY_NAME",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/Stocks/Stock/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						}
+					}
+				}
+			}
+		},
+		"StocksMatModel" : {
+			"id" : "StocksMatModel",
+			"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel",
+			"type" : "Model",
+			"vdb:metadataType" : "DDL",
+			"vdb:visible" : "true",
+			"mmcore:modelType" : "VIRTUAL",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/Portfolio/StocksMatModel"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/Portfolio"
+				}
+			],
+			"has-children" : "true",
+			"stockPricesMatView" : {
+				"id" : "stockPricesMatView",
+				"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView",
+				"type" : "View",
+				"teiidddl:schemaElementType" : "VIRTUAL",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/Portfolio/StocksMatModel"
+					}
+				],
+				"has-children" : "true",
+				"product_id" : {
+					"id" : "product_id",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/product_id",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "INTEGER",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/product_id"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"symbol" : {
+					"id" : "symbol",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/symbol",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/symbol"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"price" : {
+					"id" : "price",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/price",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/price"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"company_name" : {
+					"id" : "company_name",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/company_name",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "VARCHAR",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 256,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/company_name"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"teiid_rel:ALLOW_MATVIEW_MANAGEMENT" : {
+					"id" : "teiid_rel:ALLOW_MATVIEW_MANAGEMENT",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:ALLOW_MATVIEW_MANAGEMENT",
+					"type" : "StatementOption",
+					"ddl:value" : "true",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:ALLOW_MATVIEW_MANAGEMENT"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"teiid_rel:MATVIEW_SHARE_SCOPE" : {
+					"id" : "teiid_rel:MATVIEW_SHARE_SCOPE",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_SHARE_SCOPE",
+					"type" : "StatementOption",
+					"ddl:value" : "NONE",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_SHARE_SCOPE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"teiid_rel:MATVIEW_AFTER_LOAD_SCRIPT" : {
+					"id" : "teiid_rel:MATVIEW_AFTER_LOAD_SCRIPT",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_AFTER_LOAD_SCRIPT",
+					"type" : "StatementOption",
+					"ddl:value" : "execute accounts.native('''')",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_AFTER_LOAD_SCRIPT"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"teiid_rel:MATVIEW_TTL" : {
+					"id" : "teiid_rel:MATVIEW_TTL",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_TTL",
+					"type" : "StatementOption",
+					"ddl:value" : "120000",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_TTL"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"teiid_rel:ON_VDB_DROP_SCRIPT" : {
+					"id" : "teiid_rel:ON_VDB_DROP_SCRIPT",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:ON_VDB_DROP_SCRIPT",
+					"type" : "StatementOption",
+					"ddl:value" : "DELETE FROM Accounts.status WHERE Name=''stock'' AND schemaname = ''Stocks''",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:ON_VDB_DROP_SCRIPT"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"teiid_rel:MATERIALIZED_STAGE_TABLE" : {
+					"id" : "teiid_rel:MATERIALIZED_STAGE_TABLE",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATERIALIZED_STAGE_TABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "Accounts.h2_stock_mat",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATERIALIZED_STAGE_TABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"MATERIALIZED_TABLE" : {
+					"id" : "MATERIALIZED_TABLE",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/MATERIALIZED_TABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "Accounts.h2_stock_mat",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/MATERIALIZED_TABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"UPDATABLE" : {
+					"id" : "UPDATABLE",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/UPDATABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "TRUE",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/UPDATABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"teiid_rel:MATVIEW_BEFORE_LOAD_SCRIPT" : {
+					"id" : "teiid_rel:MATVIEW_BEFORE_LOAD_SCRIPT",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_BEFORE_LOAD_SCRIPT",
+					"type" : "StatementOption",
+					"ddl:value" : "execute accounts.native(''truncate table h2_stock_mat'');",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_BEFORE_LOAD_SCRIPT"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"teiid_rel:MATVIEW_STATUS_TABLE" : {
+					"id" : "teiid_rel:MATVIEW_STATUS_TABLE",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_STATUS_TABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "status",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_STATUS_TABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"teiid_rel:MATVIEW_ONERROR_ACTION" : {
+					"id" : "teiid_rel:MATVIEW_ONERROR_ACTION",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_ONERROR_ACTION",
+					"type" : "StatementOption",
+					"ddl:value" : "THROW_EXCEPTION",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/teiid_rel:MATVIEW_ONERROR_ACTION"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"MATERIALIZED" : {
+					"id" : "MATERIALIZED",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/MATERIALIZED",
+					"type" : "StatementOption",
+					"ddl:value" : "TRUE",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/MATERIALIZED"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "false"
+				},
+				"tsql:query" : {
+					"id" : "tsql:query",
+					"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query",
+					"type" : "TsqlSchema",
+					"tsql:teiidVersion" : "8.6.0",
+					"tsql:type" : 1,
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView"
+						}
+					],
+					"has-children" : "true",
+					"tsql:from" : {
+						"id" : "tsql:from",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:group" : {
+								"id" : "tsql:group",
+								"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses/tsql:group",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:shortName" : "S",
+								"tsql:name" : "S",
+								"tsql:definition" : "Stocks.StockPrices",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses/tsql:group"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							}
+						},
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses[2]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:group" : {
+								"id" : "tsql:group",
+								"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses[2]/tsql:group",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:shortName" : "A",
+								"tsql:name" : "A",
+								"tsql:definition" : "Accounts.PRODUCT",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses/tsql:group"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							}
+						}
+					},
+					"tsql:criteria" : {
+						"id" : "tsql:criteria",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:criteria",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"tsql:typeClass" : "BOOLEAN",
+						"tsql:operator" : "EQ",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:criteria"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:rightExpression" : {
+							"id" : "tsql:rightExpression",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:criteria/tsql:rightExpression",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "A.SYMBOL",
+							"tsql:name" : "A.SYMBOL",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:criteria/tsql:rightExpression"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:criteria"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:leftExpression" : {
+							"id" : "tsql:leftExpression",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:criteria/tsql:leftExpression",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "S.symbol",
+							"tsql:name" : "S.symbol",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:criteria/tsql:leftExpression"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:criteria"
+								}
+							],
+							"has-children" : "false"
+						}
+					},
+					"tsql:select" : {
+						"id" : "tsql:select",
+						"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"tsql:distinct" : "false",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select/tsql:symbols",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "A.ID",
+							"tsql:name" : "A.ID",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select/tsql:symbols[2]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "S.symbol",
+							"tsql:name" : "S.symbol",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select/tsql:symbols[3]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "S.price",
+							"tsql:name" : "S.price",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select/tsql:symbols[4]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "A.COMPANY_NAME",
+							"tsql:name" : "A.COMPANY_NAME",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/Portfolio/StocksMatModel/stockPricesMatView/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						}
+					}
+				}
+			}
+		}
+	},
+	{
+		"id" : "tweet-example",
+		"data-path" : "/tko:komodo/tko:workspace/tweet-example",
+		"type" : "Vdb",
+		"vdb:preview" : "false",
+		"vdb:name" : "tweet-example",
+		"vdb:description" : "Shows how to call Web Services",
+		"vdb:version" : 1,
+		"UseConnectorMetadata" : "cached",
+		"_links" : [
+			{
+				"rel" : "self",
+				"href" : "/vdb/tweet-example"
+			}
+		],
+		"has-children" : "true",
+		"vdb:translators" : {
+			"id" : "vdb:translators",
+			"data-path" : "/tko:komodo/tko:workspace/tweet-example/vdb:translators",
+			"type" : "VdbSchema",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/tweet-example/vdb:translators"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/tweet-example"
+				}
+			],
+			"has-children" : "true",
+			"rest" : {
+				"id" : "rest",
+				"data-path" : "/tko:komodo/tko:workspace/tweet-example/vdb:translators/rest",
+				"type" : "VdbTranslator",
+				"DefaultServiceMode" : "MESSAGE",
+				"DefaultBinding" : "HTTP",
+				"vdb:type" : "ws",
+				"vdb:description" : "Rest Web Service translator",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/tweet-example/vdb:translators/rest"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/tweet-example/vdb:translators"
+					}
+				],
+				"has-children" : "false"
+			}
+		},
+		"twitter" : {
+			"id" : "twitter",
+			"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitter",
+			"type" : "Model",
+			"vdb:metadataType" : "DDL",
+			"vdb:visible" : "true",
+			"mmcore:modelType" : "PHYSICAL",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/tweet-example/twitter"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/tweet-example"
+				}
+			],
+			"has-children" : "true",
+			"vdb:sources" : {
+				"id" : "vdb:sources",
+				"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitter/vdb:sources",
+				"type" : "VdbSchema",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/tweet-example/twitter/vdb:sources"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/tweet-example/twitter"
+					}
+				],
+				"has-children" : "true",
+				"twitter" : {
+					"id" : "twitter",
+					"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitter/vdb:sources/twitter",
+					"type" : "VdbModelSource",
+					"vdb:sourceTranslator" : "rest",
+					"vdb:sourceJndiName" : "java:/twitterDS",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/tweet-example/twitter/vdb:sources/twitter"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/tweet-example/twitter/vdb:sources"
+						}
+					],
+					"has-children" : "false"
+				}
+			}
+		},
+		"twitterview" : {
+			"id" : "twitterview",
+			"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview",
+			"type" : "Model",
+			"vdb:metadataType" : "DDL",
+			"vdb:visible" : "true",
+			"mmcore:modelType" : "VIRTUAL",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/tweet-example/twitterview"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/tweet-example"
+				}
+			],
+			"has-children" : "true",
+			"getTweets" : {
+				"id" : "getTweets",
+				"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets",
+				"type" : "VirtualProcedure",
+				"teiidddl:schemaElementType" : "VIRTUAL",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/tweet-example/twitterview/getTweets"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/tweet-example/twitterview"
+					}
+				],
+				"has-children" : "true",
+				"query" : {
+					"id" : "query",
+					"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/query",
+					"type" : "Parameter",
+					"ddl:nullable" : "NULL",
+					"teiidddl:result" : "false",
+					"ddl:datatypeName" : "VARCHAR",
+					"teiidddl:parameterType" : "IN",
+					"ddl:datatypeArrayDimensions" : 0,
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/tweet-example/twitterview/getTweets/query"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/tweet-example/twitterview/getTweets"
+						}
+					],
+					"has-children" : "false"
+				},
+				"resultSet" : {
+					"id" : "resultSet",
+					"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/resultSet",
+					"type" : "TabularResultSet",
+					"teiidddl:table" : "true",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/tweet-example/twitterview/getTweets"
+						}
+					],
+					"has-children" : "true",
+					"created_on" : {
+						"id" : "created_on",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/resultSet/created_on",
+						"type" : "ResultSetColumn",
+						"ddl:nullable" : "NULL",
+						"ddl:datatypeName" : "VARCHAR",
+						"ddl:datatypeArrayDimensions" : 0,
+						"ddl:datatypeLength" : 25,
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet/created_on"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet"
+							}
+						],
+						"has-children" : "false"
+					},
+					"from_user" : {
+						"id" : "from_user",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/resultSet/from_user",
+						"type" : "ResultSetColumn",
+						"ddl:nullable" : "NULL",
+						"ddl:datatypeName" : "VARCHAR",
+						"ddl:datatypeArrayDimensions" : 0,
+						"ddl:datatypeLength" : 25,
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet/from_user"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet"
+							}
+						],
+						"has-children" : "false"
+					},
+					"to_user" : {
+						"id" : "to_user",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/resultSet/to_user",
+						"type" : "ResultSetColumn",
+						"ddl:nullable" : "NULL",
+						"ddl:datatypeName" : "VARCHAR",
+						"ddl:datatypeArrayDimensions" : 0,
+						"ddl:datatypeLength" : 25,
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet/to_user"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet"
+							}
+						],
+						"has-children" : "false"
+					},
+					"profile_image_url" : {
+						"id" : "profile_image_url",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/resultSet/profile_image_url",
+						"type" : "ResultSetColumn",
+						"ddl:nullable" : "NULL",
+						"ddl:datatypeName" : "VARCHAR",
+						"ddl:datatypeArrayDimensions" : 0,
+						"ddl:datatypeLength" : 25,
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet/profile_image_url"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet"
+							}
+						],
+						"has-children" : "false"
+					},
+					"source" : {
+						"id" : "source",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/resultSet/source",
+						"type" : "ResultSetColumn",
+						"ddl:nullable" : "NULL",
+						"ddl:datatypeName" : "VARCHAR",
+						"ddl:datatypeArrayDimensions" : 0,
+						"ddl:datatypeLength" : 25,
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet/source"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet"
+							}
+						],
+						"has-children" : "false"
+					},
+					"text" : {
+						"id" : "text",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/resultSet/text",
+						"type" : "ResultSetColumn",
+						"ddl:nullable" : "NULL",
+						"ddl:datatypeName" : "VARCHAR",
+						"ddl:datatypeArrayDimensions" : 0,
+						"ddl:datatypeLength" : 140,
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet/text"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/resultSet"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"tsql:query" : {
+					"id" : "tsql:query",
+					"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query",
+					"type" : "TsqlSchema",
+					"tsql:teiidVersion" : "8.6.0",
+					"tsql:type" : 1,
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/tweet-example/twitterview/getTweets"
+						}
+					],
+					"has-children" : "true",
+					"tsql:from" : {
+						"id" : "tsql:from",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:table" : "false",
+							"tsql:name" : "w",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:command" : {
+								"id" : "tsql:command",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:displayNamedParameters" : "true",
+								"tsql:type" : 6,
+								"tsql:procedureName" : "twitter.invokeHTTP",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "true",
+								"tsql:parameters" : {
+									"id" : "tsql:parameters",
+									"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters",
+									"type" : "TsqlSchema",
+									"tsql:parameterType" : 1,
+									"tsql:teiidVersion" : "8.6.0",
+									"tsql:index" : 1,
+									"tsql:name" : "action",
+									"_links" : [
+										{
+											"rel" : "self",
+											"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters"
+										},
+										{
+											"rel" : "parent",
+											"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command"
+										}
+									],
+									"has-children" : "true",
+									"tsql:expression" : {
+										"id" : "tsql:expression",
+										"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression",
+										"type" : "TsqlSchema",
+										"tsql:teiidVersion" : "8.6.0",
+										"tsql:typeClass" : "STRING",
+										"tsql:value" : "GET",
+										"_links" : [
+											{
+												"rel" : "self",
+												"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression"
+											},
+											{
+												"rel" : "parent",
+												"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters"
+											}
+										],
+										"has-children" : "false"
+									}
+								},
+								"tsql:parameters" : {
+									"id" : "tsql:parameters",
+									"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters[2]",
+									"type" : "TsqlSchema",
+									"tsql:parameterType" : 1,
+									"tsql:teiidVersion" : "8.6.0",
+									"tsql:index" : 2,
+									"tsql:name" : "endpoint",
+									"_links" : [
+										{
+											"rel" : "self",
+											"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters"
+										},
+										{
+											"rel" : "parent",
+											"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command"
+										}
+									],
+									"has-children" : "true",
+									"tsql:expression" : {
+										"id" : "tsql:expression",
+										"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters[2]/tsql:expression",
+										"type" : "TsqlSchema",
+										"tsql:teiidVersion" : "8.6.0",
+										"tsql:typeClass" : "STRING",
+										"_links" : [
+											{
+												"rel" : "self",
+												"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression"
+											},
+											{
+												"rel" : "parent",
+												"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters"
+											}
+										],
+										"has-children" : "true",
+										"tsql:args" : {
+											"id" : "tsql:args",
+											"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters[2]/tsql:expression/tsql:args",
+											"type" : "TsqlSchema",
+											"tsql:teiidVersion" : "8.6.0",
+											"tsql:alias" : "q",
+											"_links" : [
+												{
+													"rel" : "self",
+													"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression/tsql:args"
+												},
+												{
+													"rel" : "parent",
+													"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression"
+												}
+											],
+											"has-children" : "true",
+											"tsql:expression" : {
+												"id" : "tsql:expression",
+												"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters[2]/tsql:expression/tsql:args/tsql:expression",
+												"type" : "TsqlSchema",
+												"tsql:teiidVersion" : "8.6.0",
+												"tsql:shortName" : "query",
+												"tsql:name" : "query",
+												"_links" : [
+													{
+														"rel" : "self",
+														"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression/tsql:args/tsql:expression"
+													},
+													{
+														"rel" : "parent",
+														"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression/tsql:args"
+													}
+												],
+												"has-children" : "false"
+											}
+										},
+										"tsql:path" : {
+											"id" : "tsql:path",
+											"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters[2]/tsql:expression/tsql:path",
+											"type" : "TsqlSchema",
+											"tsql:teiidVersion" : "8.6.0",
+											"tsql:typeClass" : "STRING",
+											"tsql:value" : "",
+											"_links" : [
+												{
+													"rel" : "self",
+													"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression/tsql:path"
+												},
+												{
+													"rel" : "parent",
+													"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:command/tsql:parameters/tsql:expression"
+												}
+											],
+											"has-children" : "false"
+										}
+									}
+								}
+							}
+						},
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:xquery" : "results",
+							"tsql:name" : "tweet",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:columns" : {
+								"id" : "tsql:columns",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:columns",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:type" : "string",
+								"tsql:name" : "created_on",
+								"tsql:path" : "created_at",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:columns"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							},
+							"tsql:columns" : {
+								"id" : "tsql:columns",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:columns[2]",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:type" : "string",
+								"tsql:name" : "from_user",
+								"tsql:path" : "from_user",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:columns"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							},
+							"tsql:columns" : {
+								"id" : "tsql:columns",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:columns[3]",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:type" : "string",
+								"tsql:name" : "to_user",
+								"tsql:path" : "to_user",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:columns"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							},
+							"tsql:columns" : {
+								"id" : "tsql:columns",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:columns[4]",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:type" : "string",
+								"tsql:name" : "profile_image_url",
+								"tsql:path" : "profile_image_url",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:columns"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							},
+							"tsql:columns" : {
+								"id" : "tsql:columns",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:columns[5]",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:type" : "string",
+								"tsql:name" : "source",
+								"tsql:path" : "source",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:columns"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							},
+							"tsql:columns" : {
+								"id" : "tsql:columns",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:columns[6]",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:type" : "string",
+								"tsql:name" : "text",
+								"tsql:path" : "text",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:columns"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							},
+							"tsql:passing" : {
+								"id" : "tsql:passing",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:passing",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:propagateName" : "false",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:passing"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "true",
+								"tsql:expression" : {
+									"id" : "tsql:expression",
+									"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:passing/tsql:expression",
+									"type" : "TsqlSchema",
+									"tsql:teiidVersion" : "8.6.0",
+									"tsql:name" : "JSONTOXML",
+									"_links" : [
+										{
+											"rel" : "self",
+											"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:passing/tsql:expression"
+										},
+										{
+											"rel" : "parent",
+											"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:passing"
+										}
+									],
+									"has-children" : "true",
+									"tsql:args" : {
+										"id" : "tsql:args",
+										"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:passing/tsql:expression/tsql:args",
+										"type" : "TsqlSchema",
+										"tsql:teiidVersion" : "8.6.0",
+										"tsql:typeClass" : "STRING",
+										"tsql:value" : "myxml",
+										"_links" : [
+											{
+												"rel" : "self",
+												"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:passing/tsql:expression/tsql:args"
+											},
+											{
+												"rel" : "parent",
+												"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:passing/tsql:expression"
+											}
+										],
+										"has-children" : "false"
+									},
+									"tsql:args" : {
+										"id" : "tsql:args",
+										"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses[2]/tsql:passing/tsql:expression/tsql:args[2]",
+										"type" : "TsqlSchema",
+										"tsql:teiidVersion" : "8.6.0",
+										"tsql:shortName" : "w.result",
+										"tsql:name" : "w.result",
+										"_links" : [
+											{
+												"rel" : "self",
+												"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:passing/tsql:expression/tsql:args"
+											},
+											{
+												"rel" : "parent",
+												"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:from/tsql:clauses/tsql:passing/tsql:expression"
+											}
+										],
+										"has-children" : "false"
+									}
+								}
+							}
+						}
+					},
+					"tsql:select" : {
+						"id" : "tsql:select",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:select",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"tsql:distinct" : "false",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:select"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:select/tsql:symbols",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:name" : "tweet",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "true",
+							"tsql:group" : {
+								"id" : "tsql:group",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/getTweets/tsql:query/tsql:select/tsql:symbols/tsql:group",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:shortName" : "tweet",
+								"tsql:name" : "tweet",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:select/tsql:symbols/tsql:group"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/getTweets/tsql:query/tsql:select/tsql:symbols"
+									}
+								],
+								"has-children" : "false"
+							}
+						}
+					}
+				}
+			},
+			"Tweet" : {
+				"id" : "Tweet",
+				"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/Tweet",
+				"type" : "View",
+				"teiidddl:schemaElementType" : "VIRTUAL",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/tweet-example/twitterview/Tweet"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/tweet-example/twitterview"
+					}
+				],
+				"has-children" : "true",
+				"tsql:query" : {
+					"id" : "tsql:query",
+					"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/Tweet/tsql:query",
+					"type" : "TsqlSchema",
+					"tsql:teiidVersion" : "8.6.0",
+					"tsql:type" : 1,
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/tweet-example/twitterview/Tweet"
+						}
+					],
+					"has-children" : "true",
+					"tsql:from" : {
+						"id" : "tsql:from",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/Tweet/tsql:query/tsql:from",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query/tsql:from"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/Tweet/tsql:query/tsql:from/tsql:clauses",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:group" : {
+								"id" : "tsql:group",
+								"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/Tweet/tsql:query/tsql:from/tsql:clauses/tsql:group",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:shortName" : "twitterview.getTweets",
+								"tsql:name" : "twitterview.getTweets",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query/tsql:from/tsql:clauses/tsql:group"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							}
+						}
+					},
+					"tsql:select" : {
+						"id" : "tsql:select",
+						"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/Tweet/tsql:query/tsql:select",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"tsql:distinct" : "false",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query/tsql:select"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/tweet-example/twitterview/Tweet/tsql:query/tsql:select/tsql:symbols",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/tweet-example/twitterview/Tweet/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						}
+					}
+				}
+			}
+		}
+	},
+	{
+		"id" : "MyPartsVDB_Dynamic",
+		"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic",
+		"type" : "Vdb",
+		"vdb:connectionType" : "BY_VERSION",
+		"vdb:preview" : "false",
+		"vdb:name" : "MyPartsVDB_Dynamic",
+		"vdb:version" : 1,
+		"_links" : [
+			{
+				"rel" : "self",
+				"href" : "/vdb/MyPartsVDB_Dynamic"
+			}
+		],
+		"has-children" : "true",
+		"PartsViewModel" : {
+			"id" : "PartsViewModel",
+			"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel",
+			"type" : "Model",
+			"vdb:metadataType" : "DDL",
+			"vdb:visible" : "true",
+			"mmcore:modelType" : "VIRTUAL",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/MyPartsVDB_Dynamic"
+				}
+			],
+			"has-children" : "true",
+			"PartsSummary" : {
+				"id" : "PartsSummary",
+				"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary",
+				"type" : "View",
+				"teiidddl:schemaElementType" : "VIRTUAL",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel"
+					}
+				],
+				"has-children" : "true",
+				"PART_ID" : {
+					"id" : "PART_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NOT NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 50,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+						}
+					],
+					"has-children" : "true",
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PART_NAME" : {
+					"id" : "PART_NAME",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_NAME",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 255,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_NAME"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+						}
+					],
+					"has-children" : "true",
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_NAME/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_NAME/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_NAME"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PART_COLOR" : {
+					"id" : "PART_COLOR",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_COLOR",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 30,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_COLOR"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+						}
+					],
+					"has-children" : "true",
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_COLOR/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_COLOR/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_COLOR"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PART_WEIGHT" : {
+					"id" : "PART_WEIGHT",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_WEIGHT",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 255,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_WEIGHT"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+						}
+					],
+					"has-children" : "true",
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_WEIGHT/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_WEIGHT/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/PART_WEIGHT"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"SUPPLIER_ID" : {
+					"id" : "SUPPLIER_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SUPPLIER_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NOT NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 10,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SUPPLIER_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+						}
+					],
+					"has-children" : "true",
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SUPPLIER_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SUPPLIER_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SUPPLIER_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"QUANTITY" : {
+					"id" : "QUANTITY",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/QUANTITY",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypePrecision" : 3,
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/QUANTITY"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+						}
+					],
+					"has-children" : "true",
+					"FIXED_LENGTH" : {
+						"id" : "FIXED_LENGTH",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/QUANTITY/FIXED_LENGTH",
+						"type" : "StatementOption",
+						"ddl:value" : "TRUE",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/QUANTITY/FIXED_LENGTH"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/QUANTITY"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/QUANTITY/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "All_Except_Like",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/QUANTITY/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/QUANTITY"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"SHIPPER_ID" : {
+					"id" : "SHIPPER_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SHIPPER_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypePrecision" : 2,
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SHIPPER_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+						}
+					],
+					"has-children" : "true",
+					"FIXED_LENGTH" : {
+						"id" : "FIXED_LENGTH",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SHIPPER_ID/FIXED_LENGTH",
+						"type" : "StatementOption",
+						"ddl:value" : "TRUE",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SHIPPER_ID/FIXED_LENGTH"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SHIPPER_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "All_Except_Like",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SHIPPER_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"UPDATABLE" : {
+					"id" : "UPDATABLE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/UPDATABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "TRUE",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/UPDATABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+						}
+					],
+					"has-children" : "false"
+				},
+				"tsql:query" : {
+					"id" : "tsql:query",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query",
+					"type" : "TsqlSchema",
+					"tsql:teiidVersion" : "8.6.0",
+					"tsql:type" : 1,
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary"
+						}
+					],
+					"has-children" : "true",
+					"tsql:from" : {
+						"id" : "tsql:from",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:group" : {
+								"id" : "tsql:group",
+								"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses/tsql:group",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:shortName" : "PartsSS.PARTS",
+								"tsql:name" : "PartsSS.PARTS",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses/tsql:group"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							}
+						},
+						"tsql:clauses" : {
+							"id" : "tsql:clauses",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses[2]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from"
+								}
+							],
+							"has-children" : "true",
+							"tsql:group" : {
+								"id" : "tsql:group",
+								"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses[2]/tsql:group",
+								"type" : "TsqlSchema",
+								"tsql:teiidVersion" : "8.6.0",
+								"tsql:shortName" : "PartsSS.SUPPLIER_PARTS",
+								"tsql:name" : "PartsSS.SUPPLIER_PARTS",
+								"_links" : [
+									{
+										"rel" : "self",
+										"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses/tsql:group"
+									},
+									{
+										"rel" : "parent",
+										"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:from/tsql:clauses"
+									}
+								],
+								"has-children" : "false"
+							}
+						}
+					},
+					"tsql:criteria" : {
+						"id" : "tsql:criteria",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:criteria",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"tsql:typeClass" : "BOOLEAN",
+						"tsql:operator" : "EQ",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:criteria"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:rightExpression" : {
+							"id" : "tsql:rightExpression",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:criteria/tsql:rightExpression",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "PartsSS.SUPPLIER_PARTS.PART_ID",
+							"tsql:name" : "PartsSS.SUPPLIER_PARTS.PART_ID",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:criteria/tsql:rightExpression"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:criteria"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:leftExpression" : {
+							"id" : "tsql:leftExpression",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:criteria/tsql:leftExpression",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "PartsSS.PARTS.PART_ID",
+							"tsql:name" : "PartsSS.PARTS.PART_ID",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:criteria/tsql:leftExpression"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:criteria"
+								}
+							],
+							"has-children" : "false"
+						}
+					},
+					"tsql:select" : {
+						"id" : "tsql:select",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select",
+						"type" : "TsqlSchema",
+						"tsql:teiidVersion" : "8.6.0",
+						"tsql:distinct" : "false",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query"
+							}
+						],
+						"has-children" : "true",
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "PartsSS.PARTS.PART_ID",
+							"tsql:name" : "PartsSS.PARTS.PART_ID",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols[2]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "PartsSS.PARTS.PART_NAME",
+							"tsql:name" : "PartsSS.PARTS.PART_NAME",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols[3]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "PartsSS.PARTS.PART_COLOR",
+							"tsql:name" : "PartsSS.PARTS.PART_COLOR",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols[4]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "PartsSS.PARTS.PART_WEIGHT",
+							"tsql:name" : "PartsSS.PARTS.PART_WEIGHT",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols[5]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "PartsSS.SUPPLIER_PARTS.SUPPLIER_ID",
+							"tsql:name" : "PartsSS.SUPPLIER_PARTS.SUPPLIER_ID",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols[6]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "PartsSS.SUPPLIER_PARTS.QUANTITY",
+							"tsql:name" : "PartsSS.SUPPLIER_PARTS.QUANTITY",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						},
+						"tsql:symbols" : {
+							"id" : "tsql:symbols",
+							"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols[7]",
+							"type" : "TsqlSchema",
+							"tsql:teiidVersion" : "8.6.0",
+							"tsql:shortName" : "PartsSS.SUPPLIER_PARTS.SHIPPER_ID",
+							"tsql:name" : "PartsSS.SUPPLIER_PARTS.SHIPPER_ID",
+							"_links" : [
+								{
+									"rel" : "self",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select/tsql:symbols"
+								},
+								{
+									"rel" : "parent",
+									"href" : "/vdb/MyPartsVDB_Dynamic/PartsViewModel/PartsSummary/tsql:query/tsql:select"
+								}
+							],
+							"has-children" : "false"
+						}
+					}
+				}
+			}
+		},
+		"PartsSS" : {
+			"id" : "PartsSS",
+			"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS",
+			"type" : "Model",
+			"vdb:metadataType" : "DDL",
+			"vdb:visible" : "true",
+			"mmcore:modelType" : "PHYSICAL",
+			"_links" : [
+				{
+					"rel" : "self",
+					"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS"
+				},
+				{
+					"rel" : "parent",
+					"href" : "/vdb/MyPartsVDB_Dynamic"
+				}
+			],
+			"has-children" : "true",
+			"vdb:sources" : {
+				"id" : "vdb:sources",
+				"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/vdb:sources",
+				"type" : "VdbSchema",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/vdb:sources"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS"
+					}
+				],
+				"has-children" : "true",
+				"PartsSS" : {
+					"id" : "PartsSS",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/vdb:sources/PartsSS",
+					"type" : "VdbModelSource",
+					"vdb:sourceTranslator" : "sqlserver",
+					"vdb:sourceJndiName" : "PartsSS",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/vdb:sources/PartsSS"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/vdb:sources"
+						}
+					],
+					"has-children" : "false"
+				}
+			},
+			"PARTS" : {
+				"id" : "PARTS",
+				"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS",
+				"type" : "Table",
+				"teiidddl:schemaElementType" : "FOREIGN",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS"
+					}
+				],
+				"has-children" : "true",
+				"PART_ID" : {
+					"id" : "PART_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NOT NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 50,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"PART_ID\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PART_NAME" : {
+					"id" : "PART_NAME",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 255,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"PART_NAME\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_NAME"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PART_COLOR" : {
+					"id" : "PART_COLOR",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 30,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"PART_COLOR\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_COLOR"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PART_WEIGHT" : {
+					"id" : "PART_WEIGHT",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 255,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"PART_WEIGHT\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/PART_WEIGHT"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"NAMEINSOURCE" : {
+					"id" : "NAMEINSOURCE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/NAMEINSOURCE",
+					"type" : "StatementOption",
+					"ddl:value" : "\"partssupplier\".\"dbo\".\"PARTS\"",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/NAMEINSOURCE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS"
+						}
+					],
+					"has-children" : "false"
+				},
+				"UPDATABLE" : {
+					"id" : "UPDATABLE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/PARTS/UPDATABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "TRUE",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS/UPDATABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/PARTS"
+						}
+					],
+					"has-children" : "false"
+				}
+			},
+			"SHIP_VIA" : {
+				"id" : "SHIP_VIA",
+				"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA",
+				"type" : "Table",
+				"teiidddl:schemaElementType" : "FOREIGN",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS"
+					}
+				],
+				"has-children" : "true",
+				"SHIPPER_ID" : {
+					"id" : "SHIPPER_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NOT NULL",
+					"ddl:datatypePrecision" : 2,
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA"
+						}
+					],
+					"has-children" : "true",
+					"FIXED_LENGTH" : {
+						"id" : "FIXED_LENGTH",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID/FIXED_LENGTH",
+						"type" : "StatementOption",
+						"ddl:value" : "TRUE",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID/FIXED_LENGTH"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "numeric",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "All_Except_Like",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"SHIPPER_ID\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"SHIPPER_NAME" : {
+					"id" : "SHIPPER_NAME",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 30,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"SHIPPER_NAME\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/SHIPPER_NAME"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"NAMEINSOURCE" : {
+					"id" : "NAMEINSOURCE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/NAMEINSOURCE",
+					"type" : "StatementOption",
+					"ddl:value" : "\"partssupplier\".\"dbo\".\"SHIP_VIA\"",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/NAMEINSOURCE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA"
+						}
+					],
+					"has-children" : "false"
+				},
+				"UPDATABLE" : {
+					"id" : "UPDATABLE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/UPDATABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "TRUE",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA/UPDATABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SHIP_VIA"
+						}
+					],
+					"has-children" : "false"
+				}
+			},
+			"STATUS" : {
+				"id" : "STATUS",
+				"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS",
+				"type" : "Table",
+				"teiidddl:schemaElementType" : "FOREIGN",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS"
+					}
+				],
+				"has-children" : "true",
+				"STATUS_ID" : {
+					"id" : "STATUS_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NOT NULL",
+					"ddl:datatypePrecision" : 2,
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS"
+						}
+					],
+					"has-children" : "true",
+					"FIXED_LENGTH" : {
+						"id" : "FIXED_LENGTH",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID/FIXED_LENGTH",
+						"type" : "StatementOption",
+						"ddl:value" : "TRUE",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID/FIXED_LENGTH"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "numeric",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "All_Except_Like",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"STATUS_ID\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"STATUS_NAME" : {
+					"id" : "STATUS_NAME",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 30,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"STATUS_NAME\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/STATUS_NAME"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"NAMEINSOURCE" : {
+					"id" : "NAMEINSOURCE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/NAMEINSOURCE",
+					"type" : "StatementOption",
+					"ddl:value" : "\"partssupplier\".\"dbo\".\"STATUS\"",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/NAMEINSOURCE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS"
+						}
+					],
+					"has-children" : "false"
+				},
+				"UPDATABLE" : {
+					"id" : "UPDATABLE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/STATUS/UPDATABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "TRUE",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS/UPDATABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/STATUS"
+						}
+					],
+					"has-children" : "false"
+				}
+			},
+			"SUPPLIER" : {
+				"id" : "SUPPLIER",
+				"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER",
+				"type" : "Table",
+				"teiidddl:schemaElementType" : "FOREIGN",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS"
+					}
+				],
+				"has-children" : "true",
+				"SUPPLIER_ID" : {
+					"id" : "SUPPLIER_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NOT NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 10,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"SUPPLIER_ID\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"SUPPLIER_NAME" : {
+					"id" : "SUPPLIER_NAME",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 30,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"SUPPLIER_NAME\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_NAME"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"SUPPLIER_STATUS" : {
+					"id" : "SUPPLIER_STATUS",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypePrecision" : 2,
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER"
+						}
+					],
+					"has-children" : "true",
+					"FIXED_LENGTH" : {
+						"id" : "FIXED_LENGTH",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS/FIXED_LENGTH",
+						"type" : "StatementOption",
+						"ddl:value" : "TRUE",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS/FIXED_LENGTH"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "numeric",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "All_Except_Like",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"SUPPLIER_STATUS\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATUS"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"SUPPLIER_CITY" : {
+					"id" : "SUPPLIER_CITY",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 30,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"SUPPLIER_CITY\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_CITY"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"SUPPLIER_STATE" : {
+					"id" : "SUPPLIER_STATE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 2,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"SUPPLIER_STATE\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/SUPPLIER_STATE"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"NAMEINSOURCE" : {
+					"id" : "NAMEINSOURCE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/NAMEINSOURCE",
+					"type" : "StatementOption",
+					"ddl:value" : "\"partssupplier\".\"dbo\".\"SUPPLIER\"",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/NAMEINSOURCE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER"
+						}
+					],
+					"has-children" : "false"
+				},
+				"UPDATABLE" : {
+					"id" : "UPDATABLE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/UPDATABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "TRUE",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER/UPDATABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER"
+						}
+					],
+					"has-children" : "false"
+				}
+			},
+			"SUPPLIER_PARTS" : {
+				"id" : "SUPPLIER_PARTS",
+				"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS",
+				"type" : "Table",
+				"teiidddl:schemaElementType" : "FOREIGN",
+				"_links" : [
+					{
+						"rel" : "self",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS"
+					},
+					{
+						"rel" : "parent",
+						"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS"
+					}
+				],
+				"has-children" : "true",
+				"SUPPLIER_ID" : {
+					"id" : "SUPPLIER_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NOT NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 10,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"SUPPLIER_ID\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SUPPLIER_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"PART_ID" : {
+					"id" : "PART_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NOT NULL",
+					"ddl:datatypeName" : "STRING",
+					"ddl:datatypeArrayDimensions" : 0,
+					"ddl:datatypeLength" : 50,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS"
+						}
+					],
+					"has-children" : "true",
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "varchar",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "Searchable",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"PART_ID\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/PART_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"QUANTITY" : {
+					"id" : "QUANTITY",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypePrecision" : 3,
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS"
+						}
+					],
+					"has-children" : "true",
+					"FIXED_LENGTH" : {
+						"id" : "FIXED_LENGTH",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY/FIXED_LENGTH",
+						"type" : "StatementOption",
+						"ddl:value" : "TRUE",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY/FIXED_LENGTH"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "numeric",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "All_Except_Like",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"QUANTITY\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/QUANTITY"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"SHIPPER_ID" : {
+					"id" : "SHIPPER_ID",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID",
+					"type" : "Column",
+					"ddl:nullable" : "NULL",
+					"ddl:datatypePrecision" : 2,
+					"ddl:datatypeName" : "BIGDECIMAL",
+					"ddl:datatypeArrayDimensions" : 0,
+					"teiidddl:autoIncrement" : "false",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS"
+						}
+					],
+					"has-children" : "true",
+					"FIXED_LENGTH" : {
+						"id" : "FIXED_LENGTH",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID/FIXED_LENGTH",
+						"type" : "StatementOption",
+						"ddl:value" : "TRUE",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID/FIXED_LENGTH"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NATIVE_TYPE" : {
+						"id" : "NATIVE_TYPE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID/NATIVE_TYPE",
+						"type" : "StatementOption",
+						"ddl:value" : "numeric",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID/NATIVE_TYPE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"SEARCHABLE" : {
+						"id" : "SEARCHABLE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID/SEARCHABLE",
+						"type" : "StatementOption",
+						"ddl:value" : "All_Except_Like",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID/SEARCHABLE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					},
+					"NAMEINSOURCE" : {
+						"id" : "NAMEINSOURCE",
+						"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID/NAMEINSOURCE",
+						"type" : "StatementOption",
+						"ddl:value" : "\"SHIPPER_ID\"",
+						"_links" : [
+							{
+								"rel" : "self",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID/NAMEINSOURCE"
+							},
+							{
+								"rel" : "parent",
+								"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/SHIPPER_ID"
+							}
+						],
+						"has-children" : "false"
+					}
+				},
+				"NAMEINSOURCE" : {
+					"id" : "NAMEINSOURCE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/NAMEINSOURCE",
+					"type" : "StatementOption",
+					"ddl:value" : "\"partssupplier\".\"dbo\".\"SUPPLIER_PARTS\"",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/NAMEINSOURCE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS"
+						}
+					],
+					"has-children" : "false"
+				},
+				"UPDATABLE" : {
+					"id" : "UPDATABLE",
+					"data-path" : "/tko:komodo/tko:workspace/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/UPDATABLE",
+					"type" : "StatementOption",
+					"ddl:value" : "TRUE",
+					"_links" : [
+						{
+							"rel" : "self",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS/UPDATABLE"
+						},
+						{
+							"rel" : "parent",
+							"href" : "/vdb/MyPartsVDB_Dynamic/PartsSS/SUPPLIER_PARTS"
+						}
+					],
+					"has-children" : "false"
+				}
+			}
+		}
+	}
+]
+}

--- a/documentation/api/rest/vdb-builder.raml
+++ b/documentation/api/rest/vdb-builder.raml
@@ -1,0 +1,50 @@
+#%RAML 0.8
+---
+title: vdb-builder API
+version: v1
+baseUri: http://localhost:8080/vdb-builder/api/{version}
+mediaType: application/json
+
+/vdbs:
+    get:
+        description: List available vdbs
+        responses:
+            200:
+                body:
+                    application/json:
+                        example: !include json/vdbs.json
+    put:
+    post:
+    /{vdbId}:
+        put:
+        delete:
+            responses:
+                200:
+                404:
+                    body:
+                        application/json:
+                            example: "No vdb named portfolio"
+/vdb:
+    /{vdbId}:
+        get:
+            description: Retrieve the content for the given vdb
+            headers:
+                Accept:
+                    enum: [application/json, application/xml]
+                    required: true
+            responses:
+                200:
+                    body:
+                        application/json:
+                            example: !include json/vdbsContent.json
+                        application/xml:
+                            example: !include xml/vdbsContent.xml
+                404:
+                    body:
+                        application/json:
+                            example: "No vdb named portfolio"
+                        application/xml:
+                            example: "No vdb content for vdb named portfolio"
+                406:
+                    description: Request has invalid Accept header
+        post:

--- a/documentation/api/rest/xml/vdbs.xml
+++ b/documentation/api/rest/xml/vdbs.xml
@@ -1,0 +1,23 @@
+<vdbs>
+	<vdb id="Portfolio">
+        <description>The Portfolio Vdb</description>
+		<links>
+			<link rel="self" href="/vdbs/Portfolio"></link>
+			<link rel="content" href="/vdb/Portfolio"></link>
+		</links>
+	</vdb>
+	<vdb id="tweet-example">
+        <description>The Twitter Vdb</description>
+		<links>
+			<link rel="self" href="/vdbs/tweet-example"></link>
+			<link rel="content" href="/vdb/tweet-example"></link>
+		</links>
+	</vdb>
+	<vdb id="MyPartsVDB_Dynamic">
+        <description>The Parts Vdb</description>
+		<links>
+			<link rel="self" href="/vdbs/MyPartsVDB_Dynamic"></link>
+			<link rel="content" href="/vdb/MyPartsVDB_Dynamic"></link>
+		</links>
+	</vdb>
+</vdbs>

--- a/documentation/api/rest/xml/vdbsContent.xml
+++ b/documentation/api/rest/xml/vdbsContent.xml
@@ -1,0 +1,215 @@
+<vdb-contents>
+    <vdb name="Portfolio" version="1">
+
+        <description>The Portfolio Dynamic VDB</description>
+ 
+        <!--
+            Setting to use connector supplied metadata. Can be "true" or "cached".
+            "true" will obtain metadata once for every launch of Teiid.
+            "cached" will save a file containing the metadata into
+            the deploy/<vdb name>/<vdb version/META-INF directory
+        -->
+        <property name="UseConnectorMetadata" value="true" />
+
+        <!--
+            Each model represents a access to one or more sources.
+            The name of the model will be used as a top level schema name
+            for all of the metadata imported from the connector.
+
+            NOTE: Multiple models, with different import settings, can be bound to
+            the same connector binding and will be treated as the same source at
+            runtime.
+        -->
+        <model name="MarketData">
+            <!--
+                Each source represents a translator and data source. There are
+                pre-defined translators, or you can create one.
+            -->
+            <source name="text-connector" translator-name="file" connection-jndi-name="java:/marketdata-file"/>
+        </model>
+ 
+        <model name="Accounts">
+            <!--
+                JDBC Import settings
+                importer.useFullSchemaName directs the importer to drop the source
+                schema from the Teiid object name, so that the Teiid fully qualified name
+                will be in the form of <model name>.<table name>
+            -->
+            <property name="importer.useFullSchemaName" value="false"/>
+ 
+            <!--
+                This connector is defined to reference the H2 localDS"  
+            --> 
+            <source name="h2-connector" translator-name="h2" connection-jndi-name="java:/accounts-ds"/>
+        </model>
+ 
+        <model name="PersonalValuations">
+            <property name="importer.headerRowNumber" value="1"/>
+            <property name="importer.ExcelFileName" value="otherholdings.xls"/>
+            <source name="excelconnector" translator-name="excel"  connection-jndi-name="java:/excel-file"/>
+            <metadata type="DDL"><![CDATA[
+ 
+                SET NAMESPACE 'http://www.teiid.org/translator/excel/2014' AS teiid_excel;
+ 
+                CREATE FOREIGN TABLE Sheet1 (
+                ROW_ID integer OPTIONS (SEARCHABLE 'All_Except_Like', "teiid_excel:CELL_NUMBER" 'ROW_ID'),
+                ACCOUNT_ID integer OPTIONS (SEARCHABLE 'Unsearchable', "teiid_excel:CELL_NUMBER" '1'),
+                PRODUCT_TYPE string OPTIONS (SEARCHABLE 'Unsearchable', "teiid_excel:CELL_NUMBER" '2'),
+                PRODUCT_VALUE string OPTIONS (SEARCHABLE 'Unsearchable', "teiid_excel:CELL_NUMBER" '3'),
+                CONSTRAINT PK0 PRIMARY KEY(ROW_ID)
+                ) OPTIONS ("teiid_excel:FILE" 'otherholdings.xls', "teiid_excel:FIRST_DATA_ROW_NUMBER" '2');]]>
+            </metadata>
+        </model>
+
+        <model name="Stocks" type="VIRTUAL">
+            <metadata type="DDL"><![CDATA[
+     
+                CREATE VIEW StockPrices (symbol string, price bigdecimal)
+                AS
+                    SELECT SP.symbol, SP.price
+                    FROM (EXEC MarketData.getTextFiles('*.txt')) AS f,
+                    TEXTTABLE(f.file COLUMNS symbol string, price bigdecimal HEADER) AS SP;
+
+                CREATE VIEW Stock (product_id integer, symbol string, price bigdecimal, company_name varchar(256))
+                AS
+                    SELECT  A.ID, S.symbol, S.price, A.COMPANY_NAME
+                    FROM StockPrices AS S, Accounts.PRODUCT AS A
+                    WHERE S.symbol = A.SYMBOL;]]>
+            </metadata>
+        </model>
+ 
+        <model name="StocksMatModel" type="VIRTUAL">
+            <metadata type="DDL"><![CDATA[
+                CREATE view stockPricesMatView
+                (
+                    product_id integer,
+                    symbol string,
+                    price bigdecimal,
+                    company_name   varchar(256)
+                ) OPTIONS (MATERIALIZED 'TRUE', UPDATABLE 'TRUE',
+                MATERIALIZED_TABLE 'Accounts.h2_stock_mat',
+                "teiid_rel:MATVIEW_TTL" 120000,
+                "teiid_rel:MATVIEW_BEFORE_LOAD_SCRIPT" 'execute accounts.native(''truncate table h2_stock_mat'');',
+                "teiid_rel:MATVIEW_AFTER_LOAD_SCRIPT"  'execute accounts.native('''')',
+                "teiid_rel:ON_VDB_DROP_SCRIPT" 'DELETE FROM Accounts.status WHERE Name=''stock'' AND schemaname = ''Stocks''',
+                "teiid_rel:MATERIALIZED_STAGE_TABLE" 'Accounts.h2_stock_mat',
+                "teiid_rel:ALLOW_MATVIEW_MANAGEMENT" 'true',
+                "teiid_rel:MATVIEW_STATUS_TABLE" 'status',
+                "teiid_rel:MATVIEW_SHARE_SCOPE" 'NONE',
+                "teiid_rel:MATVIEW_ONERROR_ACTION" 'THROW_EXCEPTION')
+                AS SELECT A.ID, S.symbol, S.price, A.COMPANY_NAME
+                   FROM Stocks.StockPrices AS S, Accounts.PRODUCT AS A
+                   WHERE S.symbol = A.SYMBOL;]]>
+            </metadata>
+        </model>
+    </vdb>
+    <vdb name="tweet-example" version="1">
+        
+        <description>Shows how to call Web Services</description>
+        
+        <property name="UseConnectorMetadata" value="cached" />
+        
+        <model name="twitter" type="PHYSICAL">
+            <source name="twitter" translator-name="rest" connection-jndi-name="java:/twitterDS"/>
+        </model>
+        <model name="twitterview" type="VIRTUAL">
+            <metadata type="DDL"><![CDATA[
+                CREATE VIRTUAL PROCEDURE getTweets(IN query varchar) RETURNS TABLE (created_on varchar(25), from_user varchar(25), to_user varchar(25),
+                profile_image_url varchar(25), source varchar(25), text varchar(140)) AS
+                select tweet.* from
+                (EXEC twitter.invokeHTTP(action => 'GET', endpoint => querystring('', query as q))) AS w,
+                XMLTABLE('results' passing JSONTOXML('myxml', w.result) columns
+                created_on string PATH 'created_at',
+                from_user string PATH 'from_user',
+                to_user string PATH 'to_user',
+                profile_image_url string PATH 'profile_image_url',
+                source string PATH 'source',
+                text string PATH 'text') AS tweet;
+                CREATE VIEW Tweet AS select * FROM twitterview.getTweets;
+                ]]>
+            </metadata>
+        </model>
+        
+        <translator name="rest" type="ws" description="Rest Web Service translator">
+            <property name="DefaultBinding" value="HTTP"/>
+            <property name="DefaultServiceMode" value="MESSAGE"/>
+        </translator>
+    </vdb>
+    <vdb name="MyPartsVDB_Dynamic" version="1">
+
+        <connection-type>BY_VERSION</connection-type>
+
+        <model name="PartsViewModel" type="VIRTUAL">
+            <metadata type="DDL">
+                <![CDATA[CREATE VIEW PartsSummary (
+                PART_ID string(50) NOT NULL OPTIONS (SEARCHABLE 'Searchable'),
+                PART_NAME string(255) OPTIONS (SEARCHABLE 'Searchable'),
+                PART_COLOR string(30) OPTIONS (SEARCHABLE 'Searchable'),
+                PART_WEIGHT string(255) OPTIONS (SEARCHABLE 'Searchable'),
+                SUPPLIER_ID string(10) NOT NULL OPTIONS (SEARCHABLE 'Searchable'),
+                QUANTITY bigdecimal(3) OPTIONS (FIXED_LENGTH TRUE, SEARCHABLE 'All_Except_Like'),
+                SHIPPER_ID bigdecimal(2) OPTIONS (FIXED_LENGTH TRUE, SEARCHABLE 'All_Except_Like')
+                ) OPTIONS (UPDATABLE TRUE)
+                AS
+                SELECT  PartsSS.PARTS.PART_ID, PartsSS.PARTS.PART_NAME, PartsSS.PARTS.PART_COLOR,
+                        PartsSS.PARTS.PART_WEIGHT, PartsSS.SUPPLIER_PARTS.SUPPLIER_ID, PartsSS.SUPPLIER_PARTS.QUANTITY,
+                        PartsSS.SUPPLIER_PARTS.SHIPPER_ID FROM PartsSS.PARTS,
+                        PartsSS.SUPPLIER_PARTS WHERE PartsSS.PARTS.PART_ID = PartsSS.SUPPLIER_PARTS.PART_ID;]]>
+            </metadata>
+        </model>
+        <model name="PartsSS" type="PHYSICAL">
+            <source name="PartsSS" translator-name="sqlserver" connection-jndi-name="PartsSS"></source>
+            <metadata type="DDL">
+                <![CDATA[CREATE FOREIGN TABLE PARTS (
+                PART_ID string(50) NOT NULL OPTIONS (NAMEINSOURCE '"PART_ID"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar'),
+                PART_NAME string(255) OPTIONS (NAMEINSOURCE '"PART_NAME"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar'),
+                PART_COLOR string(30) OPTIONS (NAMEINSOURCE '"PART_COLOR"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar'),
+                PART_WEIGHT string(255) OPTIONS (NAMEINSOURCE '"PART_WEIGHT"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar')
+                ) OPTIONS (NAMEINSOURCE '"partssupplier"."dbo"."PARTS"', UPDATABLE TRUE);
+                
+                CREATE FOREIGN TABLE SHIP_VIA (
+                SHIPPER_ID bigdecimal(2) NOT NULL OPTIONS (NAMEINSOURCE '"SHIPPER_ID"', FIXED_LENGTH TRUE,
+                SEARCHABLE 'All_Except_Like', NATIVE_TYPE 'numeric'),
+                SHIPPER_NAME string(30) OPTIONS (NAMEINSOURCE '"SHIPPER_NAME"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar')
+                ) OPTIONS (NAMEINSOURCE '"partssupplier"."dbo"."SHIP_VIA"', UPDATABLE TRUE);
+                
+                CREATE FOREIGN TABLE STATUS (
+                STATUS_ID bigdecimal(2) NOT NULL OPTIONS (NAMEINSOURCE '"STATUS_ID"', FIXED_LENGTH TRUE,
+                SEARCHABLE 'All_Except_Like', NATIVE_TYPE 'numeric'),
+                STATUS_NAME string(30) OPTIONS (NAMEINSOURCE '"STATUS_NAME"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar')
+                ) OPTIONS (NAMEINSOURCE '"partssupplier"."dbo"."STATUS"', UPDATABLE TRUE);
+                
+                CREATE FOREIGN TABLE SUPPLIER (
+                SUPPLIER_ID string(10) NOT NULL OPTIONS (NAMEINSOURCE '"SUPPLIER_ID"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar'),
+                SUPPLIER_NAME string(30) OPTIONS (NAMEINSOURCE '"SUPPLIER_NAME"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar'),
+                SUPPLIER_STATUS bigdecimal(2) OPTIONS (NAMEINSOURCE '"SUPPLIER_STATUS"', FIXED_LENGTH TRUE,
+                SEARCHABLE 'All_Except_Like', NATIVE_TYPE 'numeric'),
+                SUPPLIER_CITY string(30) OPTIONS (NAMEINSOURCE '"SUPPLIER_CITY"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar'),
+                SUPPLIER_STATE string(2) OPTIONS (NAMEINSOURCE '"SUPPLIER_STATE"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar')
+                ) OPTIONS (NAMEINSOURCE '"partssupplier"."dbo"."SUPPLIER"', UPDATABLE TRUE);
+                
+                CREATE FOREIGN TABLE SUPPLIER_PARTS (
+                SUPPLIER_ID string(10) NOT NULL OPTIONS (NAMEINSOURCE '"SUPPLIER_ID"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar'),
+                PART_ID string(50) NOT NULL OPTIONS (NAMEINSOURCE '"PART_ID"',
+                SEARCHABLE 'Searchable', NATIVE_TYPE 'varchar'),
+                QUANTITY bigdecimal(3) OPTIONS ( NAMEINSOURCE '"QUANTITY"', FIXED_LENGTH TRUE,
+                SEARCHABLE 'All_Except_Like', NATIVE_TYPE 'numeric'),
+                SHIPPER_ID bigdecimal(2) OPTIONS (NAMEINSOURCE '"SHIPPER_ID"', FIXED_LENGTH TRUE,
+                SEARCHABLE 'All_Except_Like', NATIVE_TYPE 'numeric')
+                ) OPTIONS (NAMEINSOURCE '"partssupplier"."dbo"."SUPPLIER_PARTS"', UPDATABLE TRUE);]]>
+                
+            </metadata>
+        </model>
+    </vdb>
+</vdb-contents>


### PR DESCRIPTION
* Subject to change, this migrates the specification and its accompanying
  examples from the vdb-bench repository.