### PR TITLE
Issue 278 cli - improve object properties display

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/PropertyDescriptorImpl.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/PropertyDescriptorImpl.java
@@ -209,4 +209,14 @@ public class PropertyDescriptorImpl implements PropertyDescriptor {
         return this.multiple;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getName();
+    }
+
 }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerObjPrintUtils.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerObjPrintUtils.java
@@ -184,7 +184,7 @@ public class ServerObjPrintUtils implements StringConstants {
                 PrintUtils.print( writer, MESSAGE_INDENT, String.format( format, propName, propValue ) );
                 // propValue exceeds maximum width - splits it up onto separate lines
             } else {
-                PrintUtils.printPropWithLongValue(writer,format,propName,propValue,maxValueWidth);
+                PrintUtils.printPropWithLongValue(writer,format,propName,propValue,null,maxValueWidth);
             }
         }
     }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/OptionContainerUtils.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/OptionContainerUtils.java
@@ -117,6 +117,16 @@ public final class OptionContainerUtils {
             return false;
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @see java.lang.Object#toString()
+         */
+        @Override
+        public String toString() {
+            return getName();
+        }
+
     }
 
     private static class PrimaryTypeDescriptor extends DescriptorImpl {

--- a/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StatementOptionImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/model/internal/StatementOptionImpl.java
@@ -135,7 +135,7 @@ public final class StatementOptionImpl extends RelationalChildRestrictedObject i
     public PropertyDescriptor getDescriptor( final UnitOfWork transaction ) throws KException {
         if ( this.descriptor == null ) {
             // find descriptor in the primary type
-            final Descriptor primaryType = getPrimaryType( transaction );
+            final Descriptor primaryType = getParent( transaction ).getPrimaryType( transaction );
             final String name = getName( transaction );
 
             for ( final PropertyDescriptor descriptor : primaryType.getPropertyDescriptors( transaction ) ) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/util/PrintUtils.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/util/PrintUtils.java
@@ -38,6 +38,7 @@ public class PrintUtils implements StringConstants {
 
     private static final int DEFAULT_WIDTH = 25;
     private static final int MAX_PROPERTY_VALUE_WIDTH = 100;  // Limit on the value column width
+    private static final int MAX_DEFAULT_VALUE_WIDTH = ( MAX_PROPERTY_VALUE_WIDTH / 3 );
 
     /**
      * Print the message to the writer.  A newLine is added after the message.
@@ -180,7 +181,9 @@ public class PrintUtils implements StringConstants {
         final String format = getFormat( maxNameWidth, maxValueWidth );
 
         print( writer, MESSAGE_INDENT, String.format( format, nameTitle, valueTitle ) );
-        print( writer, MESSAGE_INDENT, String.format( format, getHeaderDelimiter( maxNameWidth ), getHeaderDelimiter( maxValueWidth ) ) );
+        print( writer,
+               MESSAGE_INDENT,
+               String.format( format, getHeaderDelimiter( maxNameWidth ), getHeaderDelimiter( maxValueWidth ) ) );
 
         // print property name and value
         for ( final Entry< String, String > entry : sorted.entrySet() ) {
@@ -191,7 +194,7 @@ public class PrintUtils implements StringConstants {
                 print( writer, MESSAGE_INDENT, String.format( format, propName, propValue ) );
                 // propValue exceeds maximum width - splits it up onto separate lines
             } else {
-                printPropWithLongValue(writer,format,propName,propValue,maxValueWidth);
+                printPropWithLongValue(writer,format,propName,propValue,null,maxValueWidth);
             }
         }
     }
@@ -270,9 +273,10 @@ public class PrintUtils implements StringConstants {
         final String propListHeader = I18n.bind( ShellI18n.propertiesHeader, objType, path );
         print( writer, MESSAGE_INDENT, propListHeader );
 
+        final int maxDefaultValueWidth = Math.min( maxValueWidth, MAX_DEFAULT_VALUE_WIDTH );
         final String format = getFormat( new int[] { maxNameWidth,
                                                      maxValueWidth,
-                                                     maxValueWidth } );
+                                                     maxDefaultValueWidth } );
 
         print( writer,
                MESSAGE_INDENT,
@@ -285,7 +289,7 @@ public class PrintUtils implements StringConstants {
                String.format( format,
                               PrintUtils.getHeaderDelimiter( maxNameWidth ),
                               PrintUtils.getHeaderDelimiter( maxValueWidth ),
-                              PrintUtils.getHeaderDelimiter( maxValueWidth ) ) );
+                              PrintUtils.getHeaderDelimiter( maxDefaultValueWidth ) ) );
 
         // print property name, value, and default value
         for ( final Entry< String, String[] > entry : sorted.entrySet() ) {
@@ -297,7 +301,7 @@ public class PrintUtils implements StringConstants {
                 print( writer, MESSAGE_INDENT, String.format( format, propName, propValue, defaultValue ) );
             // propValue exceeds maximum width - splits it up onto separate lines
             } else {
-                printPropWithLongValue(writer,format,propName,propValue,maxValueWidth);
+                printPropWithLongValue(writer,format,propName,propValue,defaultValue,maxValueWidth);
             }
         }
     }
@@ -335,7 +339,8 @@ public class PrintUtils implements StringConstants {
             maxValueWidth = MAX_PROPERTY_VALUE_WIDTH;
         }
 
-        final String format = PrintUtils.getFormat( maxNameWidth, maxValueWidth, maxValueWidth );
+        final int maxDefaultValueWidth = Math.min( maxValueWidth, MAX_DEFAULT_VALUE_WIDTH );
+        final String format = PrintUtils.getFormat( maxNameWidth, maxValueWidth, maxDefaultValueWidth );
 
         // Print property header
         final String path = wsStatus.getDisplayPath(context);
@@ -352,14 +357,14 @@ public class PrintUtils implements StringConstants {
                String.format( format,
                               PrintUtils.getHeaderDelimiter( maxNameWidth ),
                               PrintUtils.getHeaderDelimiter( maxValueWidth ),
-                              PrintUtils.getHeaderDelimiter( maxValueWidth ) ) );
+                              PrintUtils.getHeaderDelimiter( maxDefaultValueWidth ) ) );
 
         // propValue less than maximum width
         if(propValue.length() <= maxValueWidth) {
             print( writer, MESSAGE_INDENT, String.format( format, propertyName, propValue, defaultValue ) );
         // propValue exceeds maximum width - splits it up onto separate lines
         } else {
-            printPropWithLongValue(writer,format,propertyName,propValue,maxValueWidth);
+            printPropWithLongValue(writer,format,propertyName,propValue,defaultValue,maxValueWidth);
         }
 
     }
@@ -454,20 +459,27 @@ public class PrintUtils implements StringConstants {
      * @param format the format
      * @param propName the property name
      * @param propValue the property value
+     * @param defaultValue the default value of the property (can be empty)
      * @param maxValueWidth maximum width of the value
      */
-    public static void printPropWithLongValue(Writer writer, String format, String propName, String propValue, int maxValueWidth) {
+    public static void printPropWithLongValue( Writer writer,
+                                               String format,
+                                               String propName,
+                                               String propValue,
+                                               String defaultValue,
+                                               int maxValueWidth ) {
         // splits long strings into equal length lines of 'maxValueWidth' length.
         List<String> lines = splitEqually(propValue,maxValueWidth);
+        defaultValue = ( StringUtils.isBlank( defaultValue ) ? EMPTY_STRING : defaultValue );
         boolean first = true;
         for(String line : lines) {
             // First line includes the propName
             if(first) {
-                print( writer, MESSAGE_INDENT, String.format( format, propName, line ) );
+                print( writer, MESSAGE_INDENT, String.format( format, propName, line, defaultValue ) );
                 first = false;
             // Subsequent lines the 'name' is just a spacer
             } else {
-                print( writer, MESSAGE_INDENT, String.format( format, EMPTY_STRING, line ) );
+                print( writer, MESSAGE_INDENT, String.format( format, EMPTY_STRING, line, EMPTY_STRING ) );
             }
         }
     }


### PR DESCRIPTION
- Fixes a bug where the option property descriptor wasn't being found (wrong primary type properties was being used)
- Fixes a bug that threw an exception when long property values were being shown (incorrect use of a string format pattern)