### PR TITLE
Makes vdbpath optional on create, disable all VdbEntry Commands

### DIFF
--- a/plugins/org.komodo.core/src/config/vdb.cnd
+++ b/plugins/org.komodo.core/src/config/vdb.cnd
@@ -34,7 +34,7 @@
  - vdb:version (long) = '1' autocreated
  - vdb:preview (boolean) = 'false' autocreated
  - vdb:connectionType (string)
- - vdb:originalFile (string) mandatory
+ - vdb:originalFile (string)
  + * (vdb:abstractModel) copy
  + vdb:translators (vdb:translators) copy
  + vdb:dataRoles (vdb:dataRoles) copy

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/entry/SetEntryPropertyCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/entry/SetEntryPropertyCommand.java
@@ -76,6 +76,11 @@ public final class SetEntryPropertyCommand extends EntryShellCommand {
         return result;
     }
 
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+    
     /**
      * {@inheritDoc}
      *

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/entry/UnsetEntryPropertyCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/entry/UnsetEntryPropertyCommand.java
@@ -74,6 +74,11 @@ public final class UnsetEntryPropertyCommand extends EntryShellCommand {
         return result;
     }
 
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+    
     /**
      * {@inheritDoc}
      *

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/AddEntryCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/AddEntryCommand.java
@@ -54,6 +54,11 @@ public final class AddEntryCommand extends VdbShellCommand {
         return result;
     }
 
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+    
     /**
      * {@inheritDoc}
      *

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/DeleteEntryCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/DeleteEntryCommand.java
@@ -57,6 +57,11 @@ public final class DeleteEntryCommand extends VdbShellCommand {
         return result;
     }
 
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+    
     /**
      * {@inheritDoc}
      *

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowEntriesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowEntriesCommand.java
@@ -65,6 +65,11 @@ public final class ShowEntriesCommand extends VdbShellCommand {
         return result;
     }
 
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+    
     /**
      * {@inheritDoc}
      *

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/vdbcommandmessages.properties
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/vdbcommandmessages.properties
@@ -92,7 +92,7 @@ DeleteTranslatorCommand.TRANSLATOR_DELETED=Translator "{0}" was successfully del
 ExportCommand.usage=export-vdb <file-path> [override]
 ExportCommand.help=\t{0} - exports a VDB manifest to a local file.
 ExportCommand.examples= \
-\t export-vdb /Users/me/myVdb.xml
+\t export-vdb /Users/me/myVdb.xml \n \
 \t export-vdb /Users/me/myVdb.xml true
 ExportCommand.VDB_EXPORTED = VDB "{0}" was successfully exported to "{1}" with override flag of "{2}"
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/CreateVdbCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/CreateVdbCommand.java
@@ -7,7 +7,6 @@
  */
 package org.komodo.relational.commands.workspace;
 
-import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.CreateVdbCommand.MISSING_VDB_EXTERNAL_PATH;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.CreateVdbCommand.VDB_CREATED;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.MISSING_VDB_NAME;
 import org.komodo.relational.workspace.WorkspaceManager;
