### PR TITLE
Modifies vdb importer to extract the vdb name from the xml prior to i…

### DIFF
--- a/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
+++ b/tests/org.komodo.relational.test/src/org/komodo/relational/AllTests.java
@@ -2,6 +2,7 @@ package org.komodo.relational;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import org.komodo.relational.importer.vdb.TestTeiidVdbImporter;
 import org.komodo.relational.model.internal.AbstractProcedureImplTest;
 import org.komodo.relational.model.internal.AccessPatternImplTest;
 import org.komodo.relational.model.internal.ColumnImplTest;
@@ -82,12 +83,16 @@ import org.komodo.relational.workspace.WorkspaceManagerTest;
 
     // Teiid
     TeiidImplTest.class,
-    
+
     // DDL
     SchemaImplTest.class,
 
     // Workspace
     WorkspaceManagerTest.class,
+
+    // Import
+    TestTeiidVdbImporter.class
+
     })
 public class AllTests {
     // nothing to do

--- a/tests/org.komodo.test.utils/src/org/komodo/test/utils/TestUtilities.java
+++ b/tests/org.komodo.test.utils/src/org/komodo/test/utils/TestUtilities.java
@@ -65,6 +65,11 @@ public class TestUtilities implements StringConstants {
     public static final String TWEET_EXAMPLE_NAME = "tweet-example-vdb";
 
     /**
+     * Tweet example vdb name
+     */
+    public static final String TWEET_EXAMPLE_VDB_NAME = "twitter";
+
+    /**
      * Tweet example file, translator has no description defined
      */
     public static final String NO_TRANSLATOR_DESCRIP_NAME = "notranslator-descrip-vdb";
@@ -78,6 +83,11 @@ public class TestUtilities implements StringConstants {
      * All elements example file name
      */
     public static final String ALL_ELEMENTS_EXAMPLE_NAME = "teiid-vdb-all-elements";
+
+    /**
+     * All elements example vdb name
+     */
+    public static final String ALL_ELEMENTS_EXAMPLE_VDB_NAME = "myVDB";
 
     /**
      * All elements example file suffix


### PR DESCRIPTION
…mport

* Importing a vdb relies on the sequencer to extract the contents so the
  vdb name attribute is not read initially hence the NAME Option is used
  to specify the node name of the vdb. This is problematic since the name
  of the node and the vdb:name property can end up not matching.

* Fixes the disparity by getting the vdb imported to first extract the vdb
  xml using DOM then read the name attribute of the vdb tag. This then
  overrides the NAME Option and ensures the node name and vdb:name property
  are synchronised.