### PR TITLE
Fixes cli logging issue

### DIFF
--- a/plugins/org.komodo.shell/src/org/komodo/shell/DefaultKomodoShell.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/DefaultKomodoShell.java
@@ -306,7 +306,7 @@ public class DefaultKomodoShell implements KomodoShell {
                             final String errorMsg = Messages.getString( SHELL.CommandFailure, command.toString() )
                                                     + ' '
                                                     + result.getError().getLocalizedMessage();
-                            KLog.getLogger().error( errorMsg, result.getError() );
+                            KLog.getLogger().debug( errorMsg, result.getError() );
                             PrintUtils.print( getOutputWriter(), CompletionConstants.MESSAGE_INDENT, errorMsg );
                         }
 


### PR DESCRIPTION
When a command is entered with no arguments, we were getting too much logging in the console.  This changes the log level to suppress.