### PR TITLE
Issue #260 - Adds ability to export vdb from workspace context

### DIFF
--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ExportCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ExportCommand.java
@@ -7,12 +7,17 @@
  */
 package org.komodo.relational.commands.vdb;
 
+import static org.komodo.relational.commands.vdb.VdbCommandMessages.ExportCommand.FileExistsOverwriteDisabled;
+import static org.komodo.relational.commands.vdb.VdbCommandMessages.ExportCommand.OverwriteArgInvalid;
+import static org.komodo.relational.commands.vdb.VdbCommandMessages.ExportCommand.VDB_EXPORTED;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.ERROR_WRITING_FILE;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.MISSING_OUTPUT_FILE_NAME;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.OUTPUT_FILE_ERROR;
-import static org.komodo.relational.commands.vdb.VdbCommandMessages.ExportCommand.VDB_EXPORTED;
 import java.io.File;
-import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.shell.CommandResultImpl;
@@ -20,6 +25,7 @@ import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.spi.constants.ExportConstants;
 import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.utils.StringUtils;
 
 /**
  * A shell command to export a VDB.
@@ -27,6 +33,8 @@ import org.komodo.spi.repository.Repository.UnitOfWork;
 public final class ExportCommand extends VdbShellCommand {
 
     static final String NAME = "export-vdb"; //$NON-NLS-1$
+
+    private static final List< String > VALID_OVERWRITE_ARGS = Arrays.asList( new String[] { "-o", "--overwrite" } ); //$NON-NLS-1$ //$NON-NLS-2$;
 
     /**
      * @param status
@@ -50,10 +58,23 @@ public final class ExportCommand extends VdbShellCommand {
             if ( fileName.indexOf( DOT ) == -1 ) {
                 fileName = fileName + DOT + "xml"; //$NON-NLS-1$
             }
-            final boolean override = Boolean.getBoolean( optionalArgument( 1, "false" ) ); //$NON-NLS-1$
-            final File file = new File( fileName );
 
-            if ( file.createNewFile() || ( file.exists() && override ) ) {
+            final String overwriteArg = optionalArgument( 1, null );
+            final boolean overwrite = !StringUtils.isBlank( overwriteArg );
+
+            // make sure overwrite arg is valid
+            if ( overwrite && !VALID_OVERWRITE_ARGS.contains( overwriteArg ) ) {
+                return new CommandResultImpl( false, getMessage( OverwriteArgInvalid, overwriteArg ), null );
+            }
+            
+            final File file = new File( fileName );
+            
+            // If file exists, must have overwrite option
+            if(file.exists() && !overwrite) {
+                return new CommandResultImpl( false, getMessage( FileExistsOverwriteDisabled, fileName ), null );
+            }
+
+            if ( file.createNewFile() || ( file.exists() && overwrite ) ) {
                 final UnitOfWork uow = getTransaction();
                 final Vdb vdb = getVdb();
                 Properties properties = new Properties();
@@ -61,10 +82,9 @@ public final class ExportCommand extends VdbShellCommand {
                 final String manifest = vdb.export( uow, properties );
 
                 // write file
-                try ( final FileWriter recordingFileWriter = new FileWriter( fileName, false ) ) {
-                    recordingFileWriter.write( manifest );
-                    recordingFileWriter.flush();
-                    return new CommandResultImpl( getMessage( VDB_EXPORTED, vdb.getName( uow ), fileName, override ) );
+                try{
+                    Files.write(Paths.get(file.getPath()), manifest.getBytes());
+                    return new CommandResultImpl( getMessage( VDB_EXPORTED, vdb.getName( uow ), fileName, overwrite ) );
                 } catch ( final Exception e ) {
                     return new CommandResultImpl( false, getWorkspaceMessage( ERROR_WRITING_FILE, fileName ), e );
                 }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/VdbCommandMessages.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/VdbCommandMessages.java
@@ -42,6 +42,8 @@ public class VdbCommandMessages implements StringConstants {
 
     @SuppressWarnings( "javadoc" )
     public enum ExportCommand {
+        OverwriteArgInvalid,
+        FileExistsOverwriteDisabled,
         VDB_EXPORTED;
 
         @Override

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/vdbcommandmessages.properties
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/vdbcommandmessages.properties
@@ -92,7 +92,10 @@ ExportCommand.usage=export-vdb <file-path> [override]
 ExportCommand.help=\t{0} - exports a VDB manifest to a local file.
 ExportCommand.examples= \
 \t export-vdb /Users/me/myVdb.xml \n \
-\t export-vdb /Users/me/myVdb.xml true
+\t export-vdb /Users/me/myVdb.xml -o \n \
+\t export-vdb /Users/me/myVdb.xml --overwrite
+ExportCommand.OverwriteArgInvalid = "{0}" is not a valid overwrite option.
+ExportCommand.FileExistsOverwriteDisabled = File with name "{0}" exists - an overwrite option must be supplied.  Run "help export-vdb" for overwrite options.
 ExportCommand.VDB_EXPORTED = VDB "{0}" was successfully exported to "{1}" with override flag of "{2}"
 
 SetVdbPropertyCommand.usage=set-property <property-name> <new-value>

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/ExportVdbCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/ExportVdbCommand.java
@@ -1,0 +1,166 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+ *
+ * See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+ */
+package org.komodo.relational.commands.workspace;
+
+import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.ExportVdbCommand.FileExistsOverwriteDisabled;
+import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.ExportVdbCommand.OverwriteArgInvalid;
+import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.ExportVdbCommand.VDB_EXPORTED;
+import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.ExportVdbCommand.VDB_NOT_FOUND;
+import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.ERROR_WRITING_FILE;
+import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.MISSING_OUTPUT_FILE_NAME;
+import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.MISSING_VDB_NAME;
+import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.OUTPUT_FILE_ERROR;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.relational.workspace.WorkspaceManager;
+import org.komodo.shell.CommandResultImpl;
+import org.komodo.shell.api.Arguments;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.spi.constants.ExportConstants;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.utils.StringUtils;
+
+/**
+ * A shell command to export a Vdb from Workspace context.
+ */
+public final class ExportVdbCommand extends WorkspaceShellCommand {
+
+    static final String NAME = "export-vdb"; //$NON-NLS-1$
+
+    private static final List< String > VALID_OVERWRITE_ARGS = Arrays.asList( new String[] { "-o", "--overwrite" } ); //$NON-NLS-1$ //$NON-NLS-2$;
+
+    /**
+     * @param status
+     *        the shell's workspace status (cannot be <code>null</code>)
+     */
+    public ExportVdbCommand( final WorkspaceStatus status ) {
+        super( status, NAME );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#doExecute()
+     */
+    @Override
+    protected CommandResult doExecute() {
+        try {
+            final String vdbName = requiredArgument( 0, getMessage( MISSING_VDB_NAME ) );
+            String fileName = requiredArgument( 1, getWorkspaceMessage( MISSING_OUTPUT_FILE_NAME ) );
+
+            // If there is no file extension, add .xml
+            if ( fileName.indexOf( DOT ) == -1 ) {
+                fileName = fileName + DOT + "xml"; //$NON-NLS-1$
+            }
+
+            final String overwriteArg = optionalArgument( 2, null );
+            final boolean overwrite = !StringUtils.isBlank( overwriteArg );
+
+            // make sure overwrite arg is valid
+            if ( overwrite && !VALID_OVERWRITE_ARGS.contains( overwriteArg ) ) {
+                return new CommandResultImpl( false, getMessage( OverwriteArgInvalid, overwriteArg ), null );
+            }
+            
+            // Get the VDB to Export
+            final WorkspaceManager mgr = getWorkspaceManager();
+            final KomodoObject[] vdbs = mgr.findVdbs(getTransaction());
+            Vdb vdbToExport = null;
+            for(KomodoObject vdb : vdbs) {
+                if(vdb.getName(getTransaction()).equals(vdbName)) {
+                    vdbToExport = (Vdb)vdb;
+                    break;
+                }
+            }
+            
+            if(vdbToExport==null) {
+                return new CommandResultImpl( false, getMessage( VDB_NOT_FOUND, vdbName ), null );
+            } 
+            
+            final File file = new File( fileName );
+
+            // If file exists, must have overwrite option
+            if(file.exists() && !overwrite) {
+                return new CommandResultImpl( false, getMessage( FileExistsOverwriteDisabled, fileName ), null );
+            }
+
+            if ( file.createNewFile() || ( file.exists() && overwrite ) ) {
+                final UnitOfWork uow = getTransaction();
+                Properties properties = new Properties();
+                properties.put( ExportConstants.USE_TABS_PROP_KEY, true );
+                final String manifest = vdbToExport.export( uow, properties );
+
+                // Write the file
+                try{
+                    Files.write(Paths.get(file.getPath()), manifest.getBytes());
+                    return new CommandResultImpl( getMessage( VDB_EXPORTED, vdbToExport.getName( uow ), fileName, overwrite ) );
+                } catch ( final Exception e ) {
+                    return new CommandResultImpl( false, getWorkspaceMessage( ERROR_WRITING_FILE, fileName ), e );
+                }
+            }
+
+            return new CommandResultImpl( false, getWorkspaceMessage( OUTPUT_FILE_ERROR, fileName ), null );
+        } catch ( final Exception e ) {
+            return new CommandResultImpl( e );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#getMaxArgCount()
+     */
+    @Override
+    protected int getMaxArgCount() {
+        return 3;
+    }
+    
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.BuiltInShellCommand#tabCompletion(java.lang.String, java.util.List)
+     */
+    @Override
+    public int tabCompletion( final String lastArgument,
+                              final List< CharSequence > candidates ) throws Exception {
+        final Arguments args = getArguments();
+
+        final UnitOfWork uow = getTransaction();
+        final WorkspaceManager mgr = getWorkspaceManager();
+        final KomodoObject[] vdbs = mgr.findVdbs(uow);
+        List<String> existingVdbNames = new ArrayList<String>(vdbs.length);
+        for(KomodoObject vdb : vdbs) {
+            existingVdbNames.add(vdb.getName(uow));
+        }
+
+        if ( args.isEmpty() ) {
+            if ( lastArgument == null ) {
+                candidates.addAll( existingVdbNames );
+            } else {
+                for ( final String item : existingVdbNames ) {
+                    if ( item.toUpperCase().startsWith( lastArgument.toUpperCase() ) ) {
+                        candidates.add( item );
+                    }
+                }
+            }
+
+            return 0;
+        }
+
+        // no tab completion
+        return -1;
+    }
+
+}

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/UploadVdbCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/UploadVdbCommand.java
@@ -10,8 +10,8 @@ package org.komodo.relational.commands.workspace;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.General.INPUT_FILE_ERROR;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.UploadVdbCommand.MISSING_INPUT_VDB_FILE_PATH;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.UploadVdbCommand.MISSING_VDB_NAME;
-import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.UploadVdbCommand.VDB_INPUT_FILE_IS_EMPTY;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.UploadVdbCommand.OVERWRITE_ARG_INVALID;
+import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.UploadVdbCommand.VDB_INPUT_FILE_IS_EMPTY;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.UploadVdbCommand.VDB_OVERWRITE_DISABLED;
 import static org.komodo.relational.commands.workspace.WorkspaceCommandMessages.UploadVdbCommand.VDB_UPLOADED;
 import java.nio.file.Files;
@@ -27,6 +27,7 @@ import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
 import org.komodo.utils.StringUtils;
 import org.modeshape.jcr.JcrLexicon;
+import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 /**
  * Loads a {@link Vdb VDB} from a local file.
@@ -81,14 +82,7 @@ public final class UploadVdbCommand extends WorkspaceShellCommand {
             final Repository.UnitOfWork uow = getTransaction();
 
             // make sure we can overwrite
-            Vdb[] allVdbs = getWorkspaceManager().findVdbs(uow);
-            boolean hasVdb = false;
-            for(Vdb theVdb : allVdbs) {
-                if(vdbName.equals(theVdb.getName(uow))) {
-                    hasVdb = true;
-                    break;
-                }
-            }
+            boolean hasVdb = getWorkspaceManager().hasChild(getTransaction(), vdbName, VdbLexicon.Vdb.VIRTUAL_DATABASE);
             if ( hasVdb && !overwrite ) {
                 return new CommandResultImpl( false, getMessage( VDB_OVERWRITE_DISABLED, fileName, vdbName ), null );
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/WorkspaceCommandMessages.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/WorkspaceCommandMessages.java
@@ -122,6 +122,18 @@ public class WorkspaceCommandMessages implements StringConstants {
         }
     }
 
+    public enum ExportVdbCommand {
+        OverwriteArgInvalid,
+        FileExistsOverwriteDisabled,
+        VDB_NOT_FOUND,
+        VDB_EXPORTED;
+
+        @Override
+        public String toString() {
+            return getEnumName(this) + DOT + name();
+        }
+    }
+
     public enum UploadVdbCommand {
 
         MISSING_INPUT_VDB_FILE_PATH,

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/WorkspaceCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/WorkspaceCommandProvider.java
@@ -47,6 +47,7 @@ public class WorkspaceCommandProvider implements ShellCommandProvider {
         result.add( DeleteVdbCommand.class );
         result.add( ImportVdbCommand.class );
         result.add( UploadVdbCommand.class );
+        result.add( ExportVdbCommand.class );
         result.add( WorkspaceSetPropertyCommand.class );
         result.add( WorkspaceUnsetPropertyCommand.class );
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/workspacecommandmessages.properties
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/workspacecommandmessages.properties
@@ -93,6 +93,17 @@ DeleteSchemaCommand.DELETE_SCHEMA_ERROR = An error occurred deleting the schema.
 DeleteSchemaCommand.SCHEMA_NOT_FOUND = Schema "{0}" was not found.
 DeleteSchemaCommand.SCHEMA_DELETED = Schema "{0}" was deleted.
 
+ExportVdbCommand.usage=export-vdb <vdbName> <file-path> [override]
+ExportVdbCommand.help=\t{0} - exports a VDB to a local file.
+ExportVdbCommand.examples= \
+\t export-vdb myVdb /Users/me/myVdb.xml \n \
+\t export-vdb myVdb /Users/me/myVdb.xml -o \n \
+\t export-vdb myVdb /Users/me/myVdb.xml --overwrite
+ExportVdbCommand.OverwriteArgInvalid = "{0}" is not a valid overwrite option.
+ExportVdbCommand.FileExistsOverwriteDisabled = File with name "{0}" exists - an overwrite option must be supplied.  Run "help export-vdb" for overwrite options.
+ExportVdbCommand.VDB_NOT_FOUND = Vdb "{0}" was not found.
+ExportVdbCommand.VDB_EXPORTED = VDB "{0}" was successfully exported to "{1}" with override flag of "{2}"
+
 UploadVdbCommand.usage=upload-vdb <vdb-name> <local-file-path> [-o | --overwrite]
 UploadVdbCommand.help=\t{0} - uploads a *.xml file whose content is a dynamic VDB.
 UploadVdbCommand.examples= \

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AllTests.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AllTests.java
@@ -106,6 +106,7 @@ import org.komodo.relational.commands.workspace.CreateVdbCommandTest;
 import org.komodo.relational.commands.workspace.DeleteSchemaCommandTest;
 import org.komodo.relational.commands.workspace.DeleteTeiidCommandTest;
 import org.komodo.relational.commands.workspace.DeleteVdbCommandTest;
+import org.komodo.relational.commands.workspace.ExportVdbCommandTest;
 import org.komodo.relational.commands.workspace.UploadVdbCommandTest;
 import org.komodo.relational.commands.workspace.WorkspaceSetPropertyCommandTest;
 import org.komodo.relational.commands.workspace.WorkspaceUnsetPropertyCommandTest;
@@ -136,6 +137,7 @@ import org.komodo.relational.commands.workspace.WorkspaceUnsetPropertyCommandTes
     DeleteVdbCommandTest.class,
 //    ImportVdbCommandTest.class,
     UploadVdbCommandTest.class,
+    ExportVdbCommandTest.class,
     WorkspaceSetPropertyCommandTest.class,
     WorkspaceUnsetPropertyCommandTest.class,
 

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/ExportCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/model/ExportCommandTest.java
@@ -48,9 +48,6 @@ public class ExportCommandTest extends AbstractCommandTest {
         KomodoObject tweet = TestUtilities.createTweetExampleNode(getTransaction(), kWorkspace);
 
         assertNotNull(tweet);
-
-        traverse(getTransaction(), tweet.getAbsolutePath());
-
         return tweet;
     }
 
@@ -59,9 +56,6 @@ public class ExportCommandTest extends AbstractCommandTest {
         KomodoObject tweet = TestUtilities.createAllElementsExampleNode(getTransaction(), kWorkspace);
 
         assertNotNull(tweet);
-
-        traverse(getTransaction(), tweet.getAbsolutePath());
-
         return tweet;
     }
 

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/schema/ExportCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/schema/ExportCommandTest.java
@@ -48,9 +48,6 @@ public final class ExportCommandTest extends AbstractCommandTest {
         schema.setRendition(getTransaction(), TWITTER_VIEW_MODEL_DDL);
 
         assertNotNull(schema);
-
-        traverse(getTransaction(), schema.getAbsolutePath());
-
         return schema;
     }
 

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/ExportCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/vdb/ExportCommandTest.java
@@ -42,9 +42,6 @@ public class ExportCommandTest extends AbstractCommandTest {
         KomodoObject tweet = TestUtilities.createTweetExampleNode(getTransaction(), kWorkspace);
 
         assertNotNull(tweet);
-
-        traverse(getTransaction(), tweet.getAbsolutePath());
-
         return tweet;
     }
 
@@ -53,9 +50,6 @@ public class ExportCommandTest extends AbstractCommandTest {
         KomodoObject tweet = TestUtilities.createAllElementsExampleNode(getTransaction(), kWorkspace);
 
         assertNotNull(tweet);
-
-        traverse(getTransaction(), tweet.getAbsolutePath());
-
         return tweet;
     }
 

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/ExportVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/ExportVdbCommandTest.java
@@ -42,9 +42,6 @@ public class ExportVdbCommandTest extends AbstractCommandTest {
         KomodoObject tweet = TestUtilities.createTweetExampleNode(getTransaction(), kWorkspace);
 
         assertNotNull(tweet);
-
-        traverse(getTransaction(), tweet.getAbsolutePath());
-
         return tweet;
     }
 
@@ -53,9 +50,6 @@ public class ExportVdbCommandTest extends AbstractCommandTest {
         KomodoObject tweet = TestUtilities.createAllElementsExampleNode(getTransaction(), kWorkspace);
 
         assertNotNull(tweet);
-
-        traverse(getTransaction(), tweet.getAbsolutePath());
-
         return tweet;
     }
 

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/ExportVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/workspace/ExportVdbCommandTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.relational.commands.workspace;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import org.junit.Test;
+import org.komodo.relational.commands.AbstractCommandTest;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.test.utils.TestUtilities;
+import org.w3c.dom.Document;
+
+/**
+ * Test Class to test VDB {@link ExportVdbCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public class ExportVdbCommandTest extends AbstractCommandTest {
+
+    private static final String TWEET_VDB = "./resources/tweet-example-vdb.xml";  //$NON-NLS-1$
+    private static final String ALL_ELEMENTS_VDB = "./resources/teiid-vdb-all-elements.xml";  //$NON-NLS-1$
+
+    private KomodoObject addTweetVdbExample() throws KException, Exception {
+        KomodoObject kWorkspace = _repo.komodoWorkspace(getTransaction());
+        KomodoObject tweet = TestUtilities.createTweetExampleNode(getTransaction(), kWorkspace);
+
+        assertNotNull(tweet);
+
+        traverse(getTransaction(), tweet.getAbsolutePath());
+
+        return tweet;
+    }
+
+    private KomodoObject addAllElementsVdbExample() throws Exception {
+        KomodoObject kWorkspace = _repo.komodoWorkspace(getTransaction());
+        KomodoObject tweet = TestUtilities.createAllElementsExampleNode(getTransaction(), kWorkspace);
+
+        assertNotNull(tweet);
+
+        traverse(getTransaction(), tweet.getAbsolutePath());
+
+        return tweet;
+    }
+
+    @Test
+    public void testExportCommandTweetVdb() throws Exception {
+        //
+        // Create the vdb in the repository
+        //
+        KomodoObject tweetVdb = addTweetVdbExample();
+
+        //
+        // Create the export command instructions file
+        //
+        File exportCmdFile = File.createTempFile("TestExportVdbCommand", ".txt"); //$NON-NLS-1$  //$NON-NLS-2$
+        exportCmdFile.deleteOnExit();
+
+        //
+        // Create the export destination file, ensuring it does not already exist
+        //
+        File exportDest = new File(System.getProperty("java.io.tmpdir") + File.separator + "TestExportDestination.txt"); //$NON-NLS-1$  //$NON-NLS-2$
+        exportDest.deleteOnExit();
+        if (exportDest.exists())
+            exportDest.delete();
+
+        // The test commands
+        final String[] commands = {
+            "commit",
+            "workspace",
+            "export-vdb " + tweetVdb.getName(getTransaction()) + " " + exportDest.getAbsolutePath() };
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
+        assertTrue(exportDest.exists());
+
+        Document vdbDocument = TestUtilities.createDocument(new FileInputStream(exportDest));
+        assertNotNull(vdbDocument);
+
+        InputStream tweetExample = new FileInputStream(new File(TWEET_VDB));
+        Document tweetDocument = TestUtilities.createDocument(tweetExample);
+
+        TestUtilities.compareDocuments(tweetDocument, vdbDocument);
+    }
+
+    @Test
+    public void testExportCommandAllElementsVdb() throws Exception {
+        //
+        // Create the vdb in the repository
+        //
+        KomodoObject allElementsVdb = addAllElementsVdbExample();
+
+        //
+        // Create the export command instructions file
+        //
+        File exportCmdFile = File.createTempFile("TestExportVdbCommand", ".txt"); //$NON-NLS-1$  //$NON-NLS-2$
+        exportCmdFile.deleteOnExit();
+
+        //
+        // Create the export destination file, ensuring it does not already exist
+        //
+        File exportDest = new File(System.getProperty("java.io.tmpdir") + File.separator + "TestExportDestination.txt"); //$NON-NLS-1$  //$NON-NLS-2$
+        exportDest.deleteOnExit();
+        if (exportDest.exists())
+            exportDest.delete();
+
+        // The test commands
+        final String[] commands = {
+            "commit",
+            "workspace",
+            "export-vdb " + allElementsVdb.getName(getTransaction()) + " " + exportDest.getAbsolutePath() };
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
+        assertTrue(exportDest.exists());
+
+        Document vdbDocument = TestUtilities.createDocument(new FileInputStream(exportDest));
+        assertNotNull(vdbDocument);
+
+        InputStream allElementsExample = new FileInputStream(new File(ALL_ELEMENTS_VDB));
+        Document allElementsDocument = TestUtilities.createDocument(allElementsExample);
+
+        TestUtilities.compareDocuments(allElementsDocument, vdbDocument);
+    }
+
+}


### PR DESCRIPTION
- add ExportVdbCommand, to allow user to export a vdb from the workspace context.
- adds unit test and includes it in AllTests
- made improvements to the existing ExportCommand - checks that the overwrite arg is correct and provides appropriate messages.
- simplifies vdb retrieval in ExportVdbCommand, DeleteVdbCommand, UploadVdbCommand, ServerDeployVdbCommand