### PR TITLE
Fix for Issue #304 - Command Not Found message problem

### DIFF
--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommand.java
@@ -31,11 +31,6 @@ import org.komodo.utils.i18n.I18n;
 public interface ShellCommand {
 
     /**
-     *  The command not found name
-     */
-    String COMMAND_NOT_FOUND = "cmd-not-found";  //$NON-NLS-1$
-
-    /**
      * Commands without a category will be placed in a general category.
      *
      * @return the command category (can be empty)

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandFactory.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandFactory.java
@@ -29,6 +29,13 @@ public interface ShellCommandFactory {
     ShellCommand getCommand( final String commandName ) throws Exception;
 
     /**
+     * @param commandName
+     *        the name of the command not found (cannot be empty)
+     * @return the "command not found" command (never <code>null</code>)
+     */
+    ShellCommand createCommandNotFound( final String commandName );
+
+    /**
      * @return a sorted collection of the valid command names for the current context (never <code>null</code>)
      */
     Set< String > getCommandNamesForCurrentContext();

--- a/plugins/org.komodo.shell/src/org/komodo/shell/ShellCommandFactoryImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/ShellCommandFactoryImpl.java
@@ -219,6 +219,14 @@ public class ShellCommandFactoryImpl implements ShellCommandFactory {
         }
 
         // command can't be found
+        return createCommandNotFound(commandName);
+    }
+    
+    /* (non-Javadoc)
+     * @see org.komodo.shell.api.ShellCommandFactory#createCommandNotFound(java.lang.String)
+     */
+    @Override
+    public ShellCommand createCommandNotFound(String commandName) {
         _commandNotFound.command = commandName;
         return _commandNotFound;
     }

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
@@ -789,7 +789,7 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
         }
 
         // command can't be found
-        return this.getCommandFactory().getCommand(ShellCommand.COMMAND_NOT_FOUND);
+        return this.getCommandFactory().createCommandNotFound(commandName);
     }
 
     /* (non-Javadoc)

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/AllTests.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/AllTests.java
@@ -5,6 +5,7 @@ import org.junit.runners.Suite;
 import org.komodo.shell.commands.AddChildCommandTest;
 import org.komodo.shell.commands.AddDescriptorCommandTest;
 import org.komodo.shell.commands.CdCommandTest;
+import org.komodo.shell.commands.CommandNotFoundTest;
 import org.komodo.shell.commands.CommitCommandTest;
 import org.komodo.shell.commands.DeleteChildCommandTest;
 import org.komodo.shell.commands.ExitCommandTest;
@@ -40,6 +41,7 @@ import org.komodo.shell.commands.WorkspaceStatusPropertyTest;
 @Suite.SuiteClasses( { AddChildCommandTest.class,
                        AddDescriptorCommandTest.class,
                        CdCommandTest.class,
+                       CommandNotFoundTest.class,
                        CommitCommandTest.class,
                        DeleteChildCommandTest.class,
                        ExitCommandTest.class,

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CommandNotFoundTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CommandNotFoundTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.shell.commands;
+
+import org.junit.Test;
+import org.komodo.shell.AbstractCommandTest;
+
+/**
+ * Test Class to test entry of an invalid command.
+ */
+@SuppressWarnings({"javadoc", "nls"})
+public class CommandNotFoundTest extends AbstractCommandTest {
+
+    @Test( expected = AssertionError.class )
+    public void shouldFailInvalidCommand() throws Exception {
+        final String[] commands = { "workspace",
+                                    "crappy-command" };
+
+        execute( commands );
+    }
+
+}

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CommandNotFoundTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CommandNotFoundTest.java
@@ -15,8 +15,12 @@
  */
 package org.komodo.shell.commands;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.ShellCommand;
 
 /**
  * Test Class to test entry of an invalid command.
@@ -24,12 +28,15 @@ import org.komodo.shell.AbstractCommandTest;
 @SuppressWarnings({"javadoc", "nls"})
 public class CommandNotFoundTest extends AbstractCommandTest {
 
-    @Test( expected = AssertionError.class )
+    @Test
     public void shouldFailInvalidCommand() throws Exception {
-        final String[] commands = { "workspace",
-                                    "crappy-command" };
-
-        execute( commands );
+        ShellCommand command = wsStatus.getCommand("bad-command");
+        CommandResult result = command.execute();
+        
+        // CommandNotFound - make sure message contains bad command name
+        assertFalse(result.isOk());
+        assertTrue(result.getMessage().contains("bad-command"));
+        assertTrue(result.getMessage().contains("not found"));
     }
 
 }


### PR DESCRIPTION
- adds interface method and implementation 'createCommandNotFound' to ShellCommandFactory and ShellCommandFactoryImpl.
- utilize the new method in WorkspaceStatusImpl, so that the command not found name can be properly set.
- adds test case