### PR TITLE
Issue 259 - adds ServerCommand Tests

### DIFF
--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandsI18n.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandsI18n.java
@@ -106,6 +106,7 @@ public final class ServerCommandsI18n extends I18n {
     public static String serverVdbNotFound;
     public static String teiidStatus;
     public static String vdbExportFailed;
+    public static String vdbDeployFailedMissingSourceJndi;
     public static String vdbDeployFinished;
     public static String vdbDeploymentOverwriteDisabled;
     public static String workspaceVdbNotFound;

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandsI18n.properties
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandsI18n.properties
@@ -125,6 +125,7 @@ serverTranslatorNotFound = The server translator '%s' was not found.
 serverVdbNotFound = The server VDB '%s' was not found.
 teiidStatus = Teiid '%s' connection status: %s
 vdbExportFailed = Could not convert the vdb object to string for deployment.
+vdbDeployFailedMissingSourceJndi = The VDB cannot be deployed - server does not have source '%s' required by the VDB.
 vdbDeployFinished = The VDB deployed successfully.
 vdbDeploymentOverwriteDisabled = VDB with name '%s' and version '%s' cannot be deployed because it already exists on the server. Run "help server-deploy-vdb" for overwrite options.
 workspaceVdbNotFound = The workspace VDB '%s' was not found.

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AllTests.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/AllTests.java
@@ -81,7 +81,19 @@ import org.komodo.relational.commands.schema.SchemaCommandsI18nTest;
 import org.komodo.relational.commands.schema.SetSchemaPropertyCommandTest;
 import org.komodo.relational.commands.schema.UnsetSchemaPropertyCommandTest;
 import org.komodo.relational.commands.server.ServerCommandsI18nTest;
+import org.komodo.relational.commands.server.ServerConnectCommandTest;
+import org.komodo.relational.commands.server.ServerDatasourceCommandTest;
+import org.komodo.relational.commands.server.ServerDatasourceTypeCommandTest;
+import org.komodo.relational.commands.server.ServerDatasourceTypesCommandTest;
+import org.komodo.relational.commands.server.ServerDatasourcesCommandTest;
+import org.komodo.relational.commands.server.ServerDeployVdbCommandTest;
+import org.komodo.relational.commands.server.ServerDisconnectCommandTest;
 import org.komodo.relational.commands.server.ServerSetCommandTest;
+import org.komodo.relational.commands.server.ServerTranslatorCommandTest;
+import org.komodo.relational.commands.server.ServerTranslatorsCommandTest;
+import org.komodo.relational.commands.server.ServerUndeployVdbCommandTest;
+import org.komodo.relational.commands.server.ServerVdbCommandTest;
+import org.komodo.relational.commands.server.ServerVdbsCommandTest;
 import org.komodo.relational.commands.storedprocedure.SetStoredProcedurePropertyCommandTest;
 import org.komodo.relational.commands.storedprocedure.StoredProcedureCommandsI18nTest;
 import org.komodo.relational.commands.storedprocedure.UnsetStoredProcedurePropertyCommandTest;
@@ -303,7 +315,19 @@ import org.komodo.relational.commands.workspace.WorkspaceUnsetPropertyCommandTes
 
     // Server
     ServerCommandsI18nTest.class,
+    ServerConnectCommandTest.class,
+    ServerDatasourceCommandTest.class,
+    ServerDatasourcesCommandTest.class,
+    ServerDatasourceTypeCommandTest.class,
+    ServerDatasourceTypesCommandTest.class,
+    ServerDeployVdbCommandTest.class,
+    ServerDisconnectCommandTest.class,
     ServerSetCommandTest.class,
+    ServerTranslatorCommandTest.class,
+    ServerTranslatorsCommandTest.class,
+    ServerUndeployVdbCommandTest.class,
+    ServerVdbCommandTest.class,
+    ServerVdbsCommandTest.class,
 
     // StoredProcedure
     org.komodo.relational.commands.storedprocedure.AddParameterCommandTest.class,

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/AbstractServerCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/AbstractServerCommandTest.java
@@ -1,0 +1,123 @@
+package org.komodo.relational.commands.server;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Properties;
+import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.commands.AbstractCommandTest;
+import org.komodo.relational.teiid.Teiid;
+import org.komodo.spi.repository.Descriptor;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidInstance;
+import org.komodo.spi.runtime.TeiidPropertyDefinition;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+@SuppressWarnings( { "javadoc",
+                     "nls" } )
+public abstract class AbstractServerCommandTest extends AbstractCommandTest {
+
+    // Mock Server Artifacts
+    protected static final TeiidVdb VDB1 = mock(TeiidVdb.class);
+    protected static final TeiidVdb VDB2 = mock(TeiidVdb.class);
+    protected static final TeiidTranslator TRANSLATOR1 = mock(TeiidTranslator.class);
+    protected static final TeiidTranslator TRANSLATOR2 = mock(TeiidTranslator.class);
+    protected static final TeiidDataSource DS1 = mock(TeiidDataSource.class);
+    protected static final TeiidDataSource DS2 = mock(TeiidDataSource.class);
+    protected static final String DS_TYPE1 = "DS_TYPE1";
+    protected static final String DS_TYPE2 = "DS_TYPE2";
+    
+    // Mock server artifact returns
+    static {
+        // VDBs
+        when(VDB1.getName()).thenReturn("VDB1");
+        when(VDB2.getName()).thenReturn("VDB2");
+        when(VDB1.getVersion()).thenReturn(1);
+        when(VDB2.getVersion()).thenReturn(2);
+        when(VDB1.isXmlDeployment()).thenReturn(true);
+        when(VDB2.isXmlDeployment()).thenReturn(true);
+        when(VDB1.isActive()).thenReturn(true);
+        when(VDB2.isActive()).thenReturn(false);
+        when(VDB1.getModelNames()).thenReturn(Arrays.asList(new String[]{"Model1","Model2"}));
+        when(VDB2.getModelNames()).thenReturn(Arrays.asList(new String[]{"Model1","Model2"}));
+        when(VDB1.getProperties()).thenReturn(new Properties());
+        when(VDB2.getProperties()).thenReturn(new Properties());
+        
+        // Translators
+        when(TRANSLATOR1.getName()).thenReturn("TRANSLATOR1");
+        when(TRANSLATOR2.getName()).thenReturn("TRANSLATOR2");
+        when(TRANSLATOR1.getType()).thenReturn("oracle");
+        when(TRANSLATOR2.getType()).thenReturn("salesforce");
+        when(TRANSLATOR1.getProperties()).thenReturn(new Properties());
+        when(TRANSLATOR2.getProperties()).thenReturn(new Properties());
+        
+        // DataSources
+        when(DS1.getName()).thenReturn("DS1");
+        when(DS2.getName()).thenReturn("DS2");
+        when(DS1.getDisplayName()).thenReturn("DS1");
+        when(DS2.getDisplayName()).thenReturn("DS2");
+        when(DS1.getType()).thenReturn("oracle");
+        when(DS2.getType()).thenReturn("file");
+        when(DS1.getProperties()).thenReturn(new Properties());
+        when(DS2.getProperties()).thenReturn(new Properties());
+    }
+
+    /**
+     * Inits a mock server for the test
+     * @param teiidName the name for the server
+     * @param makeDefaultServer 'true' to set the server as the workspace default
+     * @param serverConnected 'true' if the server state is 'connected', 'false' if not connected. 
+     * @param vdbs the server VDBs
+     * @param dataSources the server Datasources
+     * @param translators the server Translators
+     * @param dataSourceTypes the server Datasource Types
+     * @throws Exception
+     */
+    protected void initServer(String teiidName, boolean makeDefaultServer, boolean serverConnected, 
+                              TeiidVdb[] vdbs, TeiidDataSource[] dataSources, 
+                              TeiidTranslator[] translators, String[] dataSourceTypes) throws Exception {
+        // Set up the Teiid mock instance
+        Teiid teiid = mock(Teiid.class);
+        when(teiid.getName(getTransaction())).thenReturn(teiidName);
+        when(teiid.getRepository()).thenReturn(_repo);
+        Descriptor descriptor = mock(Descriptor.class);
+        when(descriptor.getName()).thenReturn(KomodoLexicon.Teiid.NODE_TYPE);
+        when(teiid.getPrimaryType(getTransaction())).thenReturn(descriptor);
+        when(teiid.hasDescriptor(getTransaction(), KomodoLexicon.Teiid.NODE_TYPE)).thenReturn(true);
+        if(makeDefaultServer) {
+            wsStatus.setStateObject(ServerCommandProvider.SERVER_DEFAULT_KEY, teiid);
+        }
+        _repo.add(getTransaction(), null, teiidName, KomodoLexicon.Teiid.NODE_TYPE);
+        
+        // The TeiidInstance
+        TeiidInstance teiidInstance = mock(TeiidInstance.class);
+        when(teiid.getTeiidInstance(getTransaction())).thenReturn(teiidInstance);
+        when(teiidInstance.isConnected()).thenReturn(serverConnected);
+        when(teiidInstance.hasVdb("myVdb")).thenReturn(false);
+        
+        // TeiidPropertyDefinitions
+        TeiidPropertyDefinition propDefn1 = mock(TeiidPropertyDefinition.class);
+        when(propDefn1.getDisplayName()).thenReturn("Prop1");
+        when(propDefn1.getDefaultValue()).thenReturn("Value1");
+        TeiidPropertyDefinition propDefn2 = mock(TeiidPropertyDefinition.class);
+        when(propDefn2.getDisplayName()).thenReturn("Prop2");
+        when(propDefn2.getDefaultValue()).thenReturn("Value2");
+        when(teiidInstance.getTemplatePropertyDefns(DS_TYPE1)).thenReturn(Arrays.asList(new TeiidPropertyDefinition[]{propDefn1,propDefn2}));
+        when(teiidInstance.getTemplatePropertyDefns(DS_TYPE2)).thenReturn(Arrays.asList(new TeiidPropertyDefinition[]{propDefn1,propDefn2}));
+             
+        // The returned objects
+        if(vdbs!=null) when(teiidInstance.getVdbs()).thenReturn(Arrays.asList(vdbs));
+        if(vdbs!=null) when(teiidInstance.getVdb(VDB1.getName())).thenReturn(VDB1);
+        if(vdbs!=null) when(teiidInstance.getVdb(VDB2.getName())).thenReturn(VDB2);
+        if(dataSources!=null) when(teiidInstance.getDataSources()).thenReturn(Arrays.asList(dataSources));
+        if(dataSources!=null) when(teiidInstance.getDataSource(DS1.getName())).thenReturn(DS1);
+        if(dataSources!=null) when(teiidInstance.getDataSource(DS2.getName())).thenReturn(DS2);
+        if(dataSourceTypes!=null) when(teiidInstance.getDataSourceTypeNames()).thenReturn(new HashSet(Arrays.asList(dataSourceTypes)));
+        if(translators!=null) when(teiidInstance.getTranslators()).thenReturn(Arrays.asList(translators));
+        if(translators!=null) when(teiidInstance.getTranslator(TRANSLATOR1.getName())).thenReturn(TRANSLATOR1);
+        if(translators!=null) when(teiidInstance.getTranslator(TRANSLATOR2.getName())).thenReturn(TRANSLATOR2);
+    }
+    
+}

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/AbstractServerCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/AbstractServerCommandTest.java
@@ -96,6 +96,8 @@ public abstract class AbstractServerCommandTest extends AbstractCommandTest {
         when(teiid.getTeiidInstance(getTransaction())).thenReturn(teiidInstance);
         when(teiidInstance.isConnected()).thenReturn(serverConnected);
         when(teiidInstance.hasVdb("myVdb")).thenReturn(false);
+        when(teiidInstance.hasVdb("VDB1")).thenReturn(true);
+        when(teiidInstance.hasVdb("VDB2")).thenReturn(true);
         
         // TeiidPropertyDefinitions
         TeiidPropertyDefinition propDefn1 = mock(TeiidPropertyDefinition.class);
@@ -118,6 +120,9 @@ public abstract class AbstractServerCommandTest extends AbstractCommandTest {
         if(translators!=null) when(teiidInstance.getTranslators()).thenReturn(Arrays.asList(translators));
         if(translators!=null) when(teiidInstance.getTranslator(TRANSLATOR1.getName())).thenReturn(TRANSLATOR1);
         if(translators!=null) when(teiidInstance.getTranslator(TRANSLATOR2.getName())).thenReturn(TRANSLATOR2);
+        
+        // Initing the server may change the commands that are available
+        wsStatus.updateAvailableCommands();
     }
     
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerConnectCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerConnectCommandTest.java
@@ -15,11 +15,12 @@
  */
 package org.komodo.relational.commands.server;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.ShellCommand;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
 
 /**
  * Test Class to test {@link ServerConnectCommand}.
@@ -33,7 +34,7 @@ public final class ServerConnectCommandTest extends AbstractServerCommandTest {
     }
     
     @Test
-    public void shouldFailNoLocalhostFound() throws Exception {
+    public void shouldConnect() throws Exception {
         final String[] commands = {
             "set-auto-commit false",
             "create-teiid myTeiid",
@@ -42,10 +43,14 @@ public final class ServerConnectCommandTest extends AbstractServerCommandTest {
         CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         ShellCommand command = wsStatus.getCommand("server-connect");
         result = command.execute();
-        String output = result.getMessage();
-        assertThat( output, output.contains( "localhost is not available" ), is( true ) );
+        assertCommandResultOk(result);
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceCommandTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.relational.commands.server;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * Test Class to test {@link ServerDatasourceCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ServerDatasourceCommandTest extends AbstractServerCommandTest {
+
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        this.assertCommandsNotAvailable(ServerDatasourceCommand.NAME);
+    }
+
+    @Test
+    public void shouldGetServerDatasource() throws Exception {
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        final String[] commands = { 
+            "home",  // Need this to force update of cached commands
+            "server-datasource DS1"};
+        final CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        final String output = getCommandOutput();
+        assertThat( output, output.contains( "myTeiid" ), is( true ) );
+        assertThat( output, output.contains( DS1.getName() ), is( true ) );
+        assertThat( output, output.contains( DS1.getType() ), is( true ) );
+    }
+
+}

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceCommandTest.java
@@ -30,7 +30,17 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerDatasourceCommandTest extends AbstractServerCommandTest {
 
     @Test
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerDatasourceCommand.NAME);
+    }
+
+    @Test
     public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerDatasourceCommand.NAME);
     }
 
@@ -41,9 +51,7 @@ public final class ServerDatasourceCommandTest extends AbstractServerCommandTest
                    new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
-        final String[] commands = { 
-            "home",  // Need this to force update of cached commands
-            "server-datasource DS1"};
+        final String[] commands = { "server-datasource DS1" };
         final CommandResult result = execute( commands );
         
         assertCommandResultOk(result);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceTypeCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceTypeCommandTest.java
@@ -30,7 +30,17 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerDatasourceTypeCommandTest extends AbstractServerCommandTest {
 
     @Test
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerDatasourceTypeCommand.NAME);
+    }
+
+    @Test
     public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerDatasourceTypeCommand.NAME);
     }
 
@@ -41,9 +51,7 @@ public final class ServerDatasourceTypeCommandTest extends AbstractServerCommand
                    new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
-        final String[] commands = { 
-            "home",  // Need this to force update of cached commands
-            "server-datasource-type DS_TYPE1"};
+        final String[] commands = { "server-datasource-type DS_TYPE1" };
         final CommandResult result = execute( commands );
         
         assertCommandResultOk(result);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceTypeCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceTypeCommandTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.relational.commands.server;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * Test Class to test {@link ServerDatasourceTypeCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ServerDatasourceTypeCommandTest extends AbstractServerCommandTest {
+
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        this.assertCommandsNotAvailable(ServerDatasourceTypeCommand.NAME);
+    }
+
+    @Test
+    public void shouldGetServerDatasourceType() throws Exception {
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        final String[] commands = { 
+            "home",  // Need this to force update of cached commands
+            "server-datasource-type DS_TYPE1"};
+        final CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        final String output = getCommandOutput();
+        assertThat( output, output.contains( "myTeiid" ), is( true ) );
+        assertThat( output, output.contains( DS_TYPE1 ), is( true ) );
+        assertThat( output, output.contains( "Prop1" ), is( true ) );
+        assertThat( output, output.contains( "Prop2" ), is( true ) );
+    }
+
+}

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceTypesCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceTypesCommandTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.relational.commands.server;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * Test Class to test {@link ServerDatasourceTypesCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ServerDatasourceTypesCommandTest extends AbstractServerCommandTest {
+
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        this.assertCommandsNotAvailable(ServerDatasourceTypesCommand.NAME);
+    }
+
+    @Test
+    public void shouldGetServerDatasourceTypes() throws Exception {
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        final String[] commands = { 
+            "home",  // Need this to force update of cached commands
+            "server-datasource-types"};
+        final CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        final String output = getCommandOutput();
+        assertThat( output, output.contains( "myTeiid" ), is( true ) );
+        assertThat( output, output.contains( DS_TYPE1 ), is( true ) );
+    }
+
+}

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceTypesCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourceTypesCommandTest.java
@@ -30,7 +30,17 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerDatasourceTypesCommandTest extends AbstractServerCommandTest {
 
     @Test
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerDatasourceTypesCommand.NAME);
+    }
+
+    @Test
     public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerDatasourceTypesCommand.NAME);
     }
 
@@ -41,9 +51,7 @@ public final class ServerDatasourceTypesCommandTest extends AbstractServerComman
                    new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
-        final String[] commands = { 
-            "home",  // Need this to force update of cached commands
-            "server-datasource-types"};
+        final String[] commands = { "server-datasource-types" };
         final CommandResult result = execute( commands );
         
         assertCommandResultOk(result);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourcesCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourcesCommandTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.relational.commands.server;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * Test Class to test {@link ServerDatasourcesCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ServerDatasourcesCommandTest extends AbstractServerCommandTest {
+
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        this.assertCommandsNotAvailable(ServerDatasourcesCommand.NAME);
+    }
+
+    @Test
+    public void shouldGetServerDatasources() throws Exception {
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        final String[] commands = { 
+            "home",  // Need this to force update of cached commands
+            "server-datasources"};
+        final CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        final String output = getCommandOutput();
+        assertThat( output, output.contains( "myTeiid" ), is( true ) );
+        assertThat( output, output.contains( DS1.getName() ), is( true ) );
+    }
+
+}

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourcesCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDatasourcesCommandTest.java
@@ -30,7 +30,17 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerDatasourcesCommandTest extends AbstractServerCommandTest {
 
     @Test
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerDatasourcesCommand.NAME);
+    }
+
+    @Test
     public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerDatasourcesCommand.NAME);
     }
 
@@ -41,9 +51,7 @@ public final class ServerDatasourcesCommandTest extends AbstractServerCommandTes
                    new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
-        final String[] commands = { 
-            "home",  // Need this to force update of cached commands
-            "server-datasources"};
+        final String[] commands = { "server-datasources" };
         final CommandResult result = execute( commands );
         
         assertCommandResultOk(result);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDeployVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDeployVdbCommandTest.java
@@ -18,7 +18,9 @@ package org.komodo.relational.commands.server;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import org.junit.Test;
+import org.komodo.shell.api.Arguments;
 import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.ShellCommand;
 import org.komodo.spi.runtime.TeiidDataSource;
 import org.komodo.spi.runtime.TeiidTranslator;
 import org.komodo.spi.runtime.TeiidVdb;
@@ -30,10 +32,76 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerDeployVdbCommandTest extends AbstractServerCommandTest {
 
     @Test
-    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
         this.assertCommandsNotAvailable(ServerDeployVdbCommand.NAME);
     }
 
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        this.assertCommandsNotAvailable(ServerDeployVdbCommand.NAME);
+    }
+
+    @Test
+    public void shouldNotDeployMissingWorkspaceVDB() throws Exception {
+        final String[] commands = {
+            "set-auto-commit false",
+            "create-teiid myTeiid",
+            "create-vdb VDB1",
+            "commit",
+            "set-server myTeiid"};
+        CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        
+        // Attempt to deploy the VDB - fails because workspace VDB does not exist (only VDB1 exists)
+        ShellCommand command = wsStatus.getCommand("server-deploy-vdb");
+        command.setArguments(new Arguments("myVdb"));
+        result = command.execute();
+        assertThat(result.isOk(), is( false ) );
+        String output = result.getMessage();
+        assertThat( output, output.contains( "myVdb" ), is( true ) );
+        assertThat( output, output.contains( "not found" ), is( true ) );
+    }
+
+    @Test
+    public void shouldNotDeployVDBExistsOnServer() throws Exception {
+        final String[] commands = {
+            "set-auto-commit false",
+            "create-teiid myTeiid",
+            "create-vdb VDB1",
+            "commit",
+            "set-server myTeiid"};
+        CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        
+        // Attempt to deploy workspace VDB1 - this fails because same VDB is on the server (and no overwrite arg).
+        ShellCommand command = wsStatus.getCommand("server-deploy-vdb");
+        command.setArguments(new Arguments("VDB1"));
+        result = command.execute();
+        assertThat(result.isOk(), is( false ) );
+        String output = result.getMessage();
+        assertThat( output, output.contains( "VDB1" ), is( true ) );
+        assertThat( output, output.contains( "already exists" ), is( true ) );
+    }
+    
     @Test
     public void shouldDeployVdb() throws Exception {
         final String[] commands = {
@@ -52,10 +120,74 @@ public final class ServerDeployVdbCommandTest extends AbstractServerCommandTest 
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
         
-        result = execute(new String[]{"workspace", "server-deploy-vdb myVdb"});
+        // Deploys myVdb from workspace - there is no conflicting vdb on the server.
+        result = execute(new String[]{"server-deploy-vdb myVdb"});
         
+        assertCommandResultOk( result );
         final String output = getCommandOutput();
         assertThat( output, output.contains( "deployed successfully" ), is( true ) );
+    }
+    
+    @Test
+    public void shouldDeployExistingVDBWithOverwrite() throws Exception {
+        final String[] commands = {
+            "set-auto-commit false",
+            "create-teiid myTeiid",
+            "create-vdb VDB1",
+            "commit",
+            "set-server myTeiid"};
+        CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        
+        // Deploy VDB1 from workspace - there is a conflicting server VDB, but overwrite arg is supplied.
+        ShellCommand command = wsStatus.getCommand("server-deploy-vdb");
+        command.setArguments(new Arguments("VDB1 -o"));
+        result = command.execute();
+        
+        assertCommandResultOk( result );
+    }
+
+    @Test
+    public void shouldNotDeployVDBServerMissingSources() throws Exception {
+        final String[] commands = {
+            "set-auto-commit false",
+            "create-teiid myTeiid",
+            "create-vdb VDB1",
+            "cd VDB1",
+            "add-model myModel",
+            "cd myModel",
+            "add-source modelSource",
+            "cd modelSource",
+            "set-property sourceJndiName java:/modelSource",
+            "commit",
+            "set-server myTeiid",
+            "workspace" };
+        CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        
+        // Try to deploy the VDB - fails because workspace VDB does not exist.
+        ShellCommand command = wsStatus.getCommand("server-deploy-vdb");
+        command.setArguments(new Arguments("VDB1 -o"));
+        result = command.execute();
+        
+        assertThat(result.isOk(), is( false ) );
+        String output = result.getMessage();
+        assertThat( output, output.contains( "server does not have source" ), is( true ) );
+        assertThat( output, output.contains( "java:/modelSource" ), is( true ) );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDisconnectCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDisconnectCommandTest.java
@@ -15,30 +15,68 @@
  */
 package org.komodo.relational.commands.server;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import org.junit.Test;
-import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.ShellCommand;
 
 /**
  * Test Class to test {@link ServerDisconnectCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public final class ServerDisconnectCommandTest extends AbstractCommandTest {
+public final class ServerDisconnectCommandTest extends AbstractServerCommandTest {
 
+    @Test
+    public void shouldNotBeAvailableForServerNotDefined() throws Exception {
+        this.assertCommandsNotAvailable(ServerDisconnectCommand.NAME);
+    }
+    
     @Test
     public void shouldFailNoServerConnected() throws Exception {
         final String[] commands = {
             "set-auto-commit false",
             "create-teiid myTeiid",
             "commit",
-            "set-server myTeiid",
-            "server-disconnect" };
-        final CommandResult result = execute( commands );
+            "set-server myTeiid"};
+        CommandResult result = execute( commands );
         assertCommandResultOk(result);
 
-        String msg = result.getMessage();
-        assertEquals("something", msg);
+        // Initialize a mock server (not connected) with no artifacts
+        initServer("myTeiid", true, false, null, null, null, null);
+        
+        // Results in 'command not found' - not enabled if server is not connected
+        ShellCommand command = wsStatus.getCommand("server-disconnect");
+        result = command.execute();
+        String output = result.getMessage();
+        assertThat( output, output.contains( ServerDisconnectCommand.NAME ), is( true ) );
+        assertThat( output, output.contains( "not found" ), is( true ) );
     }
+    
+    @Test
+    public void shouldDisconnectServer() throws Exception {
+        final String[] commands = {
+            "set-auto-commit false",
+            "create-teiid myTeiid",
+            "commit",
+            "set-server myTeiid"};
+        CommandResult result = execute( commands );
+        assertCommandResultOk(result);
 
+        // Initialize a mock server (connected) with no artifacts
+        initServer("myTeiid", true, true, null, null, null, null);
+        
+        // Workspace command to force command cache refresh
+        ShellCommand command = wsStatus.getCommand("workspace");
+        result = command.execute();
+        assertCommandResultOk(result);
+
+        // Disconnect the connected server
+        command = wsStatus.getCommand("server-disconnect");
+        result = command.execute();
+        assertCommandResultOk(result);
+        String output = result.getMessage();
+        assertThat( output, output.contains( "myTeiid" ), is( true ) );
+        assertThat( output, output.contains( "disconnected" ), is( true ) );
+    }
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDisconnectCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerDisconnectCommandTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.ShellCommand;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
 
 /**
  * Test Class to test {@link ServerDisconnectCommand}.
@@ -28,7 +31,17 @@ import org.komodo.shell.api.ShellCommand;
 public final class ServerDisconnectCommandTest extends AbstractServerCommandTest {
 
     @Test
-    public void shouldNotBeAvailableForServerNotDefined() throws Exception {
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerDisconnectCommand.NAME);
+    }
+    
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerDisconnectCommand.NAME);
     }
     
@@ -66,13 +79,8 @@ public final class ServerDisconnectCommandTest extends AbstractServerCommandTest
         // Initialize a mock server (connected) with no artifacts
         initServer("myTeiid", true, true, null, null, null, null);
         
-        // Workspace command to force command cache refresh
-        ShellCommand command = wsStatus.getCommand("workspace");
-        result = command.execute();
-        assertCommandResultOk(result);
-
         // Disconnect the connected server
-        command = wsStatus.getCommand("server-disconnect");
+        ShellCommand command = wsStatus.getCommand("server-disconnect");
         result = command.execute();
         assertCommandResultOk(result);
         String output = result.getMessage();

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerSetCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerSetCommandTest.java
@@ -18,7 +18,6 @@ package org.komodo.relational.commands.server;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
-import org.komodo.relational.commands.AbstractCommandTest;
 import org.komodo.relational.teiid.Teiid;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.shell.api.CommandResult;
@@ -28,7 +27,7 @@ import org.komodo.spi.repository.KomodoObject;
  * Test Class to test {@link ServerSetCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public final class ServerSetCommandTest extends AbstractCommandTest {
+public final class ServerSetCommandTest extends AbstractServerCommandTest {
 
     @Test
     public void testSet() throws Exception {

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerTranslatorCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerTranslatorCommandTest.java
@@ -30,7 +30,17 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerTranslatorCommandTest extends AbstractServerCommandTest {
 
     @Test
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerTranslatorCommand.NAME);
+    }
+
+    @Test
     public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerTranslatorCommand.NAME);
     }
 
@@ -41,9 +51,7 @@ public final class ServerTranslatorCommandTest extends AbstractServerCommandTest
                    new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
-        final String[] commands = { 
-            "home",  // Need this to force update of cached commands
-            "server-translator TRANSLATOR1"};
+        final String[] commands = { "server-translator TRANSLATOR1" };
         final CommandResult result = execute( commands );
         
         assertCommandResultOk(result);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerTranslatorCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerTranslatorCommandTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.relational.commands.server;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * Test Class to test {@link ServerTranslatorCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ServerTranslatorCommandTest extends AbstractServerCommandTest {
+
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        this.assertCommandsNotAvailable(ServerTranslatorCommand.NAME);
+    }
+
+    @Test
+    public void shouldGetServerTranslator() throws Exception {
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        final String[] commands = { 
+            "home",  // Need this to force update of cached commands
+            "server-translator TRANSLATOR1"};
+        final CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        final String output = getCommandOutput();
+        assertThat( output, output.contains( "myTeiid" ), is( true ) );
+        assertThat( output, output.contains( TRANSLATOR1.getName() ), is( true ) );
+        assertThat( output, output.contains( TRANSLATOR1.getType() ), is( true ) );
+    }
+
+}

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerTranslatorsCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerTranslatorsCommandTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.relational.commands.server;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * Test Class to test {@link ServerTranslatorsCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ServerTranslatorsCommandTest extends AbstractServerCommandTest {
+
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        this.assertCommandsNotAvailable(ServerTranslatorsCommand.NAME);
+    }
+
+    @Test
+    public void shouldGetServerTranslators() throws Exception {
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        final String[] commands = { 
+            "home",  // Need this to force update of cached commands
+            "server-translators"};
+        final CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        final String output = getCommandOutput();
+        assertThat( output, output.contains( "myTeiid" ), is( true ) );
+        assertThat( output, output.contains( TRANSLATOR1.getName() ), is( true ) );
+    }
+
+}

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerTranslatorsCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerTranslatorsCommandTest.java
@@ -30,7 +30,17 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerTranslatorsCommandTest extends AbstractServerCommandTest {
 
     @Test
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerTranslatorsCommand.NAME);
+    }
+
+    @Test
     public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerTranslatorsCommand.NAME);
     }
 
@@ -41,9 +51,7 @@ public final class ServerTranslatorsCommandTest extends AbstractServerCommandTes
                    new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
-        final String[] commands = { 
-            "home",  // Need this to force update of cached commands
-            "server-translators"};
+        final String[] commands = { "server-translators" };
         final CommandResult result = execute( commands );
         
         assertCommandResultOk(result);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerUndeployVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerUndeployVdbCommandTest.java
@@ -30,7 +30,17 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerUndeployVdbCommandTest extends AbstractServerCommandTest {
 
     @Test
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerUndeployVdbCommand.NAME);
+    }
+
+    @Test
     public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerUndeployVdbCommand.NAME);
     }
 
@@ -52,7 +62,7 @@ public final class ServerUndeployVdbCommandTest extends AbstractServerCommandTes
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
         
-        result = execute(new String[]{"workspace", "server-undeploy-vdb VDB1"});
+        result = execute(new String[]{"server-undeploy-vdb VDB1"});
         
         final String output = getCommandOutput();
         assertThat( output, output.contains( "undeployed successfully" ), is( true ) );

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerUndeployVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerUndeployVdbCommandTest.java
@@ -19,33 +19,43 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.komodo.shell.api.CommandResult;
-import org.komodo.shell.api.ShellCommand;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
 
 /**
- * Test Class to test {@link ServerConnectCommand}.
+ * Test Class to test {@link ServerUndeployVdbCommand}.
  */
 @SuppressWarnings( {"javadoc", "nls"} )
-public final class ServerConnectCommandTest extends AbstractServerCommandTest {
+public final class ServerUndeployVdbCommandTest extends AbstractServerCommandTest {
 
     @Test
-    public void shouldNotBeAvailableForServerNotDefined() throws Exception {
-        this.assertCommandsNotAvailable(ServerConnectCommand.NAME);
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        this.assertCommandsNotAvailable(ServerUndeployVdbCommand.NAME);
     }
-    
+
     @Test
-    public void shouldFailNoLocalhostFound() throws Exception {
+    public void shouldUndeployVdb() throws Exception {
         final String[] commands = {
             "set-auto-commit false",
             "create-teiid myTeiid",
+            "create-vdb myVdb",
             "commit",
-            "set-server myTeiid" };
+            "set-server myTeiid"};
         CommandResult result = execute( commands );
+        
         assertCommandResultOk(result);
-
-        ShellCommand command = wsStatus.getCommand("server-connect");
-        result = command.execute();
-        String output = result.getMessage();
-        assertThat( output, output.contains( "localhost is not available" ), is( true ) );
+        
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        
+        result = execute(new String[]{"workspace", "server-undeploy-vdb VDB1"});
+        
+        final String output = getCommandOutput();
+        assertThat( output, output.contains( "undeployed successfully" ), is( true ) );
     }
 
 }

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerVdbCommandTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.relational.commands.server;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * Test Class to test {@link ServerVdbCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ServerVdbCommandTest extends AbstractServerCommandTest {
+
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        this.assertCommandsNotAvailable(ServerVdbCommand.NAME);
+    }
+
+    @Test
+    public void shouldGetServerVdb() throws Exception {
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        final String[] commands = { 
+            "home",  // Need this to force update of cached commands
+            "server-vdb VDB1"};
+        final CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        final String output = getCommandOutput();
+        assertThat( output, output.contains( "myTeiid" ), is( true ) );
+        assertThat( output, output.contains( VDB1.getName() ), is( true ) );
+        String isActiveStr = VDB1.isActive() ? "ACTIVE" : "INACTIVE";
+        assertThat( output, output.contains( isActiveStr ), is( true ) );
+        String dynamicStr = VDB1.isXmlDeployment() ? "Dynamic" : "Archive";
+        assertThat( output, output.contains( dynamicStr ), is( true ) );
+        assertThat( output, output.contains( VDB1.getModelNames().toArray()[0].toString() ), is( true ) );
+    }
+
+}

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerVdbCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerVdbCommandTest.java
@@ -30,7 +30,17 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerVdbCommandTest extends AbstractServerCommandTest {
 
     @Test
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerVdbCommand.NAME);
+    }
+
+    @Test
     public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerVdbCommand.NAME);
     }
 