@@ -21,7 +20,8 @@ import org.komodo.shell.api.WorkspaceStatus;
 public final class CreateVdbCommand extends WorkspaceShellCommand {
 
     static final String NAME = "create-vdb"; //$NON-NLS-1$
-
+    static final String DEFAULT_PATH = "defaultPath"; //$NON-NLS-1$
+    
     /**
      * @param status
      *        the shell's workspace status (cannot be <code>null</code>)
@@ -41,7 +41,7 @@ public final class CreateVdbCommand extends WorkspaceShellCommand {
 
         try {
             final String vdbName = requiredArgument( 0, getMessage( MISSING_VDB_NAME ) );
-            final String extPath = requiredArgument( 1, getMessage( MISSING_VDB_EXTERNAL_PATH ) );
+            final String extPath = optionalArgument( 1, DEFAULT_PATH );
 
             final WorkspaceManager mgr = getWorkspaceManager();
             mgr.createVdb( getTransaction(), null, vdbName, extPath );

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/WorkspaceCommandMessages.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/WorkspaceCommandMessages.java
@@ -54,7 +54,6 @@ public class WorkspaceCommandMessages implements StringConstants {
     }
 
     public enum CreateVdbCommand {
-        MISSING_VDB_EXTERNAL_PATH,
         VDB_CREATED;
 
         @Override

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/workspacecommandmessages.properties
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/workspacecommandmessages.properties
@@ -46,12 +46,12 @@ General.UNSET_MISSING_PROPERTY_NAME = A property name is required.
 General.UNSET_PROPERTY_SUCCESS = The "{0}" property was successfully removed or reset back to its default value.
 
 ### WorkspaceCommandProvider commands
-CreateVdbCommand.usage=create-vdb <vdb-name> <external-path>
+CreateVdbCommand.usage=create-vdb <vdb-name> [external-path]
 CreateVdbCommand.help=\t{0} - create a virtual database.
 CreateVdbCommand.examples= \
+\t create-vdb myVdb \n \
 \t create-vdb myVdb /files/myVdb
 CreateVdbCommand.MISSING_VDB_NAME = A VDB requires a name.
-CreateVdbCommand.MISSING_VDB_EXTERNAL_PATH = A VDB requires an external path.
 CreateVdbCommand.VDB_CREATED = VDB "{0}" was created.
 
 ImportVdbCommand.usage=import-vdb <file-path>

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/entry/SetEntryPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/entry/SetEntryPropertyCommandTest.java
@@ -16,6 +16,7 @@
 package org.komodo.relational.commands.entry;
 
 import static org.junit.Assert.assertEquals;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.relational.vdb.Entry;
@@ -25,9 +26,10 @@ import org.komodo.shell.api.CommandResult;
 
 /**
  * Test Class to test SetEntryPropertyCommand
- *
+ * -- currently ignored - cannot create Entry in vdbbuilder
  */
 @SuppressWarnings( {"javadoc", "nls"} )
+@Ignore
 public class SetEntryPropertyCommandTest extends AbstractCommandTest {
 
     @Test

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/entry/UnsetEntryPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/entry/UnsetEntryPropertyCommandTest.java
@@ -16,6 +16,7 @@
 package org.komodo.relational.commands.entry;
 
 import static org.junit.Assert.assertEquals;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.relational.vdb.Entry;
@@ -25,9 +26,10 @@ import org.komodo.shell.api.CommandResult;
 
 /**
  * Test Class to test UnsetEntryPropertyCommand
- *
+ * -- currently ignored - cannot create Entry in vdbbuilder
  */
 @SuppressWarnings( {"javadoc", "nls"} )
+@Ignore
 public class UnsetEntryPropertyCommandTest extends AbstractCommandTest {
 
     @Test

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddEntryCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddEntryCommandTest.java
@@ -16,6 +16,7 @@
 package org.komodo.relational.commands.vdb;
 
 import static org.junit.Assert.assertEquals;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.relational.vdb.Entry;
@@ -25,9 +26,10 @@ import org.komodo.shell.api.CommandResult;
 
 /**
  * Test Class to test AddEntryCommand
- *
+ * -- currently ignored - cannot create Entry in vdbbuilder
  */
 @SuppressWarnings( {"javadoc", "nls"} )
+@Ignore
 public class AddEntryCommandTest extends AbstractCommandTest {
 
     @Test

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteEntryCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteEntryCommandTest.java
@@ -16,6 +16,7 @@
 package org.komodo.relational.commands.vdb;
 
 import static org.junit.Assert.assertEquals;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.relational.vdb.Entry;
@@ -25,9 +26,10 @@ import org.komodo.shell.api.CommandResult;
 
 /**
  * Test Class to test DeleteEntryCommand
- *
+ * -- currently ignored - cannot create Entry in vdbbuilder
  */
 @SuppressWarnings( {"javadoc", "nls"} )
+@Ignore
 public class DeleteEntryCommandTest extends AbstractCommandTest {
 
     @Test

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/CreateVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/CreateVdbCommandTest.java
@@ -30,7 +30,23 @@ import org.komodo.shell.api.CommandResult;
 public class CreateVdbCommandTest extends AbstractCommandTest {
 
     @Test
-    public void testCreateVdb1() throws Exception {
+    public void shouldCreateVdbWithoutOptionalPath() throws Exception {
+        final String[] commands = { "workspace",
+                                    "create-vdb testVdb" };
+        setup( commands  );
+
+        CommandResult result = execute();
+        assertCommandResultOk(result);
+
+        WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);
+        Vdb[] vdbs = wkspMgr.findVdbs(getTransaction());
+
+        assertEquals(1, vdbs.length);
+        assertEquals("testVdb", vdbs[0].getName(getTransaction()));
+    }
+    
+    @Test
+    public void shouldCreateVdbWithOptionalPath() throws Exception {
         final String[] commands = { "workspace",
                                     "create-vdb testVdb vdbPath" };
         setup( commands  );


### PR DESCRIPTION
- the Vdb filePath should not be mandatory.  changed the cnd to remove as mandatory
- modify the CreateVdbCommand to make the filePath an optional arg
- disabled all VdbEntry related commands.  The VDBBuilder will not be allowed to create VDB entries (may be added at a later time, but disabled for now).
- now ignores the VdbEntry unit tests.