### PR TITLE
Caching available commands in WorkspaceStatus

### DIFF
--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerConnectCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerConnectCommand.java
@@ -59,6 +59,10 @@ public final class ServerConnectCommand extends ServerShellCommand {
                 teiidInstance.connect();
                 boolean connected = teiidInstance.isConnected();
                 String connectStatus = connected ? getMessage( Connected ) : Messages.getString( NotConnected );
+
+                // Updates available commands upon connecting
+                getWorkspaceStatus().updateAvailableCommands();
+                
                 result = new CommandResultImpl( getMessage( TeiidStatus, teiid.getName( getTransaction() ), connectStatus ) );
             } catch ( Exception ex ) {
                 result = new CommandResultImpl( false, getMessage( ConnectionError, ex.getLocalizedMessage() ), ex );

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerDisconnectCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerDisconnectCommand.java
@@ -56,6 +56,10 @@ public final class ServerDisconnectCommand extends ServerShellCommand {
                        getMessage( AttemptingToDisconnect, teiid.getName( getTransaction() ) ) );
 
                 teiidInstance.disconnect();
+                
+                // Updates available commands upon disconnecting
+                getWorkspaceStatus().updateAvailableCommands();
+                
                 result = new CommandResultImpl( getMessage( DisconnectSuccessMsg, teiid.getName( getTransaction() ) ) );
             } else {
                 result = new CommandResultImpl( getMessage( NoServerToDisconnectMsg ) );

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerSetCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerSetCommand.java
@@ -70,6 +70,10 @@ public final class ServerSetCommand extends ServerShellCommand {
 
             // Set the server on workspace status
             getWorkspaceStatus().setStateObject( ServerCommandProvider.SERVER_DEFAULT_KEY, wsTeiid );
+            
+            // Updates available commands upon setting server
+            getWorkspaceStatus().updateAvailableCommands();
+            
             result = new CommandResultImpl( getMessage( ServerSetSuccess, serverName ) );
         } catch ( final Exception e ) {
             result = new CommandResultImpl( e );

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/servercommandmessages.properties
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/servercommandmessages.properties
@@ -48,7 +48,7 @@ ServerConnectCommand.usage=server-connect
 ServerConnectCommand.help=\t{0} - attempts to connect to the default server.
 ServerConnectCommand.examples= \
 \t server-connect 
-ServerConnectCommand.AttemptingToConnect=Attempting to connect to "{0}"...
+ServerConnectCommand.AttemptingToConnect=Attempting to connect to "{0}" - PLEASE WAIT...
 ServerConnectCommand.ConnectionError=*** Error Connecting: {0}
 ServerConnectCommand.TeiidStatus=Teiid "{0}" connection status: {1}
 ServerConnectCommand.Connected=Connected

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
@@ -30,6 +30,11 @@ import java.util.List;
 public interface ShellCommand {
 
     /**
+     *  The command not found name
+     */
+    String COMMAND_NOT_FOUND = "cmd-not-found";  //$NON-NLS-1$
+    
+    /**
      * Commands without a category will be placed in a general category.
      *
      * @return the command category (can be empty)

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandFactory.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandFactory.java
@@ -30,9 +30,12 @@ public interface ShellCommandFactory {
 
     /**
      * @return a sorted collection of the valid command names for the current context (never <code>null</code>)
-     * @throws Exception
-     *         if error occurs
      */
-    Set< String > getCommandNamesForCurrentContext() throws Exception;
+    Set< String > getCommandNamesForCurrentContext();
+
+    /**
+     * @return a sorted collection of the valid command names for the current context (never <code>null</code>)
+     */
+    Set< ShellCommand > getCommandsForCurrentContext();
 
 }

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import org.komodo.core.KEngine;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
@@ -103,11 +104,23 @@ public interface WorkspaceStatus extends StringConstants {
     } );
 
     /**
+     * @return the command names available for the current context (never <code>null</code>)
+     * @throws Exception
+     *         if an error occurs
+     */
+    String[] getAvailableCommandNames() throws Exception;
+
+    /**
      * @return the commands available for the current context (never <code>null</code>)
      * @throws Exception
      *         if an error occurs
      */
-    String[] getAvailableCommands() throws Exception;
+    Set<ShellCommand> getAvailableCommands() throws Exception;
+    
+    /**
+     * Update the available commands for the current context.
+     */
+    void updateAvailableCommands();
 
     /**
      * @param commandName

--- a/plugins/org.komodo.shell/src/org/komodo/shell/AbstractShellCommandReader.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/AbstractShellCommandReader.java
@@ -105,7 +105,7 @@ public abstract class AbstractShellCommandReader implements ShellCommandReader {
 		String commandName = arguments.removeCommandName();
 
 		// Create the command.
-		ShellCommand command = factory.getCommand(commandName);
+		ShellCommand command = this.wsStatus.getCommand(commandName);
 		command.setArguments(arguments);
 		command.setWriter(getOutputWriter());
 		return command;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/DefaultKomodoShell.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/DefaultKomodoShell.java
@@ -46,7 +46,6 @@ import org.komodo.shell.api.InvalidCommandArgumentException;
 import org.komodo.shell.api.KomodoShell;
 import org.komodo.shell.api.KomodoShellParent;
 import org.komodo.shell.api.ShellCommand;
-import org.komodo.shell.api.ShellCommandFactory;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.shell.commands.ExitCommand;
 import org.komodo.shell.commands.HelpCommand;
@@ -237,7 +236,6 @@ public class DefaultKomodoShell implements KomodoShell {
         startKEngine();
 
         wsStatus = new WorkspaceStatusImpl( this );
-        ShellCommandFactory factory = wsStatus.getCommandFactory();
 
         // load shell properties if they exist
         final String dataDir = getShellDataLocation();
@@ -264,7 +262,7 @@ public class DefaultKomodoShell implements KomodoShell {
         displayWelcomeMessage();
 
         // run help command
-        final ShellCommand helpCmd = factory.getCommand( HelpCommand.NAME );
+        final ShellCommand helpCmd = this.wsStatus.getCommand( HelpCommand.NAME );
         helpCmd.setArguments( new Arguments( EMPTY_STRING ) );
         helpCmd.setWriter( getOutputWriter() );
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/ShellCommandFactoryImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/ShellCommandFactoryImpl.java
@@ -222,8 +222,9 @@ public class ShellCommandFactoryImpl implements ShellCommandFactory {
         _commandNotFound.command = commandName;
         return _commandNotFound;
     }
-
-    private Set< ShellCommand > getCommandsForCurrentContext() throws Exception {
+    
+    @Override
+    public Set< ShellCommand > getCommandsForCurrentContext() {
         final Set< ShellCommand > availableCommands = new HashSet< >();
 
         for ( final String cmdName : this.commandMap.keySet() ) {
@@ -281,7 +282,7 @@ public class ShellCommandFactoryImpl implements ShellCommandFactory {
      * @see org.komodo.shell.api.ShellCommandFactory#getCommandNamesForCurrentContext()
      */
     @Override
-    public Set< String > getCommandNamesForCurrentContext() throws Exception {
+    public Set< String > getCommandNamesForCurrentContext() {
         final Set< String > commandNames = new TreeSet< >();
 
         for ( final ShellCommand possible : getCommandsForCurrentContext() ) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/HelpCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/HelpCommand.java
@@ -157,7 +157,7 @@ public class HelpCommand extends BuiltInShellCommand {
 	 */
 	private void printHelpAll() throws Exception {
         print( MESSAGE_INDENT, Messages.getString( SHELL.Help_COMMAND_LIST_MSG ) );
-        final String[] validCmdNames = getWorkspaceStatus().getAvailableCommands();
+        final String[] validCmdNames = getWorkspaceStatus().getAvailableCommandNames();
 
         if ( getWorkspaceStatus().isShowingCommandCategory() ) {
             final WorkspaceStatus status = getWorkspaceStatus();
@@ -219,7 +219,7 @@ public class HelpCommand extends BuiltInShellCommand {
                               List< CharSequence > candidates ) {
         if ( getArguments().isEmpty() ) {
             try {
-                for ( String candidate : getWorkspaceStatus().getAvailableCommands() ) {
+                for ( String candidate : getWorkspaceStatus().getAvailableCommandNames() ) {
                     if ( lastArgument == null || candidate.startsWith( lastArgument ) ) {
                         candidates.add( candidate );
                     }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/AbstractCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/AbstractCommandTest.java
@@ -133,7 +133,7 @@ public abstract class AbstractCommandTest extends AbstractLocalRepositoryTest {
     }
 
     protected void assertCommandsNotAvailable( final String... cmdNames ) throws Exception {
-        final Collection< String > available = Arrays.asList( this.wsStatus.getAvailableCommands() );
+        final Collection< String > available = Arrays.asList( this.wsStatus.getAvailableCommandNames() );
 
         for ( final String name : cmdNames ) {
             if ( available.contains( name ) ) {


### PR DESCRIPTION
- WorkspaceContextImpl now keeps track of the currently available commands - so factory is not called repeatedly.
- adds 'updateAvailableCommands' method to WorkspaceStatus so that commands can trigger update.
