### PR TITLE
Changes To Test Framework

### DIFF
--- a/tests/org.komodo.relational.commands.test/META-INF/MANIFEST.MF
+++ b/tests/org.komodo.relational.commands.test/META-INF/MANIFEST.MF
@@ -10,5 +10,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.jboss.tools.locus.mockito;bundle-version="1.9.5",
  org.komodo.test.utils;bundle-version="0.0.1",
- org.komodo.importer;bundle-version="0.0.2"
-Import-Package: org.komodo.shell
+ org.komodo.importer;bundle-version="0.0.2",
+ org.komodo.shell.test;bundle-version="0.0.2"

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AbstractCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AbstractCommandTest.java
@@ -1,50 +1,28 @@
 package org.komodo.relational.commands;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
-import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.komodo.core.KEngine;
-import org.komodo.shell.CompletionConstants;
-import org.komodo.shell.WorkspaceStatusImpl;
-import org.komodo.shell.api.Arguments;
+import org.komodo.repository.RepositoryImpl;
 import org.komodo.shell.api.CommandResult;
-import org.komodo.shell.api.InvalidCommandArgumentException;
-import org.komodo.shell.api.KomodoShell;
-import org.komodo.shell.api.WorkspaceStatus;
-import org.komodo.shell.commands.PlayCommand;
-import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.constants.SystemConstants;
-import org.komodo.spi.repository.Repository;
-import org.komodo.spi.repository.Repository.UnitOfWork;
-import org.komodo.spi.repository.RepositoryClient;
-import org.komodo.test.utils.AbstractLocalRepositoryTest;
 import org.komodo.utils.KLog;
-import org.mockito.Mockito;
 
