### PR TITLE
Shell Commands Should Have A Category So That They Can Be Grouped By The Help Command

### DIFF
--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalCommandMessages.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalCommandMessages.java
@@ -25,6 +25,7 @@ public class RelationalCommandMessages implements StringConstants {
 
     public enum General {
         MISSING_PROPERTY_NAME_VALUE,
+        RELATIONAL_COMMAND_CATEGORY,
         SET_PROPERTY_SUCCESS,
         UNSET_MISSING_PROPERTY_NAME,
         UNSET_PROPERTY_SUCCESS;

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalShellCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalShellCommand.java
@@ -7,6 +7,8 @@
  */
 package org.komodo.relational.commands;
 
+import static org.komodo.relational.commands.RelationalCommandMessages.RESOURCE_BUNDLE;
+import static org.komodo.relational.commands.RelationalCommandMessages.General.RELATIONAL_COMMAND_CATEGORY;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.INVALID_OBJECT_TYPE;
 import org.komodo.relational.Messages;
 import org.komodo.relational.RelationalObject;
@@ -39,6 +41,16 @@ public abstract class RelationalShellCommand extends BuiltInShellCommand {
         throw new KException( getMessage(INVALID_OBJECT_TYPE, kobject.getAbsolutePath() ) );
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#getCategory()
+     */
+    @Override
+    public String getCategory() {
+        return Messages.getString( RESOURCE_BUNDLE, RELATIONAL_COMMAND_CATEGORY.toString() );
+    }
+
     protected ShellCommand getCommand( final String commandName ) throws Exception {
         return getWorkspaceStatus().getCommand( commandName );
     }
@@ -68,7 +80,7 @@ public abstract class RelationalShellCommand extends BuiltInShellCommand {
     }
 
     protected String getMessage(Enum< ? > key, Object... parameters) {
-        return Messages.getString(WorkspaceCommandMessages.RESOURCE_BUNDLE,key.toString(),parameters);
+        return Messages.getString(RelationalCommandMessages.RESOURCE_BUNDLE,key.toString(),parameters);
     }
 
     protected String getWorkspaceMessage(Enum< ? > key, Object... parameters) {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/relationalcommandmessages.properties
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/relationalcommandmessages.properties
@@ -19,6 +19,7 @@
 # 02110-1301 USA.
 
 General.MISSING_PROPERTY_NAME_VALUE = Setting a property requires a property name and value.
+General.RELATIONAL_COMMAND_CATEGORY = Relational
 General.SET_PROPERTY_SUCCESS = The "{0}" property was successfully set.
 General.UNSET_MISSING_PROPERTY_NAME = A property name is required.
 General.UNSET_PROPERTY_SUCCESS = The "{0}" property was successfully removed or reset back to its default value.

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandMessages.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandMessages.java
@@ -25,6 +25,7 @@ public class ServerCommandMessages implements StringConstants {
 
     @SuppressWarnings( "javadoc" )
     public enum Common {
+        CommandCategory,
         NoTeiidDefined,
         ServerNotConnected,
         Connected,
@@ -168,7 +169,7 @@ public class ServerCommandMessages implements StringConstants {
             return getEnumName(this) + DOT + name();
         }
     }
-    
+
     @SuppressWarnings( "javadoc" )
     public enum ServerDeployVdbCommand {
         VdbExportFailed,

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerObjPrintUtils.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerObjPrintUtils.java
@@ -45,7 +45,7 @@ public class ServerObjPrintUtils implements StringConstants {
             // ------------
             PrintUtils.print(writer, indent, "Name: " + vdb.getName()); //$NON-NLS-1$
             PrintUtils.print(writer, indent, "Version: " + vdb.getVersion()); //$NON-NLS-1$
-            
+
             // ------------
             // VDB Type
             // ------------
@@ -57,13 +57,13 @@ public class ServerObjPrintUtils implements StringConstants {
             // ------------
             String status = vdb.isActive() ? "ACTIVE" : "INACTIVE"; //$NON-NLS-1$ //$NON-NLS-2$
             PrintUtils.print(writer, indent, "Status: "+status); //$NON-NLS-1$
-            
+
             // ------------
             // Models
             // ------------
             PrintUtils.print( writer, indent, StringConstants.EMPTY_STRING );
             Collection<String> modelNames = vdb.getModelNames();
-            PrintUtils.printList(writer, new ArrayList(modelNames), "VDB Models"); //$NON-NLS-1$
+            PrintUtils.printList(writer, new ArrayList< String >(modelNames), "VDB Models"); //$NON-NLS-1$
 
             // ------------
             // Properties
@@ -74,7 +74,7 @@ public class ServerObjPrintUtils implements StringConstants {
             PrintUtils.printProperties(writer, vdbProps, "Name", "Value"); //$NON-NLS-1$ //$NON-NLS-2$
         }
     }
-    
+
     /**
      * Print Translator Details
      * @param writer the Writer
@@ -87,7 +87,7 @@ public class ServerObjPrintUtils implements StringConstants {
             // Translator Name
             // ------------
             PrintUtils.print(writer, indent, "Name: " + translator.getName()); //$NON-NLS-1$
-            
+
             // ------------
             // Translator Type
             // ------------
@@ -118,7 +118,7 @@ public class ServerObjPrintUtils implements StringConstants {
             // DataSource Name
             // ------------
             PrintUtils.print(writer, indent, "Name: " + source.getName()); //$NON-NLS-1$
-            
+
             // ------------
             // DataSource Type
             // ------------

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerShellCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerShellCommand.java
@@ -58,6 +58,16 @@ abstract class ServerShellCommand extends RelationalShellCommand {
         return kObj!=null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.commands.RelationalShellCommand#getCategory()
+     */
+    @Override
+    public String getCategory() {
+        return getMessage( ServerCommandMessages.Common.CommandCategory );
+    }
+
     protected String getWorkspaceServerName() throws KException {
         KomodoObject server = getWorkspaceServer();
         if(server!=null) {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/servercommandmessages.properties
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/servercommandmessages.properties
@@ -19,6 +19,7 @@
 # 02110-1301 USA.
 
 ### ServerSetCommand commands
+Common.CommandCategory = Server
 Common.NoTeiidDefined=No teiid instance has been specified.
 Common.ServerNotConnected=Not connected to a Teiid Server.
 Common.Connected=Connected

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
@@ -30,6 +30,13 @@ import java.util.List;
 public interface ShellCommand {
 
     /**
+     * Commands without a category will be placed in a general category.
+     *
+     * @return the command category (can be empty)
+     */
+    String getCategory();
+
+    /**
      * @return the command name (never empty)
      */
     String getName();

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
@@ -52,6 +52,11 @@ public interface WorkspaceStatus extends StringConstants {
 	public static final String EXPORT_DEFAULT_DIR_KEY = "EXPORT_DEFAULT_DIR"; //$NON-NLS-1$
 
     /**
+     * Set to <code>true</code> if the command category should be displayed when help displays available commands.
+     */
+    String SHOW_COMMAND_CATEGORY = "SHOW_COMMAND_CATEGORY"; //$NON-NLS-1$
+
+    /**
      * Set to <code>true</code> if the full path of the current context object should be displayed in the prompt.
      */
     String SHOW_FULL_PATH_IN_PROMPT_KEY = "SHOW_FULL_PATH_IN_PROMPT"; //$NON-NLS-1$
@@ -88,6 +93,7 @@ public interface WorkspaceStatus extends StringConstants {
             put( EXPORT_DEFAULT_DIR_KEY, "." ); //$NON-NLS-1$
             put( IMPORT_DEFAULT_DIR_KEY, "." ); //$NON-NLS-1$
             put( RECORDING_FILE_KEY, "./commandOutput.txt" ); //$NON-NLS-1$
+            put( SHOW_COMMAND_CATEGORY, Boolean.TRUE.toString() );
             put( SHOW_FULL_PATH_IN_PROMPT_KEY, Boolean.FALSE.toString() );
             put( SHOW_HIDDEN_PROPERTIES_KEY, Boolean.FALSE.toString() );
             put( SHOW_PROP_NAME_PREFIX_KEY, Boolean.FALSE.toString() );
@@ -175,14 +181,14 @@ public interface WorkspaceStatus extends StringConstants {
      * @return the current workspace context
      */
     KomodoObject getCurrentContext();
-    
+
     /**
      * Get the context at the supplied display path
      * @param displayPath the display path
      * @return the context, null if not found.
      */
     KomodoObject getContextForDisplayPath(String displayPath);
-    
+
     /**
      * Get the display path for the supplied context
      * @param kObj the context
@@ -218,6 +224,12 @@ public interface WorkspaceStatus extends StringConstants {
 	 * @return the recording writer
 	 */
 	Writer getRecordingWriter();
+
+    /**
+     * @return <code>true</code> if the command category is being displayed when help displays the available commands
+     * @see #SHOW_COMMAND_CATEGORY
+     */
+    boolean isShowingCommandCategory();
 
     /**
      * @return <code>true</code> if the full object path is being displayed in the prompt

--- a/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
@@ -15,6 +15,7 @@
  */
 package org.komodo.shell;
 
+import static org.komodo.shell.Messages.SHELL.GeneralCommandCategory;
 import java.io.File;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -118,6 +119,16 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
         // return result
         assert (result != null);
         return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.ShellCommand#getCategory()
+     */
+    @Override
+    public String getCategory() {
+        return Messages.getString( GeneralCommandCategory );
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/Messages.java
@@ -39,6 +39,7 @@ public class Messages implements StringConstants {
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
 
     public enum SHELL {
+        GeneralCommandCategory,
         CommitSuccess,
         RollbackSuccess,
         FileNotAccessible,
@@ -62,7 +63,8 @@ public class Messages implements StringConstants {
         LOCAL_REPOSITORY_STARTING,
         LOCAL_REPOSITORY_TIMEOUT_ERROR,
     	COMMAND_NOT_FOUND,
-    	Help_COMMAND_LIST_MSG,
+        Help_Category_Header,
+        Help_COMMAND_LIST_MSG,
     	Help_INVALID_COMMAND,
     	Help_USAGE,
     	Help_GET_HELP_1,

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
@@ -447,9 +447,23 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
     public boolean isBooleanProperty( final String name ) {
         ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
         final String propertyName = name.toUpperCase();
-        return propertyName.equals( SHOW_FULL_PATH_IN_PROMPT_KEY ) || propertyName.equals( SHOW_HIDDEN_PROPERTIES_KEY )
-               || propertyName.equals( SHOW_PROP_NAME_PREFIX_KEY ) || propertyName.equals( SHOW_TYPE_IN_PROMPT_KEY )
+        return propertyName.equals( SHOW_COMMAND_CATEGORY )
+               || propertyName.equals( SHOW_FULL_PATH_IN_PROMPT_KEY )
+               || propertyName.equals( SHOW_HIDDEN_PROPERTIES_KEY )
+               || propertyName.equals( SHOW_PROP_NAME_PREFIX_KEY )
+               || propertyName.equals( SHOW_TYPE_IN_PROMPT_KEY )
                || propertyName.equals( AUTO_COMMIT );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.WorkspaceStatus#isShowingCommandCategory()
+     */
+    @Override
+    public boolean isShowingCommandCategory() {
+        assert ( this.wsProperties.containsKey( SHOW_COMMAND_CATEGORY ) );
+        return Boolean.parseBoolean( this.wsProperties.getProperty( SHOW_COMMAND_CATEGORY ) );
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/HelpCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/HelpCommand.java
@@ -15,8 +15,14 @@
  */
 package org.komodo.shell.commands;
 
+import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+import static org.komodo.shell.Messages.SHELL.Help_Category_Header;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 import org.komodo.shell.BuiltInShellCommand;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.CompletionConstants;
@@ -25,7 +31,6 @@ import org.komodo.shell.Messages.SHELL;
 import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.WorkspaceStatus;
-import org.komodo.spi.constants.StringConstants;
 
 /**
  * Implements the 'help' command.
@@ -43,8 +48,19 @@ public class HelpCommand extends BuiltInShellCommand {
      */
     public static final String NAME = "help"; //$NON-NLS-1$
 
-    private static final int CMDS_PER_LINE = 4;
+    private static final int CMDS_PER_LINE = 5;
     private static final int DEFAULT_COLUMN_WIDTH = 10;
+    private static final String INDENT;
+
+    static {
+        final StringBuffer indentBuffer = new StringBuffer( MESSAGE_INDENT );
+
+        for ( int i = 0; i < MESSAGE_INDENT; ++i ) {
+            indentBuffer.append( ' ' );
+        }
+
+        INDENT = indentBuffer.toString();
+    }
 
     /**
      * @param wsStatus
@@ -95,45 +111,87 @@ public class HelpCommand extends BuiltInShellCommand {
         return true;
     }
 
+    private void printCommandNames( final String[] commandNames,
+                                    final boolean categorized ) {
+        int maxCommandLength = DEFAULT_COLUMN_WIDTH;
+
+        // find max length of command names
+        for ( final String cmdName : commandNames ) {
+            if ( cmdName.length() > maxCommandLength ) {
+                maxCommandLength = cmdName.length();
+            }
+        }
+
+        int colCount = 0;
+        final StringBuilder builder = new StringBuilder();
+
+        for ( final String cmdName : commandNames ) {
+            if ( categorized ) {
+                builder.append( INDENT );
+            }
+
+            builder.append( String.format( "%-" + ( maxCommandLength + 5 ) + "s", cmdName ) ); //$NON-NLS-1$ //$NON-NLS-2$
+            ++colCount;
+
+            if ( colCount == CMDS_PER_LINE ) {
+                builder.append( '\n' ).append( INDENT );
+
+                if ( categorized ) {
+                    builder.append( INDENT );
+                }
+
+                colCount = 0;
+            }
+        }
+
+        final int indentSize = ( MESSAGE_INDENT * ( categorized ? 2 : 1 ) );
+        print( indentSize, builder.toString() );
+
+        if ( colCount != 0 ) {
+            print();
+        }
+    }
+
 	/**
 	 * Prints the generic help - all commands for this workspace context
 	 */
 	private void printHelpAll() throws Exception {
-		print(CompletionConstants.MESSAGE_INDENT,Messages.getString(SHELL.Help_COMMAND_LIST_MSG));
+        print( MESSAGE_INDENT, Messages.getString( SHELL.Help_COMMAND_LIST_MSG ) );
+        final String[] validCmdNames = getWorkspaceStatus().getAvailableCommands();
 
-		StringBuffer indentBuffer = new StringBuffer();
-		for(int i=0; i<CompletionConstants.MESSAGE_INDENT; i++) {
-			indentBuffer.append(StringConstants.SPACE);
-		}
+        if ( getWorkspaceStatus().isShowingCommandCategory() ) {
+            final WorkspaceStatus status = getWorkspaceStatus();
+            final Map< String, List< String > > categoryCommands = new TreeMap< >();
 
-		// Assemble the valid command names and find the max command character length
-		int maxCommandLength = DEFAULT_COLUMN_WIDTH;
-        List<String> validCmdNames = new ArrayList<String>();
-        for (final String cmdName : getWorkspaceStatus().getAvailableCommands()) {
-            if(cmdName.length()>maxCommandLength) {
-                maxCommandLength = cmdName.length();
+            // group commands by category
+            for ( final String cmdName : validCmdNames ) {
+                final String category = status.getCommand( cmdName ).getCategory();
+                List< String > commands = categoryCommands.get( category );
+
+                if ( commands == null ) {
+                    commands = new ArrayList< String >();
+                    categoryCommands.put( category, commands );
+                }
+
+                commands.add( cmdName );
             }
-            validCmdNames.add(cmdName);
+
+            // print command by category
+            for ( final Entry< String, List< String > > entry : categoryCommands.entrySet() ) {
+                if ( categoryCommands.size() > 1 ) {
+                    print( ( MESSAGE_INDENT * 2 ), Messages.getString( Help_Category_Header, entry.getKey() ) );
+                }
+
+                Collections.sort( entry.getValue() );
+                printCommandNames( entry.getValue().toArray( new String[ entry.getValue().size() ] ), true );
+            }
+        } else {
+            printCommandNames( validCmdNames, false );
         }
 
-        // Print appropriate commands per line
-		int colCount = 0;
-		StringBuilder builder = new StringBuilder();
-		for (String cmdName : validCmdNames) {
-            builder.append(String.format("%-"+(maxCommandLength+5)+"s", cmdName)); //$NON-NLS-1$ //$NON-NLS-2$
-            colCount++;
-
-            if (colCount == CMDS_PER_LINE) {
-                builder.append("\n"+indentBuffer.toString()); //$NON-NLS-1$
-                colCount = 0;
-            }
-		}
-
-		print(CompletionConstants.MESSAGE_INDENT,builder.toString());
-		if(colCount!=0) print(CompletionConstants.MESSAGE_INDENT,"\n"); //$NON-NLS-1$
-		print(CompletionConstants.MESSAGE_INDENT,Messages.getString(SHELL.Help_GET_HELP_1));
-		print(CompletionConstants.MESSAGE_INDENT,""); //$NON-NLS-1$
-		print(CompletionConstants.MESSAGE_INDENT,Messages.getString(SHELL.Help_GET_HELP_2));
+        print( MESSAGE_INDENT,Messages.getString(SHELL.Help_GET_HELP_1));
+		print( MESSAGE_INDENT,""); //$NON-NLS-1$
+		print( MESSAGE_INDENT,Messages.getString(SHELL.Help_GET_HELP_2));
 	}
 
     private void printHelpForCommand( final String cmdName ) throws Exception {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/messages.properties
@@ -258,6 +258,7 @@ WorkspaceCommand.usage = workspace
 WorkspaceCommand.help = \t{0} - changes the current context to the workspace area.
 
 # This message have SHELL enum definitions in Messages
+SHELL.GeneralCommandCategory = General
 SHELL.CommitSuccess = All changes have been saved.
 SHELL.RollbackSuccess = Unsaved changes have been reverted.
 SHELL.ERROR_LOADING_PROPERTIES = Error loading startup properties "{0}": {1} 
@@ -280,6 +281,7 @@ SHELL.ENGINE_STARTING=Starting engine...
 SHELL.LOCAL_REPOSITORY_STARTING=Starting Local Repository initialization ...
 SHELL.LOCAL_REPOSITORY_TIMEOUT_ERROR=Error: Timeout awaiting initialization of local repository
 SHELL.COMMAND_NOT_FOUND=Command "{0}" not found.  Try "help" for a list of available commands.
+SHELL.Help_Category_Header = {0} Commands:
 SHELL.Help_COMMAND_LIST_MSG=The following commands are supported at this context:\n
 SHELL.Help_INVALID_COMMAND=No help available: "{0}" is not a valid command.
 SHELL.Help_GET_HELP_1=Enter "help" to get a list of available commands or "help <command-name>" for specific information about one command.


### PR DESCRIPTION
- HelpCommand will print commands grouped by category if the global property to do so is set