@@ -41,9 +51,7 @@ public final class ServerVdbCommandTest extends AbstractServerCommandTest {
                    new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
-        final String[] commands = { 
-            "home",  // Need this to force update of cached commands
-            "server-vdb VDB1"};
+        final String[] commands = { "server-vdb VDB1" };
         final CommandResult result = execute( commands );
         
         assertCommandResultOk(result);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerVdbsCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerVdbsCommandTest.java
@@ -30,7 +30,17 @@ import org.komodo.spi.runtime.TeiidVdb;
 public final class ServerVdbsCommandTest extends AbstractServerCommandTest {
 
     @Test
+    public void shouldNotBeAvailableForServerNotSet() throws Exception {
+        this.assertCommandsNotAvailable(ServerVdbsCommand.NAME);
+    }
+
+    @Test
     public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        // Initialize a disconnected server
+        initServer("myTeiid", true, false, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
         this.assertCommandsNotAvailable(ServerVdbsCommand.NAME);
     }
 
@@ -41,9 +51,7 @@ public final class ServerVdbsCommandTest extends AbstractServerCommandTest {
                    new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
                    new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
         
-        final String[] commands = { 
-            "home",  // Need this to force update of cached commands
-            "server-vdbs"};
+        final String[] commands = { "server-vdbs" };
         final CommandResult result = execute( commands );
         
         assertCommandResultOk(result);

--- a/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerVdbsCommandTest.java
+++ b/tests/org.komodo.relational.commands.test/src/org/komodo/relational/commands/server/ServerVdbsCommandTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.komodo.relational.commands.server;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.komodo.shell.api.CommandResult;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * Test Class to test {@link ServerVdbsCommand}.
+ */
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class ServerVdbsCommandTest extends AbstractServerCommandTest {
+
+    @Test
+    public void shouldNotBeAvailableForServerNotConnected() throws Exception {
+        this.assertCommandsNotAvailable(ServerVdbsCommand.NAME);
+    }
+
+    @Test
+    public void shouldGetServerVdbs() throws Exception {
+        // Initialize mock server with artifacts
+        initServer("myTeiid", true, true, 
+                   new TeiidVdb[]{VDB1}, new TeiidDataSource[]{DS1}, 
+                   new TeiidTranslator[]{TRANSLATOR1}, new String[]{DS_TYPE1});
+        
+        final String[] commands = { 
+            "home",  // Need this to force update of cached commands
+            "server-vdbs"};
+        final CommandResult result = execute( commands );
+        
+        assertCommandResultOk(result);
+        
+        final String output = getCommandOutput();
+        assertThat( output, output.contains( "myTeiid" ), is( true ) );
+        assertThat( output, output.contains( VDB1.getName() ), is( true ) );
+    }
+
+}


### PR DESCRIPTION
- adds AbstractServerCommandTest which includes a mock server
- adds unit tests for the remaining Server Command Tests
- Improved the ServerDeployVdbCommand.  If the VDB being deployed contains physical sources, the VDB checks the server to make sure the sources are present.  If not, the deployment will fail with message that the source does not exist.