-@SuppressWarnings( { "javadoc", "nls" } )
-public abstract class AbstractCommandTest extends AbstractLocalRepositoryTest {
+@SuppressWarnings( { "javadoc",
+                     "nls" } )
+public abstract class AbstractCommandTest extends org.komodo.shell.AbstractCommandTest {
 
     private static final KLog LOGGER = KLog.getLogger();
     private static final Path SHELL_DATA_DIRECTORY;
 
-    private static KEngine kEngine = KEngine.getInstance();
+    private static Path _saveShellDataDirectory;
 
     static {
         Path tempDataDir = null;
@@ -100,190 +78,25 @@ public abstract class AbstractCommandTest extends AbstractLocalRepositoryTest {
         SHELL_DATA_DIRECTORY = tempDataDir;
     }
 
-    @BeforeClass
-    public static void startKEngine() throws Exception {
-        assertNotNull( _repo );
-        final long startTime = System.currentTimeMillis();
-        LOGGER.debug( "AbstractCommandTest:startKEngine" );
-
-        kEngine.setDefaultRepository( _repo );
-        kEngine.start();
-
-        assertEquals( RepositoryClient.State.STARTED, kEngine.getState() );
-        assertEquals( Repository.State.REACHABLE, kEngine.getDefaultRepository().getState() );
-        LOGGER.debug( "AbstractCommandTest:startKEngine finished. Time to start: {0}",
-                      ( System.currentTimeMillis() - startTime ) );
-    }
-
     @AfterClass
-    public static void stopKEngine() throws Exception {
-        assertNotNull( kEngine );
-
-        // Reset the latch to signal when repo has been shutdown
-        _repoObserver.resetLatch();
-        kEngine.shutdown();
-
-        if ( !_repoObserver.getLatch().await( 1, TimeUnit.MINUTES ) ) {
-            throw new RuntimeException( "Local repository was not stopped" );
-        }
-
-        kEngine.setDefaultRepository( null );
-        assertEquals( RepositoryClient.State.SHUTDOWN, kEngine.getState() );
-        assertEquals( Repository.State.NOT_REACHABLE, _repo.getState() );
+    public static void restoreShellDataDirectory() {
+        _shellDataDirectory = _saveShellDataDirectory;
+        System.setProperty( SystemConstants.VDB_BUILDER_DATA_DIR, _shellDataDirectory.toString() );
     }
 
-    protected Writer commandWriter;
-    private PlayCommand playCmd;
-    protected WorkspaceStatus wsStatus;
-
-    @SuppressWarnings( "unused" )
-    private UnitOfWork uow; // hides superclass variable from subclasses (always null as transaction from WorkspaceStatus is used)
+    @BeforeClass
+    public static void setShellDataDirectory() {
+        _saveShellDataDirectory = _shellDataDirectory;
+        _shellDataDirectory = SHELL_DATA_DIRECTORY;
+        System.setProperty( SystemConstants.VDB_BUILDER_DATA_DIR, _shellDataDirectory.toString() );
+    }
 
     @Before
-    public void beforeEach() throws Exception {
-        assertEquals( RepositoryClient.State.STARTED, kEngine.getState() );
-        assertEquals( Repository.State.REACHABLE, kEngine.getDefaultRepository().getState() );
-
-        KomodoShell komodoShell = Mockito.mock( KomodoShell.class );
-        Mockito.when( komodoShell.getEngine() ).thenReturn( kEngine );
-        Mockito.when( komodoShell.getInputStream() ).thenReturn( System.in );
-        Mockito.when( komodoShell.getOutputWriter() ).thenReturn( new StringWriter() );
-        Mockito.when( komodoShell.getShellDataLocation() ).thenReturn( SHELL_DATA_DIRECTORY.toString() );
-        Mockito.when( komodoShell.getShellPropertiesFile() ).thenReturn( "vdbbuilderShell.properties" );
-
-        this.wsStatus = new WorkspaceStatusImpl( super.getTransaction(), komodoShell );
-        this.commandWriter = new StringWriter();
-    }
-
-    protected void assertCommandsNotAvailable( final String... cmdNames ) throws Exception {
-        final Collection< String > available = Arrays.asList( this.wsStatus.getAvailableCommands() );
-
-        for ( final String name : cmdNames ) {
-            if ( available.contains( name ) ) {
-                Assert.fail( "Command " + name + " should not be available" );
-            }
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.test.utils.AbstractLocalRepositoryTest#getTransaction()
-     */
-    @Override
-    protected UnitOfWork getTransaction() {
-        return this.wsStatus.getTransaction();
-    }
-
-    protected void setup( final String commandFilePath ) throws Exception {
-        final String filePath = ( new File( commandFilePath ).isAbsolute() ) ? commandFilePath
-            : ( "./resources/" + commandFilePath );
-        final Arguments args = new Arguments( filePath );
-
-        // construct play command
-        this.playCmd = new PlayCommand( this.wsStatus );
-        this.playCmd.setArguments( args );
-        this.playCmd.setWriter( this.commandWriter );
-    }
-
-    protected void setup( final String[] commands ) throws Exception {
-        final File cmdFile = File.createTempFile( "TestCommand", ".txt" ); //$NON-NLS-1$  //$NON-NLS-2$
-        cmdFile.deleteOnExit();
-
-        try ( final FileWriter writer = new FileWriter( cmdFile ) ) {
-            for ( final String command : commands ) {
-                writer.write( command + NEW_LINE );
-            }
-        }
-
-        final String commandFilePath = cmdFile.getAbsolutePath();
-        setup( commandFilePath );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.test.utils.AbstractLocalRepositoryTest#commit()
-     */
-    @Override
-    protected final void commit() throws Exception {
-        this.wsStatus.commit( getClass().getSimpleName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.test.utils.AbstractLocalRepositoryTest#rollback()
-     */
-    @Override
-    protected final void rollback() throws Exception {
-        this.wsStatus.rollback( getClass().getSimpleName() );
-    }
-
-    @After
-    public void teardown() {
-        this.commandWriter = null;
-        this.playCmd = null;
-    }
-
-    /**
-     * Executes the command file, putting the result output into writer.
-     */
-    protected CommandResult execute() {
-        CommandResult result = null;
-        try {
-            result = this.playCmd.execute();
-
-            if ( result.isOk() ) {
-                commit();
-            } else {
-                rollback();
-
-                if ( result.getError() != null ) {
-                    throw result.getError();
-                }
-
-                Assert.fail( "Failed : " + result.getMessage() ); //$NON-NLS-1$
-            }
-        } catch ( InvalidCommandArgumentException e ) {
-            Assert.fail( "Failed - invalid command: " + e.getMessage() ); //$NON-NLS-1$
-        } catch ( Exception e ) {
-            Assert.fail( "Failed : " + e.getMessage() ); //$NON-NLS-1$
-        }
-        return result;
-    }
-
-    protected void assertCommandResultOk( CommandResult result ) {
-        if ( !result.isOk() ) {
-            if ( result.getError() != null ) {
-                Assert.fail( "Failed : " + result.getError().getMessage() ); //$NON-NLS-1$
-            } else {
-                Assert.fail( "Failed : " + result.getMessage() ); //$NON-NLS-1$
-            }
-        }
-    }
-
-    /**
-     * Get command output. Contains only the output of the command being tested.
-     *
-     * @return the output
-     */
-    protected String getCommandOutput() {
-        return this.commandWriter.toString();
-    }
-
-    /**
-     * Get the message indent string
-     *
-     * @return the indent string
-     */
-    protected static String getIndentStr() {
-        int indent = CompletionConstants.MESSAGE_INDENT;
-        StringBuffer sb = new StringBuffer();
-        for ( int i = 0; i < indent; i++ ) {
-            sb.append( StringConstants.SPACE );
-        }
-        return sb.toString();
+    public void startInWorkspace() throws Exception {
+        final String[] commands = { "workspace" };
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
+        assertContextIs( RepositoryImpl.WORKSPACE_ROOT );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/FindCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/FindCommandTest.java
@@ -24,19 +24,16 @@ import org.komodo.shell.api.CommandResult;
  *
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class FindCommandTest extends AbstractCommandTest {
+public final class FindCommandTest extends AbstractCommandTest {
 
     @Test
     public void testFind1() throws Exception {
         final String[] commands = { "set-auto-commit false",
-                                    "workspace",
                                     "create-vdb testVdb1 vdbPath",
                                     "create-vdb testVdb2 vdbPath",
                                     "commit",
                                     "find Vdb" };
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         // Make sure the two VDBs are found

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalAddChildCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalAddChildCommandTest.java
@@ -16,19 +16,17 @@
 package org.komodo.relational.commands;
 
 import org.junit.Test;
+import org.komodo.shell.commands.AddChildCommand;
 
 /**
  * Test Class to test {@link RelationalAddChildCommand}.
  */
-@SuppressWarnings( { "javadoc", "nls" } )
-public class RelationalAddChildCommandTest extends AbstractCommandTest {
+@SuppressWarnings( { "javadoc" } )
+public final class RelationalAddChildCommandTest extends AbstractCommandTest {
 
-    @Test( expected = AssertionError.class )
+    @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
-        final String[] commands = { "workspace",
-                                    "add-child blah" };
-        setup( commands );
-        execute();
+        assertCommandsNotAvailable( AddChildCommand.NAME );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalAddDescriptorCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalAddDescriptorCommandTest.java
@@ -16,19 +16,17 @@
 package org.komodo.relational.commands;
 
 import org.junit.Test;
+import org.komodo.shell.commands.AddDescriptorCommand;
 
 /**
  * Test Class to test {@link RelationalAddDescriptorCommand}.
  */
-@SuppressWarnings( { "javadoc", "nls" } )
-public class RelationalAddDescriptorCommandTest extends AbstractCommandTest {
+@SuppressWarnings( { "javadoc" } )
+public final class RelationalAddDescriptorCommandTest extends AbstractCommandTest {
 
-    @Test( expected = AssertionError.class )
+    @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
-        final String[] commands = { "workspace",
-                                    "add-descriptor blah" };
-        setup( commands );
-        execute();
+        assertCommandsNotAvailable( AddDescriptorCommand.NAME );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalDeleteChildCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalDeleteChildCommandTest.java
@@ -16,19 +16,17 @@
 package org.komodo.relational.commands;
 
 import org.junit.Test;
+import org.komodo.shell.commands.DeleteChildCommand;
 
 /**
  * Test Class to test {@link RelationalDeleteChildCommand}.
  */
-@SuppressWarnings( { "javadoc", "nls" } )
-public class RelationalDeleteChildCommandTest extends AbstractCommandTest {
+@SuppressWarnings( { "javadoc" } )
+public final class RelationalDeleteChildCommandTest extends AbstractCommandTest {
 
-    @Test( expected = AssertionError.class )
+    @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
-        final String[] commands = { "workspace",
-                                    "delete-child blah" };
-        setup( commands );
-        execute();
+        assertCommandsNotAvailable( DeleteChildCommand.NAME );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalRemoveDescriptorCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalRemoveDescriptorCommandTest.java
@@ -16,19 +16,17 @@
 package org.komodo.relational.commands;
 
 import org.junit.Test;
+import org.komodo.shell.commands.RemoveDescriptorCommand;
 
 /**
  * Test Class to test {@link RelationalRemoveDescriptorCommand}.
  */
-@SuppressWarnings( { "javadoc", "nls" } )
-public class RelationalRemoveDescriptorCommandTest extends AbstractCommandTest {
+@SuppressWarnings( { "javadoc" } )
+public final class RelationalRemoveDescriptorCommandTest extends AbstractCommandTest {
 
-    @Test( expected = AssertionError.class )
+    @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
-        final String[] commands = { "workspace",
-                                    "remove-descriptor blah" };
-        setup( commands );
-        execute();
+        assertCommandsNotAvailable( RemoveDescriptorCommand.NAME );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalSetPrimaryTypeCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalSetPrimaryTypeCommandTest.java
@@ -16,19 +16,17 @@
 package org.komodo.relational.commands;
 
 import org.junit.Test;
+import org.komodo.shell.commands.SetPrimaryTypeCommand;
 
 /**
  * Test Class to test {@link RelationalSetPrimaryTypeCommand}.
  */
-@SuppressWarnings( { "javadoc", "nls" } )
-public class RelationalSetPrimaryTypeCommandTest extends AbstractCommandTest {
+@SuppressWarnings( { "javadoc" } )
+public final class RelationalSetPrimaryTypeCommandTest extends AbstractCommandTest {
 
-    @Test( expected = AssertionError.class )
+    @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
-        final String[] commands = { "workspace",
-                                    "set-primary-type blah" };
-        setup( commands );
-        execute();
+        assertCommandsNotAvailable( SetPrimaryTypeCommand.NAME );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalShowDescriptorsCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/RelationalShowDescriptorsCommandTest.java
@@ -16,19 +16,17 @@
 package org.komodo.relational.commands;
 
 import org.junit.Test;
+import org.komodo.shell.commands.ShowDescriptorsCommand;
 
 /**
  * Test Class to test {@link RelationalShowDescriptorsCommand}.
  */
-@SuppressWarnings( { "javadoc", "nls" } )
-public class RelationalShowDescriptorsCommandTest extends AbstractCommandTest {
+@SuppressWarnings( { "javadoc" } )
+public final class RelationalShowDescriptorsCommandTest extends AbstractCommandTest {
 
-    @Test( expected = AssertionError.class )
+    @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
-        final String[] commands = { "workspace",
-                                    "show-descriptors" };
-        setup( commands );
-        execute();
+        assertCommandsNotAvailable( ShowDescriptorsCommand.NAME );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/SetCustomPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/SetCustomPropertyCommandTest.java
@@ -23,21 +23,17 @@ import org.komodo.shell.api.CommandResult;
 import org.komodo.spi.repository.Property;
 
 /**
- * Test Class to test SetCustomPropertyCommand
- *
+ * Test Class to test {@link SetCustomPropertyCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
 public class SetCustomPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testCustomProperty1() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-vdb testVdb vdbPath",
+        final String[] commands = { "create-vdb testVdb vdbPath",
                                     "cd testVdb",
                                     "set-custom-property newProperty myProperty" };
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/UnsetCustomPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/UnsetCustomPropertyCommandTest.java
@@ -24,23 +24,19 @@ import org.komodo.shell.api.CommandResult;
 import org.komodo.spi.repository.Property;
 
 /**
- * Test Class to test UnsetCustomPropertyCommand
- *
+ * Test Class to test {@link UnsetCustomPropertyCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class UnsetCustomPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetCustomPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetCustomProperty1() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-vdb testVdb vdbPath",
+        final String[] commands = { "create-vdb testVdb vdbPath",
                                     "cd testVdb",
                                     "set-custom-property newProperty myProperty",
                                     "unset-custom-property newProperty" };
 
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/column/SetColumnPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/column/SetColumnPropertyCommandTest.java
@@ -26,15 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetColumnPropertyCommand
- *
+ * Test Class to test {@link SetColumnPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc","nls"} )
-public class SetColumnPropertyCommandTest extends AbstractCommandTest {
+public final class SetColumnPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,9 +43,7 @@ public class SetColumnPropertyCommandTest extends AbstractCommandTest {
             "add-column myColumn",
             "cd myColumn",
             "set-property NAMEINSOURCE myNameInSource" };
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/column/UnsetColumnPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/column/UnsetColumnPropertyCommandTest.java
@@ -32,11 +32,11 @@ import org.komodo.shell.api.CommandResult;
  *
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetColumnPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetColumnPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -47,9 +47,7 @@ public class UnsetColumnPropertyCommandTest extends AbstractCommandTest {
             "cd myColumn",
             "set-property NAMEINSOURCE myNameInSource",
             "unset-property NAMEINSOURCE" };
-        setup( commands );
-        
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);
@@ -63,11 +61,11 @@ public class UnsetColumnPropertyCommandTest extends AbstractCommandTest {
 
         Table[] tables = models[0].getTables(getTransaction());
         assertEquals(1, tables.length);
-        assertEquals("myTable", tables[0].getName(getTransaction())); 
+        assertEquals("myTable", tables[0].getName(getTransaction()));
 
         Column[] columns = tables[0].getColumns(getTransaction());
         assertEquals(1, columns.length);
-        assertEquals("myColumn", columns[0].getName(getTransaction())); 
+        assertEquals("myColumn", columns[0].getName(getTransaction()));
 
         String nameInSource = columns[0].getNameInSource(getTransaction());
         assertNull(nameInSource);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/condition/SetConditionPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/condition/SetConditionPropertyCommandTest.java
@@ -29,12 +29,11 @@ import org.komodo.shell.api.CommandResult;
  * Test Class to test {@link SetConditionPropertyCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class SetConditionPropertyCommandTest extends AbstractCommandTest {
+public final class SetConditionPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-vdb myVdb vdbPath",
+        final String[] commands = { "create-vdb myVdb vdbPath",
                                     "cd myVdb",
                                     "add-data-role myDataRole",
                                     "cd myDataRole",
@@ -43,9 +42,7 @@ public class SetConditionPropertyCommandTest extends AbstractCommandTest {
                                     "add-condition myCondition",
                                     "cd myCondition",
                                     "set-property constraint true" };
-    	setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/condition/UnsetConditionPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/condition/UnsetConditionPropertyCommandTest.java
@@ -34,7 +34,7 @@ public class UnsetConditionPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -45,9 +45,7 @@ public class UnsetConditionPropertyCommandTest extends AbstractCommandTest {
             "cd myCondition",
             "set-property constraint true",
             "unset-property constraint"};
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/AddMappedRoleCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/AddMappedRoleCommandTest.java
@@ -32,7 +32,7 @@ public class AddMappedRoleCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -40,9 +40,7 @@ public class AddMappedRoleCommandTest extends AbstractCommandTest {
             "add-permission myPermission",
             "add-mapped-role myMappedRole"};
 
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/AddPermissionCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/AddPermissionCommandTest.java
@@ -33,16 +33,14 @@ public class AddPermissionCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
             "cd myDataRole",
             "add-permission myPermission"};
 
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/DeleteMappedRoleCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/DeleteMappedRoleCommandTest.java
@@ -28,7 +28,7 @@ import org.komodo.shell.api.CommandResult;
  *
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteMappedRoleCommandTest extends AbstractCommandTest {
+public final class DeleteMappedRoleCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
@@ -40,10 +40,7 @@ public class DeleteMappedRoleCommandTest extends AbstractCommandTest {
             "add-mapped-role myMappedRole1",
             "add-mapped-role myMappedRole2",
             "delete-mapped-role myMappedRole1"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/DeletePermissionCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/DeletePermissionCommandTest.java
@@ -33,7 +33,7 @@ public class DeletePermissionCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -41,10 +41,7 @@ public class DeletePermissionCommandTest extends AbstractCommandTest {
             "add-permission myPermission1",
             "add-permission myPermission2",
             "delete-permission myPermission1"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/SetDataRolePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/SetDataRolePropertyCommandTest.java
@@ -28,20 +28,17 @@ import org.komodo.shell.api.CommandResult;
  *
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetDataRolePropertyCommandTest extends AbstractCommandTest {
+public final class SetDataRolePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
             "cd myDataRole",
             "set-property description myDescription"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/UnsetDataRolePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datarole/UnsetDataRolePropertyCommandTest.java
@@ -24,25 +24,21 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetDataRolePropertyCommand
- *
+ * Test Class to test {@link UnsetDataRolePropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetDataRolePropertyCommandTest extends AbstractCommandTest {
+public final class UnsetDataRolePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
             "cd myDataRole",
             "set-property description myDescription",
             "unset-property description"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datatyperesultset/DataTypeResultSetCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datatyperesultset/DataTypeResultSetCommandTest.java
@@ -29,8 +29,7 @@ public abstract class DataTypeResultSetCommandTest extends AbstractCommandTest {
 
     @Before
     public void createContext() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-vdb myVdb vdbPath",
+        final String[] commands = { "create-vdb myVdb vdbPath",
                                     "cd myVdb",
                                     "add-model myModel ",
                                     "cd myModel",
@@ -38,8 +37,7 @@ public abstract class DataTypeResultSetCommandTest extends AbstractCommandTest {
                                     "cd myPushdownFunction",
                                     "set-result-set DataTypeResultSet",
                                     "cd resultSet" };
-        setup( commands );
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
 
         final WorkspaceManager wkspMgr = WorkspaceManager.getInstance( _repo );

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datatyperesultset/SetDataTypeResultSetPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datatyperesultset/SetDataTypeResultSetPropertyCommandTest.java
@@ -31,9 +31,8 @@ public final class SetDataTypeResultSetPropertyCommandTest extends DataTypeResul
     public void shouldSetProperty() throws Exception {
         final long expected = 99;
         final String[] commands = { "set-property datatypeLength " + expected };
-        setup( commands );
 
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertThat( get().getLength( getTransaction() ), is( expected ) );
     }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datatyperesultset/UnsetDataTypeResultSetPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/datatyperesultset/UnsetDataTypeResultSetPropertyCommandTest.java
@@ -33,9 +33,8 @@ public final class UnsetDataTypeResultSetPropertyCommandTest extends DataTypeRes
         final String[] commands = { "set-property datatypeLength 99",
                                     "set-property " + property + " blah",
                                     "unset-property " + property };
-        setup( commands );
 
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertThat( get().hasProperty( getTransaction(), property ), is( false ) );
     }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/entry/SetEntryPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/entry/SetEntryPropertyCommandTest.java
@@ -34,16 +34,13 @@ public class SetEntryPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-entry myEntry entryPath",
             "cd myEntry",
             "set-property description myDescription"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/entry/UnsetEntryPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/entry/UnsetEntryPropertyCommandTest.java
@@ -30,21 +30,18 @@ import org.komodo.shell.api.CommandResult;
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 @Ignore
-public class UnsetEntryPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetEntryPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-entry myEntry entryPath",
             "cd myEntry",
             "set-property description myDescription",
             "unset-property description"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/foreignkey/AddReferenceColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/foreignkey/AddReferenceColumnCommandTest.java
@@ -27,15 +27,15 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddReferenceColumnCommand
+ * Test Class to test {@link AddReferenceColumnCommand}.
  *
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddReferenceColumnCommandTest extends AbstractCommandTest {
+public final class AddReferenceColumnCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model refModel",
@@ -52,10 +52,7 @@ public class AddReferenceColumnCommandTest extends AbstractCommandTest {
             "add-foreign-key myForeignKey /workspace/myVdb/refModel/refTable",
             "cd myForeignKey",
             "add-ref-column /workspace/myVdb/refModel/refTable/refCol1" };
-        
-        setup( commands );
-
-    	CommandResult result = execute();
+    	final CommandResult result = execute( commands );
     	assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/foreignkey/DeleteReferenceColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/foreignkey/DeleteReferenceColumnCommandTest.java
@@ -27,16 +27,15 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteReferenceColumnCommand
+ * Test Class to test {@link DeleteReferenceColumnCommand}.
  *
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class DeleteReferenceColumnCommandTest extends AbstractCommandTest {
+public final class DeleteReferenceColumnCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-vdb myVdb vdbPath",
+        final String[] commands = { "create-vdb myVdb vdbPath",
                                     "cd myVdb",
                                     "add-model refModel",
                                     "cd refModel",
@@ -55,9 +54,7 @@ public class DeleteReferenceColumnCommandTest extends AbstractCommandTest {
                                     "add-ref-column /workspace/myVdb/refModel/refTable/refCol2",
                                     "commit", // need to commit since delete-ref-column uses search framework
                                     "delete-ref-column /workspace/myVdb/refModel/refTable/refCol1" };
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/index/SetIndexPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/index/SetIndexPropertyCommandTest.java
@@ -26,15 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetIndexPropertyCommand
- *
+ * Test Class to test {@link SetIndexPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetIndexPropertyCommandTest extends AbstractCommandTest {
+public final class SetIndexPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +43,7 @@ public class SetIndexPropertyCommandTest extends AbstractCommandTest {
             "add-index myIndex",
             "cd myIndex",
             "set-property expression myExpression"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/index/UnsetIndexPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/index/UnsetIndexPropertyCommandTest.java
@@ -26,15 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetIndexPropertyCommand
- *
+ * Test Class to test {@link UnsetIndexPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetIndexPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetIndexPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -45,10 +44,7 @@ public class UnsetIndexPropertyCommandTest extends AbstractCommandTest {
             "cd myIndex",
             "set-property expression myExpression",
             "unset-property expression" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/mask/SetMaskPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/mask/SetMaskPropertyCommandTest.java
@@ -26,15 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetMaskPropertyCommand
- *
+ * Test Class to test {@link SetMaskPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetMaskPropertyCommandTest extends AbstractCommandTest {
+public final class SetMaskPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -44,10 +43,7 @@ public class SetMaskPropertyCommandTest extends AbstractCommandTest {
             "add-mask myMask",
             "cd myMask",
             "set-property order myOrder"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/mask/UnsetMaskPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/mask/UnsetMaskPropertyCommandTest.java
@@ -26,15 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetMaskPropertyCommand
- *
+ * Test Class to test {@link UnsetMaskPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetMaskPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetMaskPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -45,10 +44,7 @@ public class UnsetMaskPropertyCommandTest extends AbstractCommandTest {
             "cd myMask",
             "set-property order myOrder",
             "unset-property order" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddPushdownFunctionCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddPushdownFunctionCommandTest.java
@@ -26,25 +26,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddPushdownFunctionCommand
- *
+ * Test Class to test {@link AddPushdownFunctionCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddPushdownFunctionCommandTest extends AbstractCommandTest {
+public final class AddPushdownFunctionCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "add-pushdown-function myPushdownFunction"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddSourceCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddSourceCommandTest.java
@@ -25,25 +25,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddSourceCommand
- *
+ * Test Class to test {@link AddSourceCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddSourceCommandTest extends AbstractCommandTest {
+public final class AddSourceCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "add-source mySource"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddStoredProcedureCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddStoredProcedureCommandTest.java
@@ -26,25 +26,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddStoredProcedureCommand
- *
+ * Test Class to test {@link AddStoredProcedureCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddStoredProcedureCommandTest extends AbstractCommandTest {
+public final class AddStoredProcedureCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "add-stored-procedure myStoredProcedure"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddTableCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddTableCommandTest.java
@@ -25,25 +25,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddTableCommand
- *
+ * Test Class to test {@link AddTableCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddTableCommandTest extends AbstractCommandTest {
+public final class AddTableCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "add-table myTable"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddUserDefinedFunctionCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddUserDefinedFunctionCommandTest.java
@@ -26,25 +26,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddUserDefinedFunctionCommand
- *
+ * Test Class to test {@link AddUserDefinedFunctionCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddUserDefinedFunctionCommandTest extends AbstractCommandTest {
+public final class AddUserDefinedFunctionCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "add-user-defined-function myUserDefinedFunction"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddViewCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddViewCommandTest.java
@@ -25,25 +25,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddViewCommand
- *
+ * Test Class to test {@link AddViewCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddViewCommandTest extends AbstractCommandTest {
+public final class AddViewCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "add-view myView"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddVirtualProcedureCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/AddVirtualProcedureCommandTest.java
@@ -26,25 +26,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddVirtualProcedureCommand
- *
+ * Test Class to test {@link AddVirtualProcedureCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddVirtualProcedureCommandTest extends AbstractCommandTest {
+public final class AddVirtualProcedureCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "add-virtual-procedure myVirtualProcedure"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeletePushdownFunctionCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeletePushdownFunctionCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeletePushdownFunctionCommand
- *
+ * Test Class to test {@link DeletePushdownFunctionCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeletePushdownFunctionCommandTest extends AbstractCommandTest {
+public final class DeletePushdownFunctionCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class DeletePushdownFunctionCommandTest extends AbstractCommandTest {
             "add-pushdown-function myPushdownFunction1",
             "add-pushdown-function myPushdownFunction2",
             "delete-pushdown-function myPushdownFunction1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteSourceCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteSourceCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteSourceCommand
- *
+ * Test Class to test {@link DeleteSourceCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteSourceCommandTest extends AbstractCommandTest {
+public final class DeleteSourceCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -42,10 +40,7 @@ public class DeleteSourceCommandTest extends AbstractCommandTest {
             "add-source mySource1",
             "add-source mySource2",
             "delete-source mySource1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteStoredProcedureCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteStoredProcedureCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteStoredProcedureCommand
- *
+ * Test Class to test {@link DeleteStoredProcedureCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteStoredProcedureCommandTest extends AbstractCommandTest {
+public final class DeleteStoredProcedureCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class DeleteStoredProcedureCommandTest extends AbstractCommandTest {
             "add-stored-procedure myStoredProcedure1",
             "add-stored-procedure myStoredProcedure2",
             "delete-stored-procedure myStoredProcedure1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteTableCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteTableCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteTableCommand
- *
+ * Test Class to test {@link DeleteTableCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteTableCommandTest extends AbstractCommandTest {
+public final class DeleteTableCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -42,10 +40,7 @@ public class DeleteTableCommandTest extends AbstractCommandTest {
             "add-table myTable1",
             "add-table myTable2",
             "delete-table myTable1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteUserDefinedFunctionCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteUserDefinedFunctionCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteUserDefinedFunctionCommand
- *
+ * Test Class to test {@link DeleteUserDefinedFunctionCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteUserDefinedFunctionCommandTest extends AbstractCommandTest {
+public final class DeleteUserDefinedFunctionCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class DeleteUserDefinedFunctionCommandTest extends AbstractCommandTest {
             "add-user-defined-function myUserDefinedFunction1",
             "add-user-defined-function myUserDefinedFunction2",
             "delete-user-defined-function myUserDefinedFunction1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteViewCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteViewCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteViewCommand
- *
+ * Test Class to test {@link DeleteViewCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteViewCommandTest extends AbstractCommandTest {
+public final class DeleteViewCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -42,10 +40,7 @@ public class DeleteViewCommandTest extends AbstractCommandTest {
             "add-view myView1",
             "add-view myView2",
             "delete-view myView1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteVirtualProcedureCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/DeleteVirtualProcedureCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteVirtualProcedureCommand
- *
+ * Test Class to test {@link DeleteVirtualProcedureCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteVirtualProcedureCommandTest extends AbstractCommandTest {
+public final class DeleteVirtualProcedureCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class DeleteVirtualProcedureCommandTest extends AbstractCommandTest {
             "add-virtual-procedure myVirtualProcedure1",
             "add-virtual-procedure myVirtualProcedure2",
             "delete-virtual-procedure myVirtualProcedure1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/ExportCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/ExportCommandTest.java
@@ -27,8 +27,7 @@ import org.komodo.spi.repository.KomodoObject;
 import org.komodo.test.utils.TestUtilities;
 
 /**
- * Test Class to test ExportCommand
- *
+ * Test Class to test {@link ExportCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 public class ExportCommandTest extends AbstractCommandTest {
@@ -95,21 +94,15 @@ public class ExportCommandTest extends AbstractCommandTest {
         //
         // The commands
         //
-        final String[] commands = { 
+        final String[] commands = {
             "commit",
             "workspace",
             "cd " + tweetVdb.getName(getTransaction()),
             "cd twitterview",
             "export-ddl " + exportDest.getAbsolutePath() };
-
-        setup( commands );
-
-        //
-        // Execute the commands
-        //
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
         assertTrue(exportDest.exists());
-        assertTrue(result.isOk());
 
         String exportContents = TestUtilities.fileToString(exportDest);
         assertEquals(TWITTER_VIEW_MODEL_DDL + NEW_LINE, exportContents);
@@ -144,19 +137,14 @@ public class ExportCommandTest extends AbstractCommandTest {
         //
         // The commands
         //
-        final String[] commands = { 
+        final String[] commands = {
             "commit",
             "workspace",
             "cd " + allElementsVdb.getName(getTransaction()),
             "cd model-one",
             "export-ddl " + exportDest.getAbsolutePath() };
-
-        setup( commands );
-
-        //
-        // Execute the commands
-        //
-        execute();
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
 //        assertTrue(exportDest.exists());
 //        assertTrue(!result.isOk());
 //
@@ -193,19 +181,13 @@ public class ExportCommandTest extends AbstractCommandTest {
         //
         // The commands
         //
-        final String[] commands = { 
+        final String[] commands = {
             "commit",
             "workspace",
             "cd " + allElementsVdb.getName(getTransaction()),
             "cd model-two",
             "export-ddl " + exportDest.getAbsolutePath() };
-
-        setup( commands );
-
-        //
-        // Execute the commands
-        //
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         assertTrue(exportDest.exists());

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/ImportCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/ImportCommandTest.java
@@ -15,34 +15,27 @@
  */
 package org.komodo.relational.commands.model;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
+import org.komodo.repository.RepositoryImpl;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test ImportCommand
- *
+ * Test Class to test {@link ImportCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class ImportCommandTest extends AbstractCommandTest {
+public final class ImportCommandTest extends AbstractCommandTest {
 
     @Test
     public void testImportDdl1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
-
-    	// Check WorkspaceContext
-    	assertEquals("/workspace", wsStatus.getDisplayPath(wsStatus.getCurrentContext())); //$NON-NLS-1$
+        assertContextIs( RepositoryImpl.WORKSPACE_ROOT );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/SetModelPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/SetModelPropertyCommandTest.java
@@ -24,25 +24,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetModelPropertyCommand
- *
+ * Test Class to test {@link SetModelPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetModelPropertyCommandTest extends AbstractCommandTest {
+public final class SetModelPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "set-property description myDescription" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/UnsetModelPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/UnsetModelPropertyCommandTest.java
@@ -24,26 +24,21 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetModelPropertyCommand
- *
+ * Test Class to test {@link UnsetModelPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetModelPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetModelPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "set-property description myDescription",
             "unset-property description" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/modelsource/SetModelSourcePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/modelsource/SetModelSourcePropertyCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetModelSourcePropertyCommand
- *
+ * Test Class to test {@link SetModelSourcePropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetModelSourcePropertyCommandTest extends AbstractCommandTest {
+public final class SetModelSourcePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -42,10 +40,7 @@ public class SetModelSourcePropertyCommandTest extends AbstractCommandTest {
             "add-source mySource",
             "cd mySource",
             "set-property sourceJndiName myJndi" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/modelsource/UnsetModelSourcePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/modelsource/UnsetModelSourcePropertyCommandTest.java
@@ -25,28 +25,23 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetModelSourcePropertyCommand
- *
+ * Test Class to test {@link UnsetModelSourcePropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetModelSourcePropertyCommandTest extends AbstractCommandTest {
+public final class UnsetModelSourcePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
             "cd myModel",
             "add-source mySource",
             "cd mySource",
-            "set-property sourceJndiName myJndi", 
+            "set-property sourceJndiName myJndi",
             "unset-property sourceJndiName" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/parameter/SetParameterPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/parameter/SetParameterPropertyCommandTest.java
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetParameterPropertyCommand
- *
+ * Test Class to test {@link SetParameterPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetParameterPropertyCommandTest extends AbstractCommandTest {
+public final class SetParameterPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -46,10 +44,7 @@ public class SetParameterPropertyCommandTest extends AbstractCommandTest {
             "add-parameter myParameter",
             "cd myParameter",
             "set-property datatypeLength 99" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/parameter/UnsetParameterPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/parameter/UnsetParameterPropertyCommandTest.java
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetParameterPropertyCommand
- *
+ * Test Class to test {@link UnsetParameterPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetParameterPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetParameterPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -47,10 +45,7 @@ public class UnsetParameterPropertyCommandTest extends AbstractCommandTest {
             "cd myParameter",
             "set-property datatypeLength 99",
             "unset-property datatypeLength"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/AddConditionCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/AddConditionCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddConditionCommand
- *
+ * Test Class to test {@link AddConditionCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddConditionCommandTest extends AbstractCommandTest {
+public final class AddConditionCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -43,10 +41,7 @@ public class AddConditionCommandTest extends AbstractCommandTest {
             "add-permission myPermission",
             "cd myPermission",
             "add-condition myCondition" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/AddMaskCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/AddMaskCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddMaskCommand
- *
+ * Test Class to test {@link AddMaskCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddMaskCommandTest extends AbstractCommandTest {
+public final class AddMaskCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -43,10 +41,7 @@ public class AddMaskCommandTest extends AbstractCommandTest {
             "add-permission myPermission",
             "cd myPermission",
             "add-mask myMask" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/DeleteConditionCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/DeleteConditionCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteConditionCommand
- *
+ * Test Class to test {@link DeleteConditionCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteConditionCommandTest extends AbstractCommandTest {
+public final class DeleteConditionCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -46,10 +44,7 @@ public class DeleteConditionCommandTest extends AbstractCommandTest {
             "add-condition myCondition2",
             "delete-condition myCondition1",
             };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/DeleteMaskCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/DeleteMaskCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteMaskCommand
- *
+ * Test Class to test {@link DeleteMaskCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteMaskCommandTest extends AbstractCommandTest {
+public final class DeleteMaskCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -45,10 +43,7 @@ public class DeleteMaskCommandTest extends AbstractCommandTest {
             "add-mask myMask1",
             "add-mask myMask2",
             "delete-mask myMask1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/SetPermissionPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/SetPermissionPropertyCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetPermissionPropertyCommand
- *
+ * Test Class to test {@link SetPermissionPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetPermissionPropertyCommandTest extends AbstractCommandTest {
+public final class SetPermissionPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -42,10 +40,7 @@ public class SetPermissionPropertyCommandTest extends AbstractCommandTest {
             "add-permission myPermission",
             "cd myPermission",
             "set-property allowAlter true" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/UnsetPermissionPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/permission/UnsetPermissionPropertyCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetPermissionPropertyCommand
- *
+ * Test Class to test {@link UnsetPermissionPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetPermissionPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetPermissionPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole",
@@ -43,10 +41,7 @@ public class UnsetPermissionPropertyCommandTest extends AbstractCommandTest {
             "cd myPermission",
             "set-property allowAlter true",
             "unset-property allowAlter"};
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/AddParameterCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/AddParameterCommandTest.java
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddParameterCommand
- *
+ * Test Class to test {@link AddParameterCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddParameterCommandTest extends AbstractCommandTest {
+public final class AddParameterCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +42,7 @@ public class AddParameterCommandTest extends AbstractCommandTest {
             "add-pushdown-function myPushdownFunction",
             "cd myPushdownFunction",
             "add-parameter myParameter" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/DeleteParameterCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/DeleteParameterCommandTest.java
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteParameterCommand
- *
+ * Test Class to test {@link DeleteParameterCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteParameterCommandTest extends AbstractCommandTest {
+public final class DeleteParameterCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -46,10 +44,7 @@ public class DeleteParameterCommandTest extends AbstractCommandTest {
             "add-parameter myParameter1",
             "add-parameter myParameter2",
             "delete-parameter myParameter1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/RemoveResultSetCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/RemoveResultSetCommandTest.java
@@ -28,16 +28,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test RemoveResultSetCommand
- *
+ * Test Class to test {@link RemoveResultSetCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class RemoveResultSetCommandTest extends AbstractCommandTest {
+public final class RemoveResultSetCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -46,10 +44,7 @@ public class RemoveResultSetCommandTest extends AbstractCommandTest {
             "cd myPushdownFunction",
             "set-result-set DataTypeResultSet",
             "remove-result-set" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/SetPushdownFunctionPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/SetPushdownFunctionPropertyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetPushdownFunctionPropertyCommand
- *
+ * Test Class to test {@link SetPushdownFunctionPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetPushdownFunctionPropertyCommandTest extends AbstractCommandTest {
+public final class SetPushdownFunctionPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
         final String[] commands = { 
-            "workspace",
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class SetPushdownFunctionPropertyCommandTest extends AbstractCommandTest 
             "add-pushdown-function myPushdownFunction",
             "cd myPushdownFunction",
             "set-property NAMEINSOURCE myNameInSource" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/SetResultSetCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/SetResultSetCommandTest.java
@@ -28,16 +28,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetResultSetCommand
- *
+ * Test Class to test {@link SetResultSetCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetResultSetCommandTest extends AbstractCommandTest {
+public final class SetResultSetCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSet() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -45,10 +43,7 @@ public class SetResultSetCommandTest extends AbstractCommandTest {
             "add-pushdown-function myPushdownFunction",
             "cd myPushdownFunction",
             "set-result-set DataTypeResultSet" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/UnsetPushdownFunctionPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/pushdownfunction/UnsetPushdownFunctionPropertyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetPushdownFunctionPropertyCommand
- *
+ * Test Class to test {@link UnsetPushdownFunctionPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetPushdownFunctionPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetPushdownFunctionPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +42,7 @@ public class UnsetPushdownFunctionPropertyCommandTest extends AbstractCommandTes
             "cd myPushdownFunction",
             "set-property NAMEINSOURCE myNameInSource",
             "unset-property NAMEINSOURCE" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/resultsetcolumn/SetResultSetColumnPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/resultsetcolumn/SetResultSetColumnPropertyCommandTest.java
@@ -29,16 +29,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetResultSetColumnPropertyCommand
- *
+ * Test Class to test {@link SetResultSetColumnPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetResultSetColumnPropertyCommandTest extends AbstractCommandTest {
+public final class SetResultSetColumnPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -50,10 +48,7 @@ public class SetResultSetColumnPropertyCommandTest extends AbstractCommandTest {
             "add-column myColumn",
             "cd myColumn",
             "set-property NAMEINSOURCE myNameInSource" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/resultsetcolumn/UnsetResultSetColumnPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/resultsetcolumn/UnsetResultSetColumnPropertyCommandTest.java
@@ -30,16 +30,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetResultSetColumnPropertyCommand
- *
+ * Test Class to test {@link UnsetResultSetColumnPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetResultSetColumnPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetResultSetColumnPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -52,10 +50,7 @@ public class UnsetResultSetColumnPropertyCommandTest extends AbstractCommandTest
             "cd myColumn",
             "set-property NAMEINSOURCE myNameInSource",
             "unset-property NAMEINSOURCE" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/schema/ExportCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/schema/ExportCommandTest.java
@@ -28,11 +28,10 @@ import org.komodo.spi.repository.KomodoObject;
 import org.komodo.test.utils.TestUtilities;
 
 /**
- * Test Class to test Schema ExportCommand
- *
+ * Test Class to test Schema {@link ExportCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class ExportCommandTest extends AbstractCommandTest {
+public final class ExportCommandTest extends AbstractCommandTest {
 
     private final static String TWITTER_VIEW_MODEL_DDL = EMPTY_STRING +
                                                          "CREATE VIRTUAL PROCEDURE getTweets(IN query varchar) RETURNS TABLE " +  //$NON-NLS-1$
@@ -82,20 +81,13 @@ public class ExportCommandTest extends AbstractCommandTest {
             exportDest.delete();
 
         // The test commands
-        final String[] commands = { 
+        final String[] commands = {
             "commit",
             "workspace",
             "cd TestTweetSchema",
             "export-ddl " + exportDest.getAbsolutePath() };
-
-        setup( commands );
-
-        //
-        // Execute the commands
-        //
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
-
         assertTrue(exportDest.exists());
 
         String exportContents = TestUtilities.fileToString(exportDest);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/schema/SetSchemaPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/schema/SetSchemaPropertyCommandTest.java
@@ -23,23 +23,18 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetSchemaPropertyCommand
- *
+ * Test Class to test {@link SetSchemaPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetSchemaPropertyCommandTest extends AbstractCommandTest {
+public final class SetSchemaPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-schema testSchema",
             "cd testSchema",
             "set-property rendition \"CREATE FOREIGN TABLE G1 (e1 integer) OPTIONS (ANNOTATION 'test', CARDINALITY '12');\"" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/schema/UnsetSchemaPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/schema/UnsetSchemaPropertyCommandTest.java
@@ -24,24 +24,19 @@ import org.komodo.shell.api.CommandResult;
 import org.komodo.utils.StringUtils;
 
 /**
- * Test Class to test UnsetSchemaPropertyCommand
- *
+ * Test Class to test {@link UnsetSchemaPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetSchemaPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetSchemaPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-schema testSchema",
             "cd testSchema",
             "set-property rendition \"CREATE FOREIGN TABLE G1 (e1 integer) OPTIONS (ANNOTATION 'test', CARDINALITY '12');\"",
             "unset-property rendition" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerConnectCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerConnectCommandTest.java
@@ -21,27 +21,23 @@ import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test ServerConnectCommand
- *
+ * Test Class to test {@link ServerConnectCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class ServerConnectCommandTest extends AbstractCommandTest {
+public final class ServerConnectCommandTest extends AbstractCommandTest {
 
     @Test
     public void shouldFailNoLocalhostFound() throws Exception {
-        final String[] commands = { 
+        final String[] commands = {
             "set-auto-commit false",
-            "workspace",
             "create-teiid myTeiid",
             "commit",
             "set-server myTeiid",
             "server-connect" };
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
 
-        setup( commands );
-
-        CommandResult result = execute();
         String msg = result.getMessage();
-
         assertTrue(msg.contains("localhost is not available"));
     }
 

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDisconnectCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDisconnectCommandTest.java
@@ -21,27 +21,23 @@ import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test ServerDisconnectCommand
- *
+ * Test Class to test {@link ServerDisconnectCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class ServerDisconnectCommandTest extends AbstractCommandTest {
+public final class ServerDisconnectCommandTest extends AbstractCommandTest {
 
     @Test
     public void shouldFailNoServerConnected() throws Exception {
-        final String[] commands = { 
+        final String[] commands = {
             "set-auto-commit false",
-            "workspace",
             "create-teiid myTeiid",
             "commit",
             "set-server myTeiid",
             "server-disconnect" };
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
 
-        setup( commands );
-
-        CommandResult result = execute();
         String msg = result.getMessage();
-
         assertEquals("something", msg);
     }
 

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerSetCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerSetCommandTest.java
@@ -25,26 +25,21 @@ import org.komodo.shell.api.CommandResult;
 import org.komodo.spi.repository.KomodoObject;
 
 /**
- * Test Class to test ServerSetCommand
- *
+ * Test Class to test {@link ServerSetCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class ServerSetCommandTest extends AbstractCommandTest {
+public final class ServerSetCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSet() throws Exception {
-        final String[] commands = { 
+        final String[] commands = {
             "set-auto-commit false",
-            "workspace",
             "create-teiid myTeiid",
             "commit",
             "set-server myTeiid",
             "commit",
             "show-global" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/AddParameterCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/AddParameterCommandTest.java
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddParameterCommand
- *
+ * Test Class to test {@link AddParameterCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddParameterCommandTest extends AbstractCommandTest {
+public final class AddParameterCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +42,7 @@ public class AddParameterCommandTest extends AbstractCommandTest {
             "add-stored-procedure myStoredProcedure",
             "cd myStoredProcedure",
             "add-parameter myParameter" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/DeleteParameterCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/DeleteParameterCommandTest.java
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteParameterCommand
- *
+ * Test Class to test {@link DeleteParameterCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteParameterCommandTest extends AbstractCommandTest {
+public final class DeleteParameterCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -46,10 +44,7 @@ public class DeleteParameterCommandTest extends AbstractCommandTest {
             "add-parameter myParameter1",
             "add-parameter myParameter2",
             "delete-parameter myParameter1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/RemoveResultSetCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/RemoveResultSetCommandTest.java
@@ -28,16 +28,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test RemoveResultSetCommand
- *
+ * Test Class to test {@link RemoveResultSetCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class RemoveResultSetCommandTest extends AbstractCommandTest {
+public final class RemoveResultSetCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -46,10 +44,7 @@ public class RemoveResultSetCommandTest extends AbstractCommandTest {
             "cd myStoredProcedure",
             "set-result-set DataTypeResultSet",
             "remove-result-set" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/SetResultSetCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/SetResultSetCommandTest.java
@@ -28,16 +28,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetResultSetCommand
- *
+ * Test Class to test {@link SetResultSetCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetResultSetCommandTest extends AbstractCommandTest {
+public final class SetResultSetCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSet() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -45,10 +43,7 @@ public class SetResultSetCommandTest extends AbstractCommandTest {
             "add-stored-procedure myStoredProcedure",
             "cd myStoredProcedure",
             "set-result-set DataTypeResultSet" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/SetStoredProcedurePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/SetStoredProcedurePropertyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetStoredProcedurePropertyCommand
- *
+ * Test Class to test {@link SetStoredProcedurePropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetStoredProcedurePropertyCommandTest extends AbstractCommandTest {
+public final class SetStoredProcedurePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class SetStoredProcedurePropertyCommandTest extends AbstractCommandTest {
             "add-stored-procedure myStoredProcedure",
             "cd myStoredProcedure",
             "set-property NAMEINSOURCE myNameInSource" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/UnsetStoredProcedurePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/storedprocedure/UnsetStoredProcedurePropertyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetStoredProcedurePropertyCommand
- *
+ * Test Class to test {@link UnsetStoredProcedurePropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetStoredProcedurePropertyCommandTest extends AbstractCommandTest {
+public final class UnsetStoredProcedurePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +42,7 @@ public class UnsetStoredProcedurePropertyCommandTest extends AbstractCommandTest
             "cd myStoredProcedure",
             "set-property NAMEINSOURCE myNameInSource",
             "unset-property NAMEINSOURCE" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddAccessPatternCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddAccessPatternCommandTest.java
@@ -29,12 +29,11 @@ import org.komodo.shell.api.CommandResult;
  * Test Class for {@link AddAccessPatternCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class AddAccessPatternCommandTest extends AbstractCommandTest {
+public final class AddAccessPatternCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -42,10 +41,7 @@ public class AddAccessPatternCommandTest extends AbstractCommandTest {
             "add-table myTable",
             "cd myTable",
             "add-access-pattern myAccessPattern" };
-        
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddColumnCommandTest.java
@@ -30,12 +30,11 @@ import org.komodo.shell.api.CommandResult;
  *
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class AddColumnCommandTest extends AbstractCommandTest {
+public final class AddColumnCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +42,7 @@ public class AddColumnCommandTest extends AbstractCommandTest {
             "add-table myTable",
             "cd myTable",
             "add-column myColumn" };
-        
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddForeignKeyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddForeignKeyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddForeignKeyCommand
- *
+ * Test Class to test {@link AddForeignKeyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddForeignKeyCommandTest extends AbstractCommandTest {
+public final class AddForeignKeyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model refModel",
@@ -47,10 +45,7 @@ public class AddForeignKeyCommandTest extends AbstractCommandTest {
             "add-table myTable",
             "cd myTable",
             "add-foreign-key myForeignKey /workspace/myVdb/refModel/refTable" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddIndexCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddIndexCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddIndexCommand
- *
+ * Test Class to test {@link AddIndexCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddIndexCommandTest extends AbstractCommandTest {
+public final class AddIndexCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class AddIndexCommandTest extends AbstractCommandTest {
             "add-table myTable",
             "cd myTable",
             "add-index myIndex" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddPrimaryKeyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddPrimaryKeyCommandTest.java
@@ -15,8 +15,8 @@
  */
 package org.komodo.relational.commands.table;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.relational.model.Model;
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddForeignKeyCommand
- *
+ * Test Class to test {@link AddPrimaryKeyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddPrimaryKeyCommandTest extends AbstractCommandTest {
+public final class AddPrimaryKeyCommandTest extends AbstractCommandTest {
 
     @Test
     public void shouldAddPrimaryKey() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +42,7 @@ public class AddPrimaryKeyCommandTest extends AbstractCommandTest {
             "add-table myTable",
             "cd myTable",
             "add-primary-key myPk" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddUniqueConstraintCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/AddUniqueConstraintCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddUniqueConstraintCommand
- *
+ * Test Class to test {@link AddUniqueConstraintCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddUniqueConstraintCommandTest extends AbstractCommandTest {
+public final class AddUniqueConstraintCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class AddUniqueConstraintCommandTest extends AbstractCommandTest {
             "add-table myTable",
             "cd myTable",
             "add-unique-constraint myUniqueConstraint" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteAccessPatternCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteAccessPatternCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteAccessPatternCommand
- *
+ * Test Class to test {@link DeleteAccessPatternCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteAccessPatternCommandTest extends AbstractCommandTest {
+public final class DeleteAccessPatternCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -45,10 +43,7 @@ public class DeleteAccessPatternCommandTest extends AbstractCommandTest {
             "add-access-pattern myAccessPattern1",
             "add-access-pattern myAccessPattern2",
             "delete-access-pattern myAccessPattern1" };
-        
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteColumnCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteColumnCommand
- *
+ * Test Class to test {@link DeleteColumnCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 public class DeleteColumnCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -45,10 +43,7 @@ public class DeleteColumnCommandTest extends AbstractCommandTest {
             "add-column myColumn1",
             "add-column myColumn2",
             "delete-column myColumn1" };
-        
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteForeignKeyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteForeignKeyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteForeignKeyCommand
- *
+ * Test Class to test {@link DeleteForeignKeyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteForeignKeyCommandTest extends AbstractCommandTest {
+public final class DeleteForeignKeyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model refModel",
@@ -49,10 +47,7 @@ public class DeleteForeignKeyCommandTest extends AbstractCommandTest {
             "add-foreign-key myForeignKey1 /workspace/myVdb/refModel/refTable",
             "add-foreign-key myForeignKey2 /workspace/myVdb/refModel/refTable",
             "delete-foreign-key myForeignKey1" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteIndexCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteIndexCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteIndexCommand
- *
+ * Test Class to test {@link DeleteIndexCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 public class DeleteIndexCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -45,10 +43,7 @@ public class DeleteIndexCommandTest extends AbstractCommandTest {
             "add-index myIndex1",
             "add-index myIndex2",
             "delete-index myIndex1" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeletePrimaryKeyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeletePrimaryKeyCommandTest.java
@@ -15,8 +15,8 @@
  */
 package org.komodo.relational.commands.table;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.relational.model.Model;
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeletePrimaryKeyCommand
- *
+ * Test Class to test {@link DeletePrimaryKeyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 public class DeletePrimaryKeyCommandTest extends AbstractCommandTest {
 
     @Test
     public void shouldRemovePrimaryKey() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -45,10 +43,7 @@ public class DeletePrimaryKeyCommandTest extends AbstractCommandTest {
             "cd myTable",
             "add-primary-key myPk",
             "delete-primary-key" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteUniqueConstraintCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/DeleteUniqueConstraintCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteUniqueConstraintCommand
- *
+ * Test Class to test {@link DeleteUniqueConstraintCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteUniqueConstraintCommandTest extends AbstractCommandTest {
+public final class DeleteUniqueConstraintCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -45,10 +43,7 @@ public class DeleteUniqueConstraintCommandTest extends AbstractCommandTest {
             "add-unique-constraint myUniqueConstraint1",
             "add-unique-constraint myUniqueConstraint2",
             "delete-unique-constraint myUniqueConstraint1" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/SetTablePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/SetTablePropertyCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetTablePropertyCommand
- *
+ * Test Class to test {@link SetTablePropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetTablePropertyCommandTest extends AbstractCommandTest {
+public final class SetTablePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -42,10 +40,7 @@ public class SetTablePropertyCommandTest extends AbstractCommandTest {
             "add-table myTable",
             "cd myTable",
             "set-property CARDINALITY 999" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/UnsetTablePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/table/UnsetTablePropertyCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetTablePropertyCommand
- *
+ * Test Class to test {@link UnsetTablePropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetTablePropertyCommandTest extends AbstractCommandTest {
+public final class UnsetTablePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class UnsetTablePropertyCommandTest extends AbstractCommandTest {
             "cd myTable",
             "set-property CARDINALITY 999",
             "unset-property CARDINALITY" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommandTest.java
@@ -28,16 +28,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddParameterCommand
- *
+ * Test Class to test {@link AddConstraintColumnCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddConstraintColumnCommandTest extends AbstractCommandTest {
+public final class AddConstraintColumnCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model refModel",
@@ -56,10 +54,7 @@ public class AddConstraintColumnCommandTest extends AbstractCommandTest {
             "add-foreign-key myForeignKey /workspace/myVdb/refModel/refTable",
             "cd myForeignKey",
             "add-column /workspace/myVdb/myModel/myTable/myCol1" };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tableconstraint/DeleteConstraintColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tableconstraint/DeleteConstraintColumnCommandTest.java
@@ -28,17 +28,15 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteParameterCommand
- *
+ * Test Class to test {@link DeleteConstraintColumnCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteConstraintColumnCommandTest extends AbstractCommandTest {
+public final class DeleteConstraintColumnCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
+        final String[] commands = {
             "set-auto-commit false",
-            "workspace",
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model refModel",
@@ -62,10 +60,7 @@ public class DeleteConstraintColumnCommandTest extends AbstractCommandTest {
             "delete-column /workspace/myVdb/myModel/myTable/myCol1",
             "commit"
             };
-
-        setup(commands);
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tabularresultset/AddColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tabularresultset/AddColumnCommandTest.java
@@ -18,12 +18,11 @@ package org.komodo.relational.commands.tabularresultset;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import org.junit.Test;
-import org.komodo.relational.commands.pushdownfunction.AddParameterCommand;
 import org.komodo.relational.model.ResultSetColumn;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test class for {@link AddParameterCommand}.
+ * Test class for {@link AddColumnCommand}.
  */
 @SuppressWarnings( { "javadoc",
                      "nls" } )
@@ -33,10 +32,8 @@ public final class AddColumnCommandTest extends TabularResultSetCommandTest {
     public void shouldAddColumn() throws Exception {
         final String addedColumn = "myColumn";
         final String[] commands = { "add-column " + addedColumn };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertCommandResultOk( result );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
 
         final ResultSetColumn[] cols = get().getColumns( getTransaction() );
         assertThat( cols.length, is( 1 ) );

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tabularresultset/DeleteColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tabularresultset/DeleteColumnCommandTest.java
@@ -35,10 +35,8 @@ public final class DeleteColumnCommandTest extends TabularResultSetCommandTest {
         final String[] commands = { "add-column " + deletedColumn,
                                     "add-column " + remainingColumn,
                                     "delete-column " + deletedColumn };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertCommandResultOk( result );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
 
         final ResultSetColumn[] cols = get().getColumns( getTransaction() );
         assertThat( cols.length, is( 1 ) );

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tabularresultset/TabularResultSetCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/tabularresultset/TabularResultSetCommandTest.java
@@ -38,9 +38,8 @@ public abstract class TabularResultSetCommandTest extends AbstractCommandTest {
                                     "cd myPushdownFunction",
                                     "set-result-set TabularResultSet",
                                     "cd resultSet" };
-        setup( commands );
-        final CommandResult result = execute();
-        assertCommandResultOk( result );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
 
         final WorkspaceManager wkspMgr = WorkspaceManager.getInstance( _repo );
         final Vdb[] vdbs = wkspMgr.findVdbs( getTransaction() );

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/teiid/SetTeiidPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/teiid/SetTeiidPropertyCommandTest.java
@@ -23,23 +23,18 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetTeiidPropertyCommand
- *
+ * Test Class to test {@link SetTeiidPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetTeiidPropertyCommandTest extends AbstractCommandTest {
+public final class SetTeiidPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-teiid testTeiid",
             "cd testTeiid",
             "set-property adminPort 88" };
-
-        setup( commands  );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/teiid/UnsetTeiidPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/teiid/UnsetTeiidPropertyCommandTest.java
@@ -23,24 +23,19 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetTeiidPropertyCommand
- *
+ * Test Class to test {@link UnsetTeiidPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetTeiidPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetTeiidPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-teiid testTeiid",
             "cd testTeiid",
             "set-property adminPort 88",
             "unset-property adminPort" };
-
-        setup( commands  );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/translator/SetTranslatorPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/translator/SetTranslatorPropertyCommandTest.java
@@ -24,25 +24,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetTranslatorPropertyCommand
- *
+ * Test Class to test {@link SetTranslatorPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetTranslatorPropertyCommandTest extends AbstractCommandTest {
+public final class SetTranslatorPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-translator myTranslator tType",
             "cd myTranslator",
             "set-property description myDescription" };
-        
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/translator/UnsetTranslatorPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/translator/UnsetTranslatorPropertyCommandTest.java
@@ -24,26 +24,21 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetTranslatorPropertyCommand
- *
+ * Test Class to test {@link UnsetTranslatorPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetTranslatorPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetTranslatorPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-translator myTranslator tType",
             "cd myTranslator",
             "set-property description myDescription",
             "unset-property description" };
-        
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/userdefinedfunction/AddParameterCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/userdefinedfunction/AddParameterCommandTest.java
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddParameterCommand
- *
+ * Test Class to test {@link AddParameterCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddParameterCommandTest extends AbstractCommandTest {
+public final class AddParameterCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +42,7 @@ public class AddParameterCommandTest extends AbstractCommandTest {
             "add-user-defined-function myUserDefinedFunction",
             "cd myUserDefinedFunction",
             "add-parameter myParameter" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/userdefinedfunction/DeleteParameterCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/userdefinedfunction/DeleteParameterCommandTest.java
@@ -16,7 +16,6 @@
 package org.komodo.relational.commands.userdefinedfunction;
 
 import static org.junit.Assert.assertEquals;
-import java.io.File;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.relational.model.Function;
@@ -28,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteParameterCommand
- *
+ * Test Class to test {@link DeleteParameterCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteParameterCommandTest extends AbstractCommandTest {
+public final class DeleteParameterCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -47,13 +44,7 @@ public class DeleteParameterCommandTest extends AbstractCommandTest {
             "add-parameter myParameter1",
             "add-parameter myParameter2",
             "delete-parameter myParameter1" };
-
-        setup( commands );
-
-        File cmdFile = File.createTempFile("TestCommand", ".txt");  //$NON-NLS-1$  //$NON-NLS-2$
-        cmdFile.deleteOnExit();
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/userdefinedfunction/SetUserDefinedFunctionPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/userdefinedfunction/SetUserDefinedFunctionPropertyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetUserDefinedFunctionPropertyCommand
- *
+ * Test Class to test {@link SetUserDefinedFunctionPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetUserDefinedFunctionPropertyCommandTest extends AbstractCommandTest {
+public final class SetUserDefinedFunctionPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class SetUserDefinedFunctionPropertyCommandTest extends AbstractCommandTe
             "add-user-defined-function myUserDefinedFunction",
             "cd myUserDefinedFunction",
             "set-property NAMEINSOURCE myNameInSource" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/userdefinedfunction/UnsetUserDefinedFunctionPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/userdefinedfunction/UnsetUserDefinedFunctionPropertyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetUserDefinedFunctionPropertyCommand
- *
+ * Test Class to test {@link UnsetUserDefinedFunctionPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetUserDefinedFunctionPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetUserDefinedFunctionPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +42,7 @@ public class UnsetUserDefinedFunctionPropertyCommandTest extends AbstractCommand
             "cd myUserDefinedFunction",
             "set-property NAMEINSOURCE myNameInSource",
             "unset-property NAMEINSOURCE" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddDataRoleCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddDataRoleCommandTest.java
@@ -24,23 +24,18 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddDataRoleCommand
- *
+ * Test Class to test {@link AddDataRoleCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddDataRoleCommandTest extends AbstractCommandTest {
+public final class AddDataRoleCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddEntryCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddEntryCommandTest.java
@@ -25,24 +25,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddEntryCommand
+ * Test Class to test {@link AddEntryCommand}.
  * -- currently ignored - cannot create Entry in vdbbuilder
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 @Ignore
-public class AddEntryCommandTest extends AbstractCommandTest {
+public final class AddEntryCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-entry myEntry entryPath" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddImportCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddImportCommandTest.java
@@ -24,23 +24,18 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddImportCommand
- *
+ * Test Class to test {@link AddImportCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddImportCommandTest extends AbstractCommandTest {
+public final class AddImportCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-import myImport" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddModelCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddModelCommandTest.java
@@ -24,23 +24,18 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddModelCommand
- *
+ * Test Class to test {@link AddModelCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddModelCommandTest extends AbstractCommandTest {
+public final class AddModelCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddTranslatorCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/AddTranslatorCommandTest.java
@@ -24,23 +24,18 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddTranslatorCommand
- *
+ * Test Class to test {@link AddTranslatorCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddTranslatorCommandTest extends AbstractCommandTest {
+public final class AddTranslatorCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-translator myTranslator tType" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteDataRoleCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteDataRoleCommandTest.java
@@ -24,25 +24,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteDataRoleCommand
- *
+ * Test Class to test {@link DeleteDataRoleCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteDataRoleCommandTest extends AbstractCommandTest {
+public final class DeleteDataRoleCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-data-role myDataRole1",
             "add-data-role myDataRole2",
             "delete-data-role myDataRole1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteEntryCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteEntryCommandTest.java
@@ -25,26 +25,22 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteEntryCommand
+ * Test Class to test {@link DeleteEntryCommand}.
  * -- currently ignored - cannot create Entry in vdbbuilder
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 @Ignore
-public class DeleteEntryCommandTest extends AbstractCommandTest {
+public final class DeleteEntryCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-entry myEntry1 entryPath",
             "add-entry myEntry2 entryPath",
             "delete-entry myEntry1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteImportCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteImportCommandTest.java
@@ -24,25 +24,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteImportCommand
- *
+ * Test Class to test {@link DeleteImportCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteImportCommandTest extends AbstractCommandTest {
+public final class DeleteImportCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-import myImport1",
             "add-import myImport2",
             "delete-import myImport1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteModelCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteModelCommandTest.java
@@ -24,25 +24,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteModelCommand
- *
+ * Test Class to test {@link DeleteModelCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteModelCommandTest extends AbstractCommandTest {
+public final class DeleteModelCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel1",
             "add-model myModel2",
             "delete-model myModel1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteTranslatorCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/DeleteTranslatorCommandTest.java
@@ -24,25 +24,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteTranslatorCommand
- *
+ * Test Class to test {@link DeleteTranslatorCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteTranslatorCommandTest extends AbstractCommandTest {
+public final class DeleteTranslatorCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-translator myTranslator1 tType",
             "add-translator myTranslator2 tType",
             "delete-translator myTranslator1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/ExportCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/ExportCommandTest.java
@@ -29,8 +29,7 @@ import org.komodo.test.utils.TestUtilities;
 import org.w3c.dom.Document;
 
 /**
- * Test Class to test VDB ExportCommand
- *
+ * Test Class to test VDB {@link ExportCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
 public class ExportCommandTest extends AbstractCommandTest {
@@ -82,19 +81,13 @@ public class ExportCommandTest extends AbstractCommandTest {
             exportDest.delete();
 
         // The test commands
-        final String[] commands = { 
+        final String[] commands = {
             "commit",
             "workspace",
             "cd " + tweetVdb.getName(getTransaction()),
             "export-vdb " + exportDest.getAbsolutePath() };
-
-        setup( commands );
-
-        //
-        // Execute the commands
-        //
-        execute();
-
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
         assertTrue(exportDest.exists());
 
         Document vdbDocument = TestUtilities.createDocument(new FileInputStream(exportDest));
@@ -128,20 +121,13 @@ public class ExportCommandTest extends AbstractCommandTest {
             exportDest.delete();
 
         // The test commands
-        final String[] commands = { 
+        final String[] commands = {
             "commit",
             "workspace",
             "cd " + allElementsVdb.getName(getTransaction()),
             "export-vdb " + exportDest.getAbsolutePath() };
-
-        setup( commands );
-
-        //
-        // Execute the commands
-        //
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
-
         assertTrue(exportDest.exists());
 
         Document vdbDocument = TestUtilities.createDocument(new FileInputStream(exportDest));

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/SetVdbPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/SetVdbPropertyCommandTest.java
@@ -23,23 +23,18 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetVdbPropertyCommand
- *
+ * Test Class to test {@link SetVdbPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetVdbPropertyCommandTest extends AbstractCommandTest {
+public final class SetVdbPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb testVdb vdbPath",
             "cd testVdb",
             "set-property version 3" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/UnsetVdbPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/UnsetVdbPropertyCommandTest.java
@@ -23,24 +23,19 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetVdbPropertyCommand
- *
+ * Test Class to test {@link UnsetVdbPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetVdbPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetVdbPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb testVdb vdbPath",
             "cd testVdb",
             "set-property version 3",
             "unset-property version" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/UploadModelCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/UploadModelCommandTest.java
@@ -36,9 +36,7 @@ public class UploadModelCommandTest extends AbstractCommandTest {
                                     "create-vdb testVdb vdbPath",
                                     "cd testVdb",
                                     "upload-model myModel PHYSICAL " + UPLOAD_MODEL };
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);
@@ -50,7 +48,7 @@ public class UploadModelCommandTest extends AbstractCommandTest {
         // Make sure model was created
         assertEquals(1, vdbs[0].getModels( getTransaction() ).length);
         assertEquals("myModel", vdbs[0].getModels( getTransaction() )[0].getName( getTransaction() ));
-        
+
         // Should be 5 tables in the model
         assertEquals(5, vdbs[0].getModels(getTransaction())[0].getTables(getTransaction()).length);
     }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdbimport/SetVdbImportPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdbimport/SetVdbImportPropertyCommandTest.java
@@ -24,25 +24,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetVdbImportPropertyCommand
- *
+ * Test Class to test {@link SetVdbImportPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetVdbImportPropertyCommandTest extends AbstractCommandTest {
+public final class SetVdbImportPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-import myImport",
             "cd myImport",
             "set-property version 3" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdbimport/UnsetVdbImportPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdbimport/UnsetVdbImportPropertyCommandTest.java
@@ -24,26 +24,21 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetVdbImportPropertyCommand
- *
+ * Test Class to test {@link UnsetVdbImportPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetVdbImportPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetVdbImportPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-import myImport",
             "cd myImport",
             "set-property version 3",
             "unset-property version" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/view/AddColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/view/AddColumnCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddColumnCommand
- *
+ * Test Class to test {@link AddColumnCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddColumnCommandTest extends AbstractCommandTest {
+public final class AddColumnCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class AddColumnCommandTest extends AbstractCommandTest {
             "add-view myView",
             "cd myView",
             "add-column myColumn" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/view/DeleteColumnCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/view/DeleteColumnCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteColumnCommand
- *
+ * Test Class to test {@link DeleteColumnCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteColumnCommandTest extends AbstractCommandTest {
+public final class DeleteColumnCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -45,10 +43,7 @@ public class DeleteColumnCommandTest extends AbstractCommandTest {
             "add-column myColumn1",
             "add-column myColumn2",
             "delete-column myColumn1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/view/SetViewPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/view/SetViewPropertyCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetViewPropertyCommand
- *
+ * Test Class to test {@link SetViewPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetViewPropertyCommandTest extends AbstractCommandTest {
+public final class SetViewPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -42,10 +40,7 @@ public class SetViewPropertyCommandTest extends AbstractCommandTest {
             "add-view myView",
             "cd myView",
             "set-property ANNOTATION myDescription" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/view/UnsetViewPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/view/UnsetViewPropertyCommandTest.java
@@ -25,16 +25,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetViewPropertyCommand
- *
+ * Test Class to test {@link UnsetViewPropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetViewPropertyCommandTest extends AbstractCommandTest {
+public final class UnsetViewPropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class UnsetViewPropertyCommandTest extends AbstractCommandTest {
             "cd myView",
             "set-property ANNOTATION myDescription",
             "unset-property ANNOTATION" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/virtualprocedure/AddParameterCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/virtualprocedure/AddParameterCommandTest.java
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test AddParameterCommand
- *
+ * Test Class to test {@link AddParameterCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class AddParameterCommandTest extends AbstractCommandTest {
+public final class AddParameterCommandTest extends AbstractCommandTest {
 
     @Test
     public void testAdd1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +42,7 @@ public class AddParameterCommandTest extends AbstractCommandTest {
             "add-virtual-procedure myVirtualProcedure",
             "cd myVirtualProcedure",
             "add-parameter myParameter" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/virtualprocedure/DeleteParameterCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/virtualprocedure/DeleteParameterCommandTest.java
@@ -27,16 +27,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteParameterCommand
- *
+ * Test Class to test {@link DeleteParameterCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class DeleteParameterCommandTest extends AbstractCommandTest {
+public final class DeleteParameterCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDelete1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -46,10 +44,7 @@ public class DeleteParameterCommandTest extends AbstractCommandTest {
             "add-parameter myParameter1",
             "add-parameter myParameter2",
             "delete-parameter myParameter1" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/virtualprocedure/SetVirtualProcedurePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/virtualprocedure/SetVirtualProcedurePropertyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test SetVirtualProcedurePropertyCommand
- *
+ * Test Class to test {@link SetVirtualProcedurePropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class SetVirtualProcedurePropertyCommandTest extends AbstractCommandTest {
+public final class SetVirtualProcedurePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testSetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -43,10 +41,7 @@ public class SetVirtualProcedurePropertyCommandTest extends AbstractCommandTest 
             "add-virtual-procedure myVirtualProcedure",
             "cd myVirtualProcedure",
             "set-property name-in-source myNameInSource" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/virtualprocedure/UnsetVirtualProcedurePropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/virtualprocedure/UnsetVirtualProcedurePropertyCommandTest.java
@@ -26,16 +26,14 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UnsetVirtualProcedurePropertyCommand
- *
+ * Test Class to test {@link UnsetVirtualProcedurePropertyCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public class UnsetVirtualProcedurePropertyCommandTest extends AbstractCommandTest {
+public final class UnsetVirtualProcedurePropertyCommandTest extends AbstractCommandTest {
 
     @Test
     public void testUnsetProperty1() throws Exception {
-        final String[] commands = { 
-            "workspace",
+        final String[] commands = {
             "create-vdb myVdb vdbPath",
             "cd myVdb",
             "add-model myModel",
@@ -44,10 +42,7 @@ public class UnsetVirtualProcedurePropertyCommandTest extends AbstractCommandTes
             "cd myVirtualProcedure",
             "set-property name-in-source myNameInSource",
             "unset-property name-in-source" };
-
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/CreateSchemaCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/CreateSchemaCommandTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
-import org.komodo.relational.commands.workspace.CreateSchemaCommand;
 import org.komodo.relational.model.Schema;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.CompletionConstants;
@@ -31,15 +30,12 @@ import org.komodo.shell.api.CommandResult;
  * Test Class to test {@link CreateSchemaCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class CreateSchemaCommandTest extends AbstractCommandTest {
+public final class CreateSchemaCommandTest extends AbstractCommandTest {
 
     @Test
     public void testCreateSchema1() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-schema testSchema" };
-        setup( commands  );
-
-        CommandResult result = execute();
+        final String[] commands = { "create-schema testSchema" };
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
     	WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);
@@ -52,7 +48,7 @@ public class CreateSchemaCommandTest extends AbstractCommandTest {
     @Test
     public void shouldDisplayHelp( ) throws Exception {
         CreateSchemaCommand command = new CreateSchemaCommand(wsStatus);
-        command.setWriter( this.commandWriter );
+        command.setWriter( getOutputWriter() );
         command.printHelp(CompletionConstants.MESSAGE_INDENT);
 
         String writerOutput = getCommandOutput();

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/CreateTeiidCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/CreateTeiidCommandTest.java
@@ -23,19 +23,15 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test CreateTeiidCommand
- *
+ * Test Class to test {@link CreateTeiidCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class CreateTeiidCommandTest extends AbstractCommandTest {
+public final class CreateTeiidCommandTest extends AbstractCommandTest {
 
     @Test
     public void testCreateTeiid1() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-teiid testTeiid" };
-        setup( commands  );
-
-        CommandResult result = execute();
+        final String[] commands = { "create-teiid testTeiid" };
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/CreateVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/CreateVdbCommandTest.java
@@ -23,19 +23,15 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test CreateVdbCommand
- *
+ * Test Class to test {@link CreateVdbCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class CreateVdbCommandTest extends AbstractCommandTest {
+public final class CreateVdbCommandTest extends AbstractCommandTest {
 
     @Test
     public void shouldCreateVdbWithoutOptionalPath() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-vdb testVdb" };
-        setup( commands  );
-
-        CommandResult result = execute();
+        final String[] commands = { "create-vdb testVdb" };
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);
@@ -44,14 +40,11 @@ public class CreateVdbCommandTest extends AbstractCommandTest {
         assertEquals(1, vdbs.length);
         assertEquals("testVdb", vdbs[0].getName(getTransaction()));
     }
-    
+
     @Test
     public void shouldCreateVdbWithOptionalPath() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-vdb testVdb vdbPath" };
-        setup( commands  );
-
-        CommandResult result = execute();
+        final String[] commands = { "create-vdb testVdb vdbPath" };
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/DeleteSchemaCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/DeleteSchemaCommandTest.java
@@ -23,24 +23,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteSchemaCommand
- *
+ * Test Class to test {@link DeleteSchemaCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class DeleteSchemaCommandTest extends AbstractCommandTest {
+public final class DeleteSchemaCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDeleteSchema1() throws Exception {
         final String[] commands = { "set-auto-commit false",
-                                    "workspace",
                                     "create-schema testSchema1",
                                     "create-schema testSchema2",
                                     "commit",
                                     "delete-schema testSchema1",
                                     "commit" };
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/DeleteTeiidCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/DeleteTeiidCommandTest.java
@@ -23,24 +23,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteTeiidCommand
- *
+ * Test Class to test {@link DeleteTeiidCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class DeleteTeiidCommandTest extends AbstractCommandTest {
+public final class DeleteTeiidCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDeleteTeiid1() throws Exception {
         final String[] commands = { "set-auto-commit false",
-                                    "workspace",
                                     "create-teiid testTeiid1",
                                     "create-teiid testTeiid2",
                                     "commit",
                                     "delete-teiid testTeiid1",
                                     "commit" };
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/DeleteVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/DeleteVdbCommandTest.java
@@ -23,24 +23,20 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test DeleteVdbCommand
- *
+ * Test Class to test {@link DeleteVdbCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class DeleteVdbCommandTest extends AbstractCommandTest {
+public final class DeleteVdbCommandTest extends AbstractCommandTest {
 
     @Test
     public void testDeleteVdb1() throws Exception {
         final String[] commands = { "set-auto-commit false",
-                                    "workspace",
                                     "create-vdb testVdb1 vdbPath",
                                     "create-vdb testVdb2 vdbPath",
                                     "commit",
                                     "delete-vdb testVdb1",
                                     "commit" };
-        setup( commands );
-
-        CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/ImportVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/ImportVdbCommandTest.java
@@ -15,29 +15,23 @@
  */
 package org.komodo.relational.commands.workspace;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
+import org.komodo.repository.RepositoryImpl;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test ImportVdbCommand
- *
+ * Test Class to test {@link ImportVdbCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class ImportVdbCommandTest extends AbstractCommandTest {
+public final class ImportVdbCommandTest extends AbstractCommandTest {
 
     @Test
     public void testImportVdb1() throws Exception {
-        final String[] commands = { "workspace",
-                                    "create-vdb testVdb1 vdbPath" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
-
-    	// Check WorkspaceContext
-    	assertEquals("/workspace", wsStatus.getCurrentContextDisplayPath()); //$NON-NLS-1$
+        final String[] commands = { "create-vdb testVdb1 vdbPath" };
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
+        assertContextIs( RepositoryImpl.WORKSPACE_ROOT );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/UploadVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/UploadVdbCommandTest.java
@@ -23,21 +23,17 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
 
 /**
- * Test Class to test UploadVdbCommand
- *
+ * Test Class to test {@link UploadVdbCommand}.
  */
 @SuppressWarnings( { "javadoc", "nls" } )
-public class UploadVdbCommandTest extends AbstractCommandTest {
+public final class UploadVdbCommandTest extends AbstractCommandTest {
 
     private static final String UPLOAD_VDB = "./resources/AzureService-vdb.xml";
 
     @Test
     public void shouldUploadVdb1() throws Exception {
-        final String[] commands = { "workspace",
-                                    "upload-vdb myVdb " + UPLOAD_VDB };
-        setup( commands );
-
-        CommandResult result = execute();
+        final String[] commands = { "upload-vdb myVdb " + UPLOAD_VDB };
+        final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(_repo);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/WorkspaceSetPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/WorkspaceSetPropertyCommandTest.java
@@ -17,20 +17,17 @@ package org.komodo.relational.commands.workspace;
 
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
-import org.komodo.relational.commands.workspace.WorkspaceSetPropertyCommand;
+import org.komodo.shell.commands.SetPropertyCommand;
 
 /**
  * Test Class to test {@link WorkspaceSetPropertyCommand}.
  */
-@SuppressWarnings( { "javadoc", "nls" } )
+@SuppressWarnings( { "javadoc" } )
 public class WorkspaceSetPropertyCommandTest extends AbstractCommandTest {
 
-    @Test( expected = AssertionError.class )
+    @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
-        final String[] commands = { "workspace",
-                                    "set-property blah blah" };
-        setup( commands );
-        execute();
+        assertCommandsNotAvailable( SetPropertyCommand.NAME );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/WorkspaceUnsetPropertyCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/WorkspaceUnsetPropertyCommandTest.java
@@ -17,19 +17,17 @@ package org.komodo.relational.commands.workspace;
 
 import org.junit.Test;
 import org.komodo.relational.commands.AbstractCommandTest;
+import org.komodo.shell.commands.UnsetPropertyCommand;
 
 /**
  * Test Class to test {@link WorkspaceUnsetPropertyCommand}.
  */
-@SuppressWarnings( { "javadoc", "nls" } )
-public class WorkspaceUnsetPropertyCommandTest extends AbstractCommandTest {
+@SuppressWarnings( { "javadoc" } )
+public final class WorkspaceUnsetPropertyCommandTest extends AbstractCommandTest {
 
-    @Test( expected = AssertionError.class )
+    @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
-        final String[] commands = { "workspace",
-                                    "unset-property blah" };
-        setup( commands );
-        execute();
+        assertCommandsNotAvailable( UnsetPropertyCommand.NAME );
     }
 
 }

--- a/tests/org.komodo.shell.test/META-INF/MANIFEST.MF
+++ b/tests/org.komodo.shell.test/META-INF/MANIFEST.MF
@@ -4,10 +4,14 @@ Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.komodo.shell.test;singleton:=true
 Bundle-Version: 0.0.2.qualifier
 Bundle-Vendor: %Bundle-Vendor.0
-Fragment-Host: org.komodo.shell
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.komodo.spi;bundle-version="[0.0.1,2.0.0)",
  org.komodo.test.utils;bundle-version="[0.0.1,2.0.0)",
- org.jboss.tools.locus.mockito
+ org.jboss.tools.locus.mockito,
+ org.komodo.shell;bundle-version="0.0.2",
+ org.komodo.shell-api;bundle-version="0.0.2",
+ org.komodo.utils;bundle-version="0.0.2"
+Export-Package: org.komodo.shell,
+ org.komodo.shell.commands

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/AddChildCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/AddChildCommandTest.java
@@ -25,17 +25,14 @@ public final class AddChildCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "add-child childName extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
     public void shouldAllowAtRoot() throws Exception {
         final String child = "blah";
         final String[] commands = { "add-child " + child };
-        setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
 
         final KomodoObject root = _repo.komodoWorkspace( getTransaction() ).getParent( getTransaction() );
@@ -46,10 +43,8 @@ public final class AddChildCommandTest extends AbstractCommandTest {
     public void shouldAddChildAtLibrary() throws Exception {
         final String childName = "blah";
         final String[] commands = { "library", "add-child " + childName };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( true ) );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         final KomodoObject library = _repo.komodoLibrary( getTransaction() );
         assertThat( library.getChildren( getTransaction() ).length, is( 1 ) );
@@ -60,10 +55,8 @@ public final class AddChildCommandTest extends AbstractCommandTest {
     public void shouldAddChildAtWorkspace() throws Exception {
         final String childName = "blah";
         final String[] commands = { "workspace", "add-child " + childName };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( true ) );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         final KomodoObject workspace = _repo.komodoWorkspace( getTransaction() );
         assertThat( workspace.getChildren( getTransaction() ).length, is( 1 ) );
@@ -74,24 +67,21 @@ public final class AddChildCommandTest extends AbstractCommandTest {
     public void shouldNotBeAllowedToAddEnvironmentAtRoot() throws Exception {
         final String childName = KomodoLexicon.Komodo.ENVIRONMENT;
         final String[] commands = { "add-child " + childName };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test( expected = AssertionError.class )
     public void shouldNotBeAllowedToAddLibraryAtRoot() throws Exception {
         final String childName = KomodoLexicon.Komodo.LIBRARY;
         final String[] commands = { "add-child " + childName };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test( expected = AssertionError.class )
     public void shouldNotBeAllowedToAddWorkspaceAtRoot() throws Exception {
         final String childName = KomodoLexicon.Komodo.WORKSPACE;
         final String[] commands = { "add-child " + childName };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/AddDescriptorCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/AddDescriptorCommandTest.java
@@ -27,16 +27,13 @@ public final class AddDescriptorCommandTest extends AbstractCommandTest {
             "add-child blah",
             "cd blah",
             "add-descriptor aDescriptor extraArg"};
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
     public void shouldNotHaveAddDescriptorAvailableAtLibrary() throws Exception {
         final String[] commands = { "library" };
-        setup( commands );
-        final CommandResult result = execute();
-
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( AddDescriptorCommand.NAME );
     }
@@ -49,9 +46,7 @@ public final class AddDescriptorCommandTest extends AbstractCommandTest {
     @Test
     public void shouldNotHaveAddDescriptorAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace" };
-        setup( commands );
-        final CommandResult result = execute();
-
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( AddDescriptorCommand.NAME );
     }
@@ -64,8 +59,7 @@ public final class AddDescriptorCommandTest extends AbstractCommandTest {
             "add-child " + childName,
             "cd " + childName,
             "add-descriptor aDescriptor"};
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
@@ -77,10 +71,8 @@ public final class AddDescriptorCommandTest extends AbstractCommandTest {
             "add-child " + childName,
             "cd " + childName,
             "add-descriptor " + expected };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( true ) );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         final KomodoObject workspace = _repo.komodoWorkspace( getTransaction() );
         assertThat( workspace.getChildren( getTransaction() ).length, is( 1 ) );

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CdCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CdCommandTest.java
@@ -17,6 +17,7 @@ package org.komodo.shell.commands;
 
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+import org.komodo.repository.RepositoryImpl;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
 
@@ -29,30 +30,23 @@ public class CdCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "cd somewhere extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void shouldCdAbsolute() throws Exception {
         final String[] commands = { "cd /workspace" };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
-
-    	// Check WorkspaceContext
-    	assertEquals("/workspace", wsStatus.getDisplayPath(wsStatus.getCurrentContext()));
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
+        assertContextIs( RepositoryImpl.WORKSPACE_ROOT );
     }
 
     @Test
     public void shouldCdRelative() throws Exception {
         final String[] commands = { "workspace",
                                     "cd .." };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
     	// Check WorkspaceContext
         String contextPath = wsStatus.getCurrentContextDisplayPath();
@@ -62,10 +56,8 @@ public class CdCommandTest extends AbstractCommandTest {
     @Test
     public void shouldTestGoToAlias() throws Exception {
         final String[] commands = { "goto /workspace" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         String contextPath = wsStatus.getCurrentContextDisplayPath();
         assertEquals("/workspace", contextPath);
@@ -74,10 +66,8 @@ public class CdCommandTest extends AbstractCommandTest {
     @Test
     public void shouldTestEditAlias() throws Exception {
         final String[] commands = { "edit /workspace" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         String contextPath = wsStatus.getCurrentContextDisplayPath();
         assertEquals("/workspace", contextPath);

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CommitCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CommitCommandTest.java
@@ -37,10 +37,9 @@ public final class CommitCommandTest extends AbstractCommandTest {
                                     "commit", // should add child and *not* be rollbacked by the play command
                                     "home",
                                     "delete-child workspace" }; // should fail
-        setup( commands );
 
         try {
-            execute();
+            execute( commands );
             fail(); // delete-child should throw exception so should not get here
         } catch ( final Throwable e ) {
             // make sure the work done before the commit was persisted
@@ -51,8 +50,7 @@ public final class CommitCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs() throws Exception {
         final String[] commands = { "commit extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/DeleteChildCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/DeleteChildCommandTest.java
@@ -23,34 +23,30 @@ public final class DeleteChildCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldNotDeleteChildAtRoot() throws Exception {
         final String[] commands = { "delete-child blah" }; // delete-child is not available at root
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String child1Name = "blah1";
-        final String[] commands = { 
-            "library", 
+        final String[] commands = {
+            "library",
             "add-child " + child1Name,
             "delete-child " + child1Name + " optionalType extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void shouldDeleteChildAtLibrary() throws Exception {
         final String child1Name = "blah1";
         final String child2Name = "blah2";
-        final String[] commands = { 
-            "library", 
+        final String[] commands = {
+            "library",
             "add-child " + child1Name,
             "add-child " + child2Name,
             "delete-child " + child1Name };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( true ) );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         final KomodoObject library = _repo.komodoLibrary( getTransaction() );
         assertThat( library.getChildren( getTransaction() ).length, is( 1 ) );
@@ -61,15 +57,13 @@ public final class DeleteChildCommandTest extends AbstractCommandTest {
     public void shouldDeleteChildAtWorkspace() throws Exception {
         final String child1Name = "blah1";
         final String child2Name = "blah2";
-        final String[] commands = { 
-            "workspace", 
+        final String[] commands = {
+            "workspace",
             "add-child " + child1Name,
             "add-child " + child2Name,
             "delete-child " + child1Name };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( true ) );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         final KomodoObject workspace = _repo.komodoWorkspace( getTransaction() );
         assertThat( workspace.getChildren( getTransaction() ).length, is( 1 ) );

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ExitCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ExitCommandTest.java
@@ -28,8 +28,7 @@ public class ExitCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs() throws Exception {
         final String[] commands = { "exit -s extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
@@ -39,8 +38,7 @@ public class ExitCommandTest extends AbstractCommandTest {
                                     "cd blah",
                                     "set-property sledge hammer",
                                     "exit -s" };
-        setup( commands );
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
     }
 
@@ -51,8 +49,7 @@ public class ExitCommandTest extends AbstractCommandTest {
                                     "cd blah",
                                     "set-property sledge hammer",
                                     "exit -f" };
-        setup( commands );
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
     }
 
@@ -63,8 +60,7 @@ public class ExitCommandTest extends AbstractCommandTest {
                                     "cd blah",
                                     "set-property sledge hammer",
                                     "exit" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/HelpCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/HelpCommandTest.java
@@ -29,18 +29,15 @@ public class HelpCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "help cd extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void shouldShowHelpAtContext() throws Exception {
         final String[] commands = { "workspace",
                                     "help" };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         // check help text
         String writerOutput = getCommandOutput();
@@ -52,9 +49,8 @@ public class HelpCommandTest extends AbstractCommandTest {
     public void shouldShowHelpForCommand() throws Exception {
         final String[] commands = { "workspace",
                                     "help cd" };
-        setup( commands );
-
-        execute();
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         // check help text
         String writerOutput = getCommandOutput();

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/HomeCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/HomeCommandTest.java
@@ -15,7 +15,6 @@
  */
 package org.komodo.shell.commands;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.komodo.repository.RepositoryImpl;
 import org.komodo.shell.AbstractCommandTest;
@@ -30,19 +29,16 @@ public final class HomeCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "home extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
     public void shouldGoToKomodoRoot() throws Exception {
         final String[] commands = { "workspace",
                                     "home" };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
-        assertEquals( RepositoryImpl.KOMODO_ROOT, this.wsStatus.getCurrentContext().getAbsolutePath() );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
+        assertContextIs( RepositoryImpl.KOMODO_ROOT );
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/LibraryCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/LibraryCommandTest.java
@@ -15,7 +15,6 @@
  */
 package org.komodo.shell.commands;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.komodo.repository.RepositoryImpl;
 import org.komodo.shell.AbstractCommandTest;
@@ -30,18 +29,15 @@ public final class LibraryCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "library extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
     public void shouldGoToLibrary() throws Exception {
         final String[] commands = { "library" };
-    	setup( commands );
-
-        final CommandResult result = execute();
-        assertCommandResultOk(result);
-        assertEquals( RepositoryImpl.LIBRARY_ROOT, this.wsStatus.getCurrentContext().getAbsolutePath() );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
+        assertContextIs( RepositoryImpl.LIBRARY_ROOT );
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ListCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ListCommandTest.java
@@ -29,18 +29,15 @@ public class ListCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "list extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void testList1() throws Exception {
         final String[] commands =  { "workspace",
                                      "list" };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         // workspace is empty
     	String writerOutput = getCommandOutput();
@@ -51,10 +48,8 @@ public class ListCommandTest extends AbstractCommandTest {
     public void testListLsAlias() throws Exception {
         final String[] commands =  { "workspace",
                                      "ls" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         // workspace is empty
         String writerOutput = getCommandOutput();
@@ -65,10 +60,8 @@ public class ListCommandTest extends AbstractCommandTest {
     public void testListLlAlias() throws Exception {
         final String[] commands =  { "workspace",
                                      "ll" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         // workspace is empty
         String writerOutput = getCommandOutput();

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/PlayCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/PlayCommandTest.java
@@ -15,8 +15,6 @@
  */
 package org.komodo.shell.commands;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
@@ -36,7 +34,7 @@ public final class PlayCommandTest extends AbstractCommandTest {
         final CommandResult result = execute();
 
         assertCommandResultOk( result );
-        assertThat( this.wsStatus.getCurrentContext().getAbsolutePath(), is( "/tko:komodo/tko:workspace/blah/blahblah" ) );
+        assertContextIs( "/tko:komodo/tko:workspace/blah/blahblah" );
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/RemoveDescriptorCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/RemoveDescriptorCommandTest.java
@@ -29,16 +29,13 @@ public final class RemoveDescriptorCommandTest extends AbstractCommandTest {
                                     "cd " + childName,
                                     "add-descriptor " + removed,
                                     "remove-descriptor " + removed + " extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
     public void shouldNotHaveRemoveDescriptorAvailableAtLibrary() throws Exception {
         final String[] commands = { "library" };
-        setup( commands );
-        final CommandResult result = execute();
-
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( RemoveDescriptorCommand.NAME );
     }
@@ -51,9 +48,7 @@ public final class RemoveDescriptorCommandTest extends AbstractCommandTest {
     @Test
     public void shouldNotHaveRemoveDescriptorAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace" };
-        setup( commands );
-        final CommandResult result = execute();
-
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( RemoveDescriptorCommand.NAME );
     }
@@ -65,8 +60,7 @@ public final class RemoveDescriptorCommandTest extends AbstractCommandTest {
                                     "add-child " + childName,
                                     "cd " + childName,
                                     "remove-descriptor mix:referenceable" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
@@ -78,9 +72,7 @@ public final class RemoveDescriptorCommandTest extends AbstractCommandTest {
                                     "cd " + childName,
                                     "add-descriptor " + removed,
                                     "remove-descriptor " + removed };
-        setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
 
         final KomodoObject library = _repo.komodoWorkspace( getTransaction() );

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/RenameCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/RenameCommandTest.java
@@ -31,36 +31,31 @@ public class RenameCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldNotRenameAtRoot() throws Exception {
         final String[] commands = { "rename workspace myWorkspace" }; // rename is not available at root
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String childName = "blah";
         final String newChildName = "blech";
-        final String[] commands = { 
-            "workspace", 
+        final String[] commands = {
+            "workspace",
             "add-child " + childName,
             "rename " + childName + " " + newChildName + " extraArg"};
-        
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void shouldRenameChild() throws Exception {
         final String childName = "blah";
         final String newChildName = "blech";
-        final String[] commands = { 
-            "workspace", 
+        final String[] commands = {
+            "workspace",
             "add-child " + childName,
             "rename " + childName + " " + newChildName};
-        
-        setup( commands );
 
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( true ) );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         final KomodoObject workspace = _repo.komodoWorkspace( getTransaction() );
         assertThat( workspace.getChildren( getTransaction() ).length, is( 1 ) );

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/RollbackCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/RollbackCommandTest.java
@@ -30,8 +30,7 @@ public class RollbackCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "rollback extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
@@ -40,9 +39,7 @@ public class RollbackCommandTest extends AbstractCommandTest {
         final String[] commands = { "workspace",
                                     "add-child " + childName,
                                     RollbackCommand.NAME };
-        setup( commands );
-
-        final CommandResult result = execute(); // this does a commit
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertThat( _repo.komodoWorkspace( getTransaction() ).hasChild( getTransaction(), childName ), is( false ) );
     }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetAutoCommitCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetAutoCommitCommandTest.java
@@ -29,19 +29,15 @@ public class SetAutoCommitCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "set-auto-commit false extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void test1() throws Exception {
         final String[] commands = { "workspace",
                                     "set-auto-commit false" };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
-
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
     	assertEquals(false, wsStatus.isAutoCommit());
     }
 

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetGlobalPropertyCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetGlobalPropertyCommandTest.java
@@ -30,24 +30,20 @@ public class SetGlobalPropertyCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "set-global anArg extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test( expected = AssertionError.class )
     public void shouldFailBadGlobalProperty( ) throws Exception {
         final String[] commands = { "set-global anArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void shouldSetShowTypeInPrompt() throws Exception {
         final String[] commands = { "set-global " + WorkspaceStatus.SHOW_TYPE_IN_PROMPT_KEY + " true" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         // Check Context and property value
         assertEquals("/", wsStatus.getCurrentContextDisplayPath());
@@ -57,10 +53,8 @@ public class SetGlobalPropertyCommandTest extends AbstractCommandTest {
     @Test
     public void shouldSetRecordingOutputFile() throws Exception {
         final String[] commands = { "set-global " + WorkspaceStatus.RECORDING_FILE_KEY + " /aRecordingFile.txt" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         // Check Context and property value
         assertEquals("/", wsStatus.getCurrentContextDisplayPath());

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetPrimaryTypeCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetPrimaryTypeCommandTest.java
@@ -34,8 +34,7 @@ public class SetPrimaryTypeCommandTest extends AbstractCommandTest {
                                     "add-child myChild",
                                     "cd myChild",
                                     "set-primary-type nt:folder extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
@@ -46,9 +45,7 @@ public class SetPrimaryTypeCommandTest extends AbstractCommandTest {
     @Test
     public void shouldNotHaveSetPrimaryTypeAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace" };
-        setup( commands );
-        final CommandResult result = execute();
-
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( SetPrimaryTypeCommand.NAME );
     }
@@ -61,8 +58,7 @@ public class SetPrimaryTypeCommandTest extends AbstractCommandTest {
             "cd myChild",
             "set-primary-type myType"
         };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
@@ -73,9 +69,7 @@ public class SetPrimaryTypeCommandTest extends AbstractCommandTest {
             "cd myChild",
             "set-primary-type nt:folder"
         };
-    	setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
 
         final KomodoObject workspace = _repo.komodoWorkspace( getTransaction() );

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetPropertyCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetPropertyCommandTest.java
@@ -31,8 +31,7 @@ public final class SetPropertyCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "set-property prop value extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
@@ -44,10 +43,8 @@ public final class SetPropertyCommandTest extends AbstractCommandTest {
                                     "add-child " + childName,
                                     "cd " + childName,
                                     "set-property " + propName + " " + propValue };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( true ) );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         final KomodoObject workspace = _repo.komodoWorkspace( getTransaction() );
         assertThat( workspace.getChildren( getTransaction() ).length, is( 1 ) );

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetRecordCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetRecordCommandTest.java
@@ -29,18 +29,15 @@ public class SetRecordCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "set-record on extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void shouldSetRecordOn() throws Exception {
         final String[] commands = { "workspace",
                                     "set-record on" };
-    	setup( commands );
-
-        execute();
-
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
         assertEquals(true, wsStatus.getRecordingStatus());
     }
 
@@ -49,11 +46,8 @@ public class SetRecordCommandTest extends AbstractCommandTest {
         final String[] commands = { "workspace",
                                     "set-record on",
                                     "set-record off" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
-
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
         assertEquals(false, wsStatus.getRecordingStatus());
     }
 

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowChildrenCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowChildrenCommandTest.java
@@ -29,36 +29,31 @@ public class ShowChildrenCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "show-children extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void shouldShowChildrenNoChildren() throws Exception {
         final String[] commands = { "workspace",
                                     "show-children" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
         assertTrue(writerOutput.contains("There are no children"));
     }
-    
+
     @Test
     public void shouldShowTwoChildren() throws Exception {
         final String child1Name = "blah1";
         final String child2Name = "blah2";
-        final String[] commands = { 
-            "workspace", 
+        final String[] commands = {
+            "workspace",
             "add-child " + child1Name,
             "add-child " + child2Name,
             "show-children" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
         assertTrue(writerOutput.contains(child1Name));

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowDescriptorsCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowDescriptorsCommandTest.java
@@ -15,7 +15,6 @@
  */
 package org.komodo.shell.commands;
 
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
@@ -29,36 +28,28 @@ public class ShowDescriptorsCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "show-descriptors extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
-//    @Test
-//    public void shouldShowRootDescriptors() throws Exception {
-//        final String[] commands = { "show-descriptors" };
-//        setup( commands );
-//
-//        CommandResult result = execute();
-//        assertCommandResultOk(result);
-//
-//        // root primary type
-//        String writerOutput = getCommandOutput();
-//        assertTrue(writerOutput.contains("No Descriptors"));
-//    }
-//
-//    @Test
-//    public void shouldShowWorkspaceDescriptors() throws Exception {
-//        final String[] commands = { 
-//            "workspace",
-//            "show-descriptors"};
-//        setup( commands );
-//
-//        CommandResult result = execute();
-//        assertCommandResultOk(result);
-//
-//        // root primary type
-//        String writerOutput = getCommandOutput();
-//        assertTrue(writerOutput.contains("No Descriptors"));
-//    }
+
+    @Test
+    public void shouldNotHaveAvailableAtLibrary() throws Exception {
+        final String[] commands = { LibraryCommand.NAME };
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
+        assertCommandsNotAvailable( ShowDescriptorsCommand.NAME );
+    }
+
+    @Test
+    public void shouldNotHaveAvailableAtRoot() throws Exception {
+        assertCommandsNotAvailable( ShowDescriptorsCommand.NAME );
+    }
+
+    @Test
+    public void shouldNotHaveAvailableAtWorkspace() throws Exception {
+        final String[] commands = { WorkspaceCommand.NAME };
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
+        assertCommandsNotAvailable( ShowDescriptorsCommand.NAME );
+    }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowGlobalCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowGlobalCommandTest.java
@@ -30,17 +30,14 @@ public class ShowGlobalCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "show-global extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void testShowGlobal1() throws Exception {
         final String[] commands = { "show-global" };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
     	// make sure repository URL and workspace appear, no Teiid is set, and current context path
     	String writerOutput = getCommandOutput();

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowPropertiesCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowPropertiesCommandTest.java
@@ -15,8 +15,6 @@
  */
 package org.komodo.shell.commands;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
@@ -31,16 +29,13 @@ public class ShowPropertiesCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "show-properties extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
     public void shouldNotBeAvailableAtLibrary() throws Exception {
         final String[] commands = { "library" };
-        setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( ShowPropertiesCommand.NAME );
     }
@@ -53,9 +48,7 @@ public class ShowPropertiesCommandTest extends AbstractCommandTest {
     @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace" };
-        setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( ShowPropertiesCommand.NAME );
     }
@@ -68,10 +61,8 @@ public class ShowPropertiesCommandTest extends AbstractCommandTest {
             "add-child " + childName,
             "cd " + childName,
             "show-properties " };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( true ) );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
         assertTrue(writerOutput.contains("primaryType"));

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowPropertyCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowPropertyCommandTest.java
@@ -15,8 +15,6 @@
  */
 package org.komodo.shell.commands;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
@@ -31,16 +29,13 @@ public class ShowPropertyCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "show-property aProp extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
     public void shouldNotBeAvailableAtLibrary() throws Exception {
         final String[] commands = { "library" };
-        setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( ShowPropertyCommand.NAME );
     }
@@ -53,9 +48,7 @@ public class ShowPropertyCommandTest extends AbstractCommandTest {
     @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace" };
-        setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( ShowPropertyCommand.NAME );
     }
@@ -68,10 +61,8 @@ public class ShowPropertyCommandTest extends AbstractCommandTest {
             "add-child " + childName,
             "cd " + childName,
             "show-property primaryType" };
-        setup( commands );
-
-        final CommandResult result = execute();
-        assertThat( result.isOk(), is( true ) );
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
         assertTrue(writerOutput.contains("primaryType"));

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowStatusCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowStatusCommandTest.java
@@ -29,18 +29,15 @@ public class ShowStatusCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "show-status extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void testShowStatus1() throws Exception {
         final String[] commands = { "workspace",
                                     "show-status" };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
     	// make sure repository URL and workspace appear, no Teiid is set, and current context path
     	String writerOutput = getCommandOutput();

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowSummaryCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowSummaryCommandTest.java
@@ -32,18 +32,15 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "show-summary extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
-    
+
     @Test
     public void shouldBeAvailableAtLibrary() throws Exception {
         final String[] commands = { "library",
                                     "show-summary" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
         assertThat( writerOutput, writerOutput.contains( KomodoObject.class.getSimpleName()
@@ -56,10 +53,8 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
     @Test
     public void shouldBeAvailableAtRoot() throws Exception {
         final String[] commands = { "show-summary" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
         assertThat( writerOutput, writerOutput.contains( KomodoObject.class.getSimpleName()
@@ -73,10 +68,8 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
     public void shouldBeAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace",
                                     "show-summary" };
-        setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
         assertThat( writerOutput, writerOutput.contains( KomodoObject.class.getSimpleName()

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/UnsetPropertyCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/UnsetPropertyCommandTest.java
@@ -33,16 +33,13 @@ public final class UnsetPropertyCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "unset-property aProp extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
     public void shouldNotBeAvailableAtLibrary() throws Exception {
         final String[] commands = { "library" };
-        setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( UnsetPropertyCommand.NAME );
     }
@@ -55,9 +52,7 @@ public final class UnsetPropertyCommandTest extends AbstractCommandTest {
     @Test
     public void shouldNotBeAvailableAtWorkspace() throws Exception {
         final String[] commands = { "workspace" };
-        setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
         assertCommandsNotAvailable( UnsetPropertyCommand.NAME );
     }
@@ -74,9 +69,7 @@ public final class UnsetPropertyCommandTest extends AbstractCommandTest {
                                     "commit",
                                     "set-property " + prop + " bar",
                                     "unset-property " + prop };
-        setup( commands );
-
-        final CommandResult result = execute();
+        final CommandResult result = execute( commands );
         assertCommandResultOk( result );
 
         final KomodoObject kobject = _repo.getFromWorkspace( getTransaction(), child );

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/WorkspaceCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/WorkspaceCommandTest.java
@@ -15,7 +15,6 @@
  */
 package org.komodo.shell.commands;
 
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.komodo.repository.RepositoryImpl;
 import org.komodo.shell.AbstractCommandTest;
@@ -30,20 +29,16 @@ public final class WorkspaceCommandTest extends AbstractCommandTest {
     @Test( expected = AssertionError.class )
     public void shouldFailTooManyArgs( ) throws Exception {
         final String[] commands = { "workspace extraArg" };
-        setup( commands );
-        execute();
+        execute( commands );
     }
 
     @Test
     public void shouldGoToWorkspace() throws Exception {
-        final String[] commands = {
-            "library",
-            "workspace" };
-    	setup( commands );
-
-        CommandResult result = execute();
-        assertCommandResultOk(result);
-        assertEquals( RepositoryImpl.WORKSPACE_ROOT, this.wsStatus.getCurrentContext().getAbsolutePath() );
+        final String[] commands = { LibraryCommand.NAME,
+                                    WorkspaceCommand.NAME };
+        final CommandResult result = execute( commands );
+        assertCommandResultOk( result );
+        assertContextIs( RepositoryImpl.WORKSPACE_ROOT );
     }
 
 }


### PR DESCRIPTION
- changed shell.test from fragment to a plugin to allow relational.commands.test to inherit AbstractCommandTest class
- relational.commands.test tests now automatically start in /workspace so each test does not have to issue the workspace command
- changed all tests that were calling setup(String[]) to now call new execute(String[]) which calls setup and execute.