### PR TITLE
Changes to allow persisting default server

### DIFF
--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandProvider.java
@@ -124,10 +124,10 @@ public class ServerCommandProvider implements ShellCommandProvider {
      */
     @Override
     public void initWorkspaceState(WorkspaceStatus wsStatus) throws KException {
-        Properties globalProps = wsStatus.getProperties();
+        Properties providedProps = wsStatus.getProvidedProperties();
         // Look for Server default key.  If found, attempt to set the state object
-        if(globalProps.containsKey(ServerCommandProvider.SERVER_DEFAULT_KEY)) {
-            String defaultServerName = globalProps.getProperty(ServerCommandProvider.SERVER_DEFAULT_KEY);
+        if(providedProps.containsKey(ServerCommandProvider.SERVER_DEFAULT_KEY)) {
+            String defaultServerName = providedProps.getProperty(ServerCommandProvider.SERVER_DEFAULT_KEY);
             WorkspaceManager wsMgr = WorkspaceManager.getInstance(wsStatus.getCurrentContext().getRepository());
             Teiid teiid = ServerUtils.getWorkspaceTeiidObject(wsMgr, wsStatus, defaultServerName);
             wsStatus.setStateObject(ServerCommandProvider.SERVER_DEFAULT_KEY, teiid);

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/DeleteTeiidCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/DeleteTeiidCommand.java
@@ -9,6 +9,7 @@ package org.komodo.relational.commands.workspace;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.komodo.relational.commands.server.ServerCommandProvider;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.api.Arguments;
@@ -58,6 +59,12 @@ public final class DeleteTeiidCommand extends WorkspaceShellCommand {
             if(objToDelete[0]==null) {
                 result = new CommandResultImpl( false, I18n.bind( WorkspaceCommandsI18n.teiidNotFound, teiidName ), null );
             } else {
+                // If server being deleted is the current default server, remove the default
+                KomodoObject defaultTeiid = getWorkspaceStatus().getStateObjects().get( ServerCommandProvider.SERVER_DEFAULT_KEY );
+                if(defaultTeiid!=null && defaultTeiid.getName(getTransaction()).equals(teiidName)) {
+                    getWorkspaceStatus().setStateObject( ServerCommandProvider.SERVER_DEFAULT_KEY, null );
+                }
+
                 mgr.delete(getTransaction(), objToDelete);
                 result = new CommandResultImpl( I18n.bind( WorkspaceCommandsI18n.teiidDeleted, teiidName ) );
             }

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
@@ -139,9 +139,38 @@ public interface WorkspaceStatus extends StringConstants {
      * @param propValue
      *        the property value (can be empty when changing to the default value)
      */
-    void setProperty( final String propKey,
-                      final String propValue );
+    void setGlobalProperty( final String propKey,
+                            final String propValue );
 
+    /**
+     * Sets provided workspace properties on startup
+     *
+     * @param props
+     *        the properties (can be <code>null</code> or null to remove)
+     * @throws Exception
+     *         if an error occurs
+     */
+    void setProvidedProperties( final Properties props ) throws Exception;
+    
+    /**
+     * Sets the specified provided property value in workspace properties.
+     *
+     * @param propKey
+     *        the property key (cannot be empty)
+     * @param propValue
+     *        the property value (can be empty when changing to the default value)
+     */
+    void setProvidedProperty( final String propKey,
+                              final String propValue );
+
+    /**
+     * Gets a copy of the provided workspace properties.  This returns only the properties that are provided.
+     *
+     * @return the provided workspace properties (never <code>null</code> or empty)
+     * @see #setProvidedProperty(String, String)
+     */
+    Properties getProvidedProperties();
+    
     /**
      * Sets global workspace properties on startup
      *
@@ -150,15 +179,15 @@ public interface WorkspaceStatus extends StringConstants {
      * @throws Exception
      *         if an error occurs
      */
-    void setProperties( final Properties props ) throws Exception;
+    void setGlobalProperties( final Properties props ) throws Exception;
 
     /**
-     * Gets a copy of the global workspace properties.
+     * Gets a copy of the global workspace properties.  This includes the defined global properties and defined hidden properties. 
      *
      * @return the global workspace properties (never <code>null</code> or empty)
-     * @see #setProperty(String, String)
+     * @see #setGlobalProperty(String, String)
      */
-    Properties getProperties();
+    Properties getGlobalProperties();
 
     /**
      * @param propertyName the name of the property being checked (cannot be empty)
@@ -308,14 +337,6 @@ public interface WorkspaceStatus extends StringConstants {
      */
     void commit(String source) throws Exception;
 
-//    /**
-//     * Commit
-//     * @param source identifier for commit
-//     * @param importMessages collects import messages
-//     * @throws Exception
-//     */
-//	void commitImport( final String source, ImportMessages importMessages ) throws Exception;
-
     /**
      * Rolls back any unsaved changes.
      *
@@ -356,8 +377,9 @@ public interface WorkspaceStatus extends StringConstants {
      * Set a generic workspace state object
      * @param key the state key
      * @param stateObj the state object
+     * @throws KException the exception
      */
-    void setStateObject(String key, KomodoObject stateObj);
+    void setStateObject(String key, KomodoObject stateObj) throws KException;
 
     /**
      * Remove a generic workspace state object

--- a/plugins/org.komodo.shell/src/org/komodo/shell/DefaultKomodoShell.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/DefaultKomodoShell.java
@@ -274,7 +274,8 @@ public class DefaultKomodoShell implements KomodoShell {
                                                      e.getMessage() ) );
             }
 
-            this.wsStatus.setProperties( props );
+            this.wsStatus.setGlobalProperties( props );
+            this.wsStatus.setProvidedProperties( props );
         }
 
         reader = ShellCommandReaderFactory.createCommandReader( args, wsStatus );
@@ -466,7 +467,10 @@ public class DefaultKomodoShell implements KomodoShell {
                 Files.createFile( propFile );
             }
 
-            this.wsStatus.getProperties().store( new FileOutputStream( propFile.toString() ), null );
+            Properties allProps = this.wsStatus.getGlobalProperties();
+            Properties providedProps = this.wsStatus.getProvidedProperties();
+            allProps.putAll(providedProps);
+            allProps.store( new FileOutputStream( propFile.toString() ), null );
             this.wsStatus.closeRecordingWriter();
 
             // should not have any changes at this point unless user ctrl-c
@@ -516,7 +520,7 @@ public class DefaultKomodoShell implements KomodoShell {
                 recordingWriter.write( command.toString() + StringConstants.NEW_LINE );
                 recordingWriter.flush();
             } catch ( IOException ex ) {
-                String filePath = wsStatus.getProperties().getProperty( WorkspaceStatus.RECORDING_FILE_KEY );
+                String filePath = wsStatus.getGlobalProperties().getProperty( WorkspaceStatus.RECORDING_FILE_KEY );
                 PrintUtils.print( recordingWriter, 0, I18n.bind( ShellI18n.recordingFileOutputError, filePath ) );
             }
             // Print error message if the recording file was not defined

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
@@ -686,7 +686,7 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
         if ( StringUtils.isEmpty( value ) ) {
             this.wsProperties.remove(name);
         } else {
-            this.wsProperties.setProperty( name.toUpperCase(), value );
+            this.wsProperties.setProperty( name, value );
         }
     }
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
@@ -164,7 +164,7 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
     }
 
     private void initGlobalProperties() throws KException {
-        resetProperties();
+        resetGlobalProperties();
 
         // load shell properties if they exist
         final String dataDir = this.shell.getShellDataLocation();
@@ -587,20 +587,20 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
         return null; // name and value are valid
     }
 
-    private void resetProperties() {
+    private void resetGlobalProperties() {
         for ( final Entry< String, String > entry : GLOBAL_PROPS.entrySet() ) {
-            setProperty( entry.getKey(), entry.getValue() );
+            setGlobalProperty( entry.getKey(), entry.getValue() );
         }
     }
 
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.WorkspaceStatus#setProperty(java.lang.String, java.lang.String)
+     * @see org.komodo.shell.api.WorkspaceStatus#setGlobalProperty(java.lang.String, java.lang.String)
      */
     @Override
-    public void setProperty( final String name,
-                             final String value ) {
+    public void setGlobalProperty( final String name,
+                                   final String value ) {
         ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
 
         if ( !HIDDEN_PROPS.contains( name ) && WorkspaceStatus.GLOBAL_PROPS.containsKey( name.toUpperCase() ) ) {
@@ -613,7 +613,7 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
                     this.wsProperties.setProperty( name.toUpperCase(), value );
                 } else {
                     // reset to default value if value is invalid
-                    setProperty( name, null );
+                    this.wsProperties.setProperty( name, GLOBAL_PROPS.get( name ) );
                 }
             }
             if(name.toUpperCase().equals(WorkspaceStatus.RECORDING_FILE_KEY)) {
@@ -625,15 +625,15 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.WorkspaceStatus#setProperties(java.util.Properties)
+     * @see org.komodo.shell.api.WorkspaceStatus#setGlobalProperties(java.util.Properties)
      */
     @Override
-    public void setProperties( final Properties props ) throws Exception {
-        resetProperties();
+    public void setGlobalProperties( final Properties props ) throws Exception {
+        resetGlobalProperties();
 
         if ( ( props != null ) && !props.isEmpty() ) {
             for ( final String name : props.stringPropertyNames() ) {
-                setProperty( name, props.getProperty( name ) );
+                setGlobalProperty( name, props.getProperty( name ) );
             }
 
             // set current context to saved context if necessary
@@ -659,6 +659,34 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
             }
 
             setCurrentContext( context );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.shell.api.WorkspaceStatus#setProvidedProperties(java.util.Properties)
+     */
+    @Override
+    public void setProvidedProperties( final Properties props ) throws Exception {
+        if ( ( props != null ) && !props.isEmpty() ) {
+            for ( final String name : props.stringPropertyNames() ) {
+                setProvidedProperty( name, props.getProperty( name ) );
+            }
+        }
+    }
+    
+    /* (non-Javadoc)
+     * @see org.komodo.shell.api.WorkspaceStatus#setStateProperty(java.lang.String, java.lang.String)
+     */
+    @Override
+    public void setProvidedProperty(String name,
+                                    String value) {
+        ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
+        if ( StringUtils.isEmpty( value ) ) {
+            this.wsProperties.remove(name);
+        } else {
+            this.wsProperties.setProperty( name.toUpperCase(), value );
         }
     }
 
@@ -706,14 +734,33 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.WorkspaceStatus#getProperties()
+     * @see org.komodo.shell.api.WorkspaceStatus#getGlobalProperties()
      */
     @Override
-    public Properties getProperties() {
+    public Properties getGlobalProperties() {
         final Properties copy = new Properties(); // just provide a copy
 
         for ( final String propName : this.wsProperties.stringPropertyNames() ) {
-            copy.setProperty( propName, this.wsProperties.getProperty( propName ) );
+            // Includes the defined global properties and hidden properties
+            if ( HIDDEN_PROPS.contains( propName ) || WorkspaceStatus.GLOBAL_PROPS.containsKey( propName.toUpperCase() ) ) {
+                copy.setProperty( propName, this.wsProperties.getProperty( propName ) );
+            }
+        }
+
+        return copy;
+    }
+
+    /* (non-Javadoc)
+     * @see org.komodo.shell.api.WorkspaceStatus#getProvidedProperties()
+     */
+    @Override
+    public Properties getProvidedProperties() {
+        final Properties copy = new Properties(); // just provide a copy
+
+        for ( final String propName : this.wsProperties.stringPropertyNames() ) {
+            if ( !HIDDEN_PROPS.contains(propName) && !WorkspaceStatus.GLOBAL_PROPS.containsKey( propName.toUpperCase() ) ) {
+                copy.setProperty( propName, this.wsProperties.getProperty( propName ) );
+            }
         }
 
         return copy;
@@ -758,8 +805,15 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
      */
     @Override
     public void setStateObject(String key,
-                               KomodoObject stateObj) {
-        this.stateObjects.put(key, stateObj);
+                               KomodoObject stateObj) throws KException {
+        String stateObjName = null;
+        if(stateObj!=null) {
+            this.stateObjects.put(key, stateObj);
+            stateObjName = stateObj.getName(getTransaction());
+        } else {
+            this.stateObjects.remove(key);
+        }
+        setProvidedProperty(key,stateObjName);
     }
 
     /* (non-Javadoc)
@@ -768,6 +822,7 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
     @Override
     public void removeStateObject(String key) {
         this.stateObjects.remove(key);
+        setProvidedProperty(key,null);
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/PlayCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/PlayCommand.java
@@ -70,7 +70,7 @@ public class PlayCommand  extends BuiltInShellCommand {
             try {
                 // turn auto-commit off for batch
                 if ( saveAutoCommit ) {
-                    wsStatus.setProperty( WorkspaceStatus.AUTO_COMMIT, Boolean.FALSE.toString() );
+                    wsStatus.setGlobalProperty( WorkspaceStatus.AUTO_COMMIT, Boolean.FALSE.toString() );
                 }
 
                 { // play file
@@ -124,7 +124,7 @@ public class PlayCommand  extends BuiltInShellCommand {
             } finally {
                 // if AUTO_COMMIT if different (script could've changed value also)
                 if ( getWorkspaceStatus().isAutoCommit() != saveAutoCommit ) {
-                    getWorkspaceStatus().setProperty( WorkspaceStatus.AUTO_COMMIT,
+                    getWorkspaceStatus().setGlobalProperty( WorkspaceStatus.AUTO_COMMIT,
                                                       Boolean.toString( getWorkspaceStatus().isAutoCommit() ) );
                 }
             }

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/ResetGlobalPropertyCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/ResetGlobalPropertyCommand.java
@@ -7,18 +7,32 @@ import org.komodo.shell.BuiltInShellCommand;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.ShellI18n;
 import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.utils.StringUtils;
 import org.komodo.utils.i18n.I18n;
 
+/**
+ * A {@link ShellCommand command} that can reset global workspace properties
+ * <p>
+ * Usage:
+ * <p>
+ * <code>&nbsp;&nbsp;
+ * reset-global &lt;propName&gt;
+ * </code>
+ */
 public class ResetGlobalPropertyCommand extends BuiltInShellCommand {
 	/**
 	 * The command name.
 	 */
 	public static final String NAME = "reset-global"; //$NON-NLS-1$
 
-	private final static String ARG_ALL = "--all";
+	private final static String ARG_ALL = "--all"; //$NON-NLS-1$
 
+    /**
+     * @param workspaceStatus
+     *        the workspace status (cannot be <code>null</code>)
+     */
 	public ResetGlobalPropertyCommand(final WorkspaceStatus workspaceStatus) {
 		super(workspaceStatus, NAME);
 	}
@@ -37,13 +51,13 @@ public class ResetGlobalPropertyCommand extends BuiltInShellCommand {
 			WorkspaceStatus status = getWorkspaceStatus();
 			if (firstArgument.equals(ARG_ALL)) {
 				// reset all global properties
-				status.setProperties(null);
+				status.setGlobalProperties(null);
 				return new CommandResultImpl(I18n.bind(ShellI18n.globalResetAllProps)); //Reset all props OK
 			} else { 
 				// reset single property
 				String validationStatus = status.validateGlobalPropertyValue(firstArgument.toUpperCase(), null);
 				if (StringUtils.isEmpty(validationStatus)) {
-					status.setProperty(firstArgument.toUpperCase(), null);
+					status.setGlobalProperty(firstArgument.toUpperCase(), null);
 					return new CommandResultImpl(I18n.bind(ShellI18n.globalPropertyReset,firstArgument));// Reset one prop OK
 				} else { 
 					// invalid property name
@@ -62,6 +76,7 @@ public class ResetGlobalPropertyCommand extends BuiltInShellCommand {
 	}
 	
 
+    @Override
     public int tabCompletion( final String lastArgument, final List< CharSequence > candidates ) throws Exception {
         if ( getArguments().size() == 0 ) {
             // Global property completion options and reset all argument

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetAutoCommitCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetAutoCommitCommand.java
@@ -59,7 +59,7 @@ public class SetAutoCommitCommand extends BuiltInShellCommand {
                                               null );
             }
 
-            getWorkspaceStatus().setProperty(WorkspaceStatus.AUTO_COMMIT, arg);
+            getWorkspaceStatus().setGlobalProperty(WorkspaceStatus.AUTO_COMMIT, arg);
 
             return new CommandResultImpl( I18n.bind( ShellI18n.globalPropertySet, WorkspaceStatus.AUTO_COMMIT ) );
         } catch ( final Exception e ) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetGlobalPropertyCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetGlobalPropertyCommand.java
@@ -127,7 +127,7 @@ public class SetGlobalPropertyCommand extends BuiltInShellCommand {
      */
     private void setGlobalProperty(String propName, String propValue) throws Exception {
         WorkspaceStatus wsStatus = getWorkspaceStatus();
-        wsStatus.setProperty(propName, propValue);
+        wsStatus.setGlobalProperty(propName, propValue);
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetRecordCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/SetRecordCommand.java
@@ -78,7 +78,7 @@ public class SetRecordCommand extends BuiltInShellCommand {
 
             // Set WorkspaceStatus
             WorkspaceStatus wsStatus = getWorkspaceStatus();
-            String recordingFileStr = getWorkspaceStatus().getProperties().getProperty(WorkspaceStatus.RECORDING_FILE_KEY);
+            String recordingFileStr = getWorkspaceStatus().getGlobalProperties().getProperty(WorkspaceStatus.RECORDING_FILE_KEY);
             if(onOffArg.equalsIgnoreCase(ON)) {
                 wsStatus.setRecordingStatus(true);
 
@@ -177,7 +177,7 @@ public class SetRecordCommand extends BuiltInShellCommand {
                 recordingWriter.write(message+StringConstants.NEW_LINE);
                 recordingWriter.flush();
             } catch (IOException ex) {
-                String filePath = wsStatus.getProperties().getProperty(WorkspaceStatus.RECORDING_FILE_KEY);
+                String filePath = wsStatus.getGlobalProperties().getProperty(WorkspaceStatus.RECORDING_FILE_KEY);
                 print(MESSAGE_INDENT, I18n.bind(ShellI18n.recordingFileOutputError, filePath));
             }
         // Print error message if the recording file was not defined

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/ShowGlobalCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/ShowGlobalCommand.java
@@ -74,7 +74,8 @@ public class ShowGlobalCommand extends BuiltInShellCommand {
     @Override
     protected CommandResult doExecute() {
         try {
-            final Properties globalProperties = getWorkspaceStatus().getProperties();
+            // Gets all global properties(except hidden).
+            final Properties globalProperties = getWorkspaceStatus().getGlobalProperties();
 
             // Print properties header
             final String globalPropsHeader = I18n.bind( ShellI18n.globalPropertiesHeader );

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/AllTests.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/AllTests.java
@@ -31,6 +31,7 @@ import org.komodo.shell.commands.ShowStatusCommandTest;
 import org.komodo.shell.commands.ShowSummaryCommandTest;
 import org.komodo.shell.commands.UnsetPropertyCommandTest;
 import org.komodo.shell.commands.WorkspaceCommandTest;
+import org.komodo.shell.commands.WorkspaceStatusPropertyTest;
 
 /**
  * All Tests for CommandLine
@@ -65,7 +66,8 @@ import org.komodo.shell.commands.WorkspaceCommandTest;
                        ShowStatusCommandTest.class,
                        ShowSummaryCommandTest.class,
                        UnsetPropertyCommandTest.class,
-                       WorkspaceCommandTest.class } )
+                       WorkspaceCommandTest.class,
+                       WorkspaceStatusPropertyTest.class } )
 public class AllTests {
     // nothing to do
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ResetGlobalPropertyCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ResetGlobalPropertyCommandTest.java
@@ -45,14 +45,14 @@ public class ResetGlobalPropertyCommandTest extends AbstractCommandTest {
     public void shouldResetShowTypeInPrompt() throws Exception {
     	String propertyName=WorkspaceStatus.SHOW_TYPE_IN_PROMPT_KEY;
   
-    	wsStatus.setProperty(propertyName, negateBooleanValue(propertyName));
+    	wsStatus.setGlobalProperty(propertyName, negateBooleanValue(propertyName));
         final String[] commands = { "reset-global "+propertyName};
         final CommandResult result = execute( commands );
         assertCommandResultOk( result );
 
         // Check Context and property value
         assertEquals("/", wsStatus.getCurrentContextDisplayPath());
-        assertEquals(WorkspaceStatus.GLOBAL_PROPS.get(propertyName), wsStatus.getProperties().getProperty(propertyName));
+        assertEquals(WorkspaceStatus.GLOBAL_PROPS.get(propertyName), wsStatus.getGlobalProperties().getProperty(propertyName));
     }
 
     @Test
@@ -61,8 +61,8 @@ public class ResetGlobalPropertyCommandTest extends AbstractCommandTest {
     	String secondPropName=WorkspaceStatus.EXPORT_DEFAULT_DIR_KEY;
     	String secondPropNewVal="/tmp";
     	// Modify two global properties
-    	wsStatus.setProperty(firstPropName, negateBooleanValue(firstPropName));
-    	wsStatus.setProperty(secondPropName, secondPropNewVal);
+    	wsStatus.setGlobalProperty(firstPropName, negateBooleanValue(firstPropName));
+    	wsStatus.setGlobalProperty(secondPropName, secondPropNewVal);
     	// Issue command reset all
         final String[] commands = { "reset-global --all"};
         final CommandResult result = execute( commands );
@@ -70,8 +70,8 @@ public class ResetGlobalPropertyCommandTest extends AbstractCommandTest {
 
         // Check Context and properties value
         assertEquals("/", wsStatus.getCurrentContextDisplayPath());
-        assertEquals(WorkspaceStatus.GLOBAL_PROPS.get(firstPropName), wsStatus.getProperties().getProperty(firstPropName));
-        assertEquals(WorkspaceStatus.GLOBAL_PROPS.get(secondPropName), wsStatus.getProperties().getProperty(secondPropName));
+        assertEquals(WorkspaceStatus.GLOBAL_PROPS.get(firstPropName), wsStatus.getGlobalProperties().getProperty(firstPropName));
+        assertEquals(WorkspaceStatus.GLOBAL_PROPS.get(secondPropName), wsStatus.getGlobalProperties().getProperty(secondPropName));
     }
 
     private String negateBooleanValue(String name){

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetGlobalPropertyCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetGlobalPropertyCommandTest.java
@@ -47,7 +47,7 @@ public class SetGlobalPropertyCommandTest extends AbstractCommandTest {
 
         // Check Context and property value
         assertEquals("/", wsStatus.getCurrentContextDisplayPath());
-        assertEquals("true", wsStatus.getProperties().getProperty(WorkspaceStatus.SHOW_TYPE_IN_PROMPT_KEY));
+        assertEquals("true", wsStatus.getGlobalProperties().getProperty(WorkspaceStatus.SHOW_TYPE_IN_PROMPT_KEY));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class SetGlobalPropertyCommandTest extends AbstractCommandTest {
 
         // Check Context and property value
         assertEquals("/", wsStatus.getCurrentContextDisplayPath());
-        assertEquals("/aRecordingFile.txt", wsStatus.getProperties().getProperty(WorkspaceStatus.RECORDING_FILE_KEY));
+        assertEquals("/aRecordingFile.txt", wsStatus.getGlobalProperties().getProperty(WorkspaceStatus.RECORDING_FILE_KEY));
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/WorkspaceStatusPropertyTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/WorkspaceStatusPropertyTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.shell.commands;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.komodo.shell.AbstractCommandTest;
+import org.komodo.shell.api.WorkspaceStatus;
+
+/**
+ * Test Class to test setting WorkspaceStatus global and provider properties
+ */
+@SuppressWarnings( { "javadoc", "nls" } )
+public class WorkspaceStatusPropertyTest extends AbstractCommandTest {
+
+    @Test
+    public void shouldSetGlobalProperty() throws Exception {
+        // Test default
+        assertEquals( "true" , wsStatus.getGlobalProperties().getProperty(WorkspaceStatus.SHOW_TYPE_IN_PROMPT_KEY));
+        
+        // Set a property
+        wsStatus.setGlobalProperty(WorkspaceStatus.SHOW_TYPE_IN_PROMPT_KEY, "false");
+        
+        // Test property changed
+        assertEquals( "false" , wsStatus.getGlobalProperties().getProperty(WorkspaceStatus.SHOW_TYPE_IN_PROMPT_KEY));
+    }
+    
+    @Test
+    public void shouldSetProvidedProperty() throws Exception {
+        // Test no provided properties
+        assertEquals( 0 , wsStatus.getProvidedProperties().size() );
+        
+        // Set a property
+        wsStatus.setProvidedProperty("myPropKey", "aValue");
+        
+        // Test property was set
+        assertEquals( "aValue" , wsStatus.getProvidedProperties().getProperty("myPropKey") );
+    }
+    
+    @Test
+    public void shouldTestGlobalAfterAddingProvided() throws Exception {
+        // Number of global at startup
+        int startingGlobal = wsStatus.getGlobalProperties().size();
+        
+        // Test no provided properties
+        assertEquals( 0 , wsStatus.getProvidedProperties().size() );
+        
+        // Set provided properties
+        wsStatus.setProvidedProperty("myPropKey1", "aValue1");
+        wsStatus.setProvidedProperty("myPropKey2", "aValue2");
+        wsStatus.setProvidedProperty("myPropKey3", "aValue3");
+        
+        // Count global after adding provided properties
+        assertEquals( startingGlobal , wsStatus.getGlobalProperties().size() );
+        // Count provided after adding provided properties
+        assertEquals( 3 , wsStatus.getProvidedProperties().size() );
+        
+        // Ensure global does not contain provided properties
+        assertEquals( "aValue1", wsStatus.getProvidedProperties().getProperty("myPropKey1"));
+        assertEquals( "aValue2", wsStatus.getProvidedProperties().getProperty("myPropKey2"));
+        assertEquals( "aValue3", wsStatus.getProvidedProperties().getProperty("myPropKey3"));
+    }
+
+    @Test
+    public void shouldTestProvidedAfterSettingGlobal() throws Exception {
+        // Number of provided at startup
+        int startingProvided = wsStatus.getProvidedProperties().size();
+        // Number of global at startup
+        int startingGlobal = wsStatus.getGlobalProperties().size();
+        
+        // Set global properties
+        wsStatus.setGlobalProperty(WorkspaceStatus.SHOW_TYPE_IN_PROMPT_KEY, "false");
+        wsStatus.setGlobalProperty(WorkspaceStatus.AUTO_COMMIT, "false");
+        wsStatus.setGlobalProperty(WorkspaceStatus.EXPORT_DEFAULT_DIR_KEY, "exportDefaultDir");
+        
+        // Number of global doesnt change - they all have defaults
+        assertEquals( startingGlobal , wsStatus.getGlobalProperties().size() );
+        // Number of provided does not change
+        assertEquals( startingProvided , wsStatus.getProvidedProperties().size() );
+    }
+
+}


### PR DESCRIPTION
Changes to allow providers to supply properties. 
- renamed workspaceStatus.getProperties and similar methods to getGlobalProperties, to distinguish the defined global properties.
- added workspaceStatus.getProvidedProperties and similar methods to distinguish the 'provided properties'.
- the above allows the known global properties to be validated, etc.  But also allows the user to specify their own arbitrary properties.
-  ServerCommandProvider now uses the provided properties.
-  DeleteTeiidCommand cleans up server state if the default server is deleted.

