### PR TITLE
#316, #317 Redesigned LabelProviders

### DIFF
--- a/plugins/org.komodo.core/src/org/komodo/repository/KomodoTypeRegistry.java
+++ b/plugins/org.komodo.core/src/org/komodo/repository/KomodoTypeRegistry.java
@@ -24,6 +24,7 @@ package org.komodo.repository;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.komodo.core.KomodoLexicon;
 import org.komodo.modeshape.teiid.cnd.TeiidSqlLexicon;
 import org.komodo.spi.constants.StringConstants;
@@ -119,6 +120,8 @@ public class KomodoTypeRegistry implements StringConstants {
         index(KomodoType.COLUMN, TeiidDdlLexicon.CreateTable.TABLE_ELEMENT);
 
         index(KomodoType.DATA_TYPE_RESULT_SET, TeiidDdlLexicon.CreateProcedure.RESULT_DATA_TYPE);
+
+        index(KomodoType.DATASOURCE, KomodoLexicon.DataSource.NODE_TYPE);
 
         index(KomodoType.FOREIGN_KEY, TeiidDdlLexicon.Constraint.FOREIGN_KEY_CONSTRAINT);
 

--- a/plugins/org.komodo.relational.commands/META-INF/services/org.komodo.shell.api.KomodoObjectLabelProvider
+++ b/plugins/org.komodo.relational.commands/META-INF/services/org.komodo.shell.api.KomodoObjectLabelProvider
@@ -1,1 +1,1 @@
-org.komodo.relational.commands.RelationalLabelProvider
+org.komodo.relational.RelationalLabelProvider

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/FindCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/FindCommand.java
@@ -8,18 +8,22 @@
 package org.komodo.relational.commands;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
 import org.komodo.relational.RelationalObject;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.repository.KomodoTypeRegistry;
+import org.komodo.repository.ObjectImpl;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.KomodoObjectLabelProvider;
 import org.komodo.shell.api.TabCompletionModifier;
 import org.komodo.shell.api.WorkspaceStatus;
+import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.komodo.utils.StringUtils;
 import org.komodo.utils.i18n.I18n;
@@ -152,7 +156,14 @@ public final class FindCommand extends RelationalShellCommand {
             return searchResults;
         }
 
-        final KomodoObjectLabelProvider labelProvider = wsStatus.getCurrentContextLabelProvider();
+        KomodoObject unknownObject=new ObjectImpl(wsStatus.getCurrentContext().getRepository(), searchResults[0], 0);
+        KomodoObject resolvedObject=wsStatus.resolve(unknownObject);
+        KomodoObjectLabelProvider labelProvider;
+        if(resolvedObject == null){
+        	labelProvider = wsStatus.getCurrentContextLabelProvider();
+        }else{
+            labelProvider = wsStatus.getObjectLabelProvider(resolvedObject);
+        }
         final String[] result = new String[ searchResults.length ];
         int i = 0;
         for ( final String absolutePath : searchResults ) {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/FindCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/FindCommand.java
@@ -152,7 +152,7 @@ public final class FindCommand extends RelationalShellCommand {
             return searchResults;
         }
 
-        final KomodoObjectLabelProvider labelProvider = wsStatus.getLabelProvider();
+        final KomodoObjectLabelProvider labelProvider = wsStatus.getCurrentContextLabelProvider();
         final String[] result = new String[ searchResults.length ];
         int i = 0;
         for ( final String absolutePath : searchResults ) {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalCommandProvider.java
@@ -15,7 +15,6 @@ import org.komodo.shell.api.ShellCommandProvider;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
-import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Repository;
 
 /**
@@ -66,15 +65,6 @@ public class RelationalCommandProvider implements ShellCommandProvider {
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(kObj.getRepository());
         if(wkspMgr.getAbsolutePath().equals(kObj.getAbsolutePath())) {
             return wkspMgr;
-        }
-        return null;
-    }
-
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        WorkspaceManager wkspMgr = WorkspaceManager.getInstance(kObj.getRepository());
-        if(wkspMgr.getAbsolutePath().equals(kObj.getAbsolutePath())) {
-            return KomodoType.WORKSPACE.getType();
         }
         return null;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalLabelProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalLabelProvider.java
@@ -7,26 +7,25 @@
  */
 package org.komodo.relational.commands;
 
-import static org.komodo.spi.constants.StringConstants.EMPTY_STRING;
-import static org.komodo.spi.constants.StringConstants.FORWARD_SLASH;
 import java.util.Arrays;
 import java.util.List;
-import org.komodo.repository.ObjectImpl;
+
+import org.komodo.relational.RelationalObject;
 import org.komodo.shell.DefaultLabelProvider;
+import org.komodo.shell.ShellI18n;
+import org.komodo.shell.api.ShellCommandProvider;
 import org.komodo.spi.KException;
-import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
-import org.komodo.spi.repository.Repository;
-import org.komodo.utils.ArgCheck;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.utils.KLog;
+import org.komodo.utils.i18n.I18n;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
 /**
  * A label provider for relational objects.
  */
 public class RelationalLabelProvider extends DefaultLabelProvider {
-
-    private static final String TKO_PREFIX = "tko:"; //$NON-NLS-1$
-    
+  
     /**
      * A collection of grouping node names that should be removed from the display paths.
      */
@@ -39,7 +38,6 @@ public class RelationalLabelProvider extends DefaultLabelProvider {
                                                                                        VdbLexicon.Vdb.ENTRIES,
                                                                                        VdbLexicon.Vdb.IMPORT_VDBS} );
 
-
     /**
      * Constructs a command provider for workspace shell commands.
      */
@@ -50,182 +48,35 @@ public class RelationalLabelProvider extends DefaultLabelProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.KomodoObjectLabelProvider#getDisplayName(org.komodo.spi.repository.KomodoObject)
+     * @see org.komodo.shell.api.KomodoObjectLabelProvider#getGroupingNodes(java.lang.String)
      */
-    @Override
-    public String getDisplayName( final KomodoObject kobject ) {
-        ArgCheck.isNotNull( kobject, "kobject" ); //$NON-NLS-1$
-
-        // Null returned if grouping node
-        final Repository.UnitOfWork uow = this.status.getTransaction();
-        String nodeName = null;
-        try {
-            nodeName = kobject.getName(uow);
-        } catch (KException ex) {
-            // node exception
-        }
-        if(GROUPING_NODES.contains( nodeName )) {
-            return null;
-        }
-        return super.getDisplayName(kobject);
-    }
-    
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.shell.api.KomodoObjectLabelProvider#getDisplayPath(java.lang.String)
-     */
-    @Override
-    public String getDisplayPath( final String repositoryAbsolutePath ) {
-        ArgCheck.isNotEmpty( repositoryAbsolutePath, "repositoryAbsolutePath" ); //$NON-NLS-1$
-
-        if ( !repositoryAbsolutePath.startsWith( ROOT_PATH ) ) {
-            return null;
-        }
-
-        // /tko:komodo
-        if ( ROOT_PATH.equals( repositoryAbsolutePath ) || ROOT_SLASH_PATH.equals( repositoryAbsolutePath ) ) {
-            return ROOT_DISPLAY_PATH;
-        }
-
-        // /tko:komodo/workspace
-        if ( WORKSPACE_PATH.equals( repositoryAbsolutePath ) || WORKSPACE_SLASH_PATH.equals( repositoryAbsolutePath ) ) {
-            return WORKSPACE_DISPLAY_PATH;
-        }
-
-        // /tko:komodo/library
-        if ( LIB_PATH.equals( repositoryAbsolutePath ) || LIB_SLASH_PATH.equals( repositoryAbsolutePath ) ) {
-            return LIB_DISPLAY_PATH;
-        }
-
-        // /tko:komodo/environment
-        if ( ENV_PATH.equals( repositoryAbsolutePath ) || ENV_SLASH_PATH.equals( repositoryAbsolutePath ) ) {
-            return ENV_DISPLAY_PATH;
-        }
-
-        final String relativePath = repositoryAbsolutePath.substring( ROOT_PATH.length() );
-        final StringBuilder displayPath = new StringBuilder( ROOT_DISPLAY_PATH );
-        boolean firstTime = true;
-
-        for ( final String segment : relativePath.split( FORWARD_SLASH ) ) {
-            if ( EMPTY_STRING.equals( segment ) ) {
-                continue;
-            }
-
-            final boolean skip = GROUPING_NODES.contains( segment );
-
-            if ( !firstTime && !skip ) {
-                displayPath.append( FORWARD_SLASH );
-            } else {
-                firstTime = false;
-            }
-
-            if ( !skip ) {
-                if(segment.startsWith(TKO_PREFIX)) {
-                    displayPath.append(segment.substring(TKO_PREFIX.length()));
-                } else {
-                    displayPath.append( segment );
-                }
-            }
-        }
-
-        if ( repositoryAbsolutePath.endsWith( FORWARD_SLASH ) ) {
-            displayPath.append( FORWARD_SLASH );
-        }
-
-        return displayPath.toString();
-    }
-    
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.shell.api.KomodoObjectLabelProvider#getPath(java.lang.String)
-     */
-    @Override
-    public String getPath( final String displayPath ) {
-        ArgCheck.isNotEmpty( displayPath, "displayPath" ); //$NON-NLS-1$
-
-        if ( !displayPath.startsWith( ROOT_DISPLAY_PATH ) ) {
-            return null;
-        }
-
-        if ( ROOT_DISPLAY_PATH.equals( displayPath ) ) {
-            return ROOT_PATH;
-        }
-
-        KomodoObject kobject = null;
-
-        try {
-            KomodoObject parent = new ObjectImpl( this.repository, ROOT_PATH, 0 );
-
-            // for each segment make sure a child exists and add in prefix if necessary
-            for ( final String segment : displayPath.split( FORWARD_SLASH ) ) {
-                if ( EMPTY_STRING.equals( segment ) || StringConstants.DOT.equals(segment) ) {
-                    continue;
-                }
-                // Process '..' in display path
-                if (StringConstants.DOT_DOT.equals(segment)) {
-                    KomodoObject theParent = parent.getParent(this.status.getTransaction());
-                    if(theParent!=null) {
-                        if(GROUPING_NODES.contains(theParent.getName(this.status.getTransaction()))) {
-                            parent = theParent.getParent(this.status.getTransaction());
-                        } else {
-                            parent = theParent;
-                        }
-                        continue;
-                    }
-                }
-
-                if ( this.status.isShowingPropertyNamePrefixes() ) {
-                    if ( parent.hasChild( this.status.getTransaction(), segment ) ) {
-                        kobject = parent.getChild( this.status.getTransaction(), segment );
-                        parent = kobject;
-                    } else {
-                        return null; // no child with that name
-                    }
-                } else {
-                    // loop through children and take first one with local name match.  skip grouping nodes
-                    boolean childFound = false;
-                    for ( final KomodoObject kid : parent.getChildren( this.status.getTransaction() ) ) {
-                        final String name = kid.getName( this.status.getTransaction() );
-                        final int index = name.indexOf( StringConstants.COLON );
-
-                        if ( index == -1 ) {
-                            if ( segment.equals( name ) ) {
-                                kobject = kid;
-                                parent = kobject;
-                                childFound = true;
-                                break;
-                            }
-                        } else if (GROUPING_NODES.contains( name )) {
-                            KomodoObject[] children = kid.getChildren(this.status.getTransaction(), segment);
-                            if(children.length>0) {
-                                kobject = children[0];
-                                parent = kobject;
-                                childFound = true;
-                                break;
-                            }
-                        } else {
-                            if ( segment.equals( name.substring( index + 1 ) ) ) {
-                                kobject = kid;
-                                parent = kobject;
-                                childFound = true;
-                                break;
-                            }
-                        }
-                    }
-                    if(!childFound) return null;
-                }
-            }
-
-            if ( kobject == null ) {
-                return null;
-            }
-
-            return kobject.getAbsolutePath();
-        } catch ( final Exception e ) {
-            return null;
-        }
-    }
+	@Override
+	public List<String> getGroupingNodes(){
+		return GROUPING_NODES;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @throws KException 
+	 * 
+	 * @see org.komodo.shell.api.KomodoObjectLabelProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
+	 *      org.komodo.spi.repository.KomodoObject)
+	 */
+	@Override
+	public String getTypeDisplay(UnitOfWork uow, KomodoObject kobject){
+		for(ShellCommandProvider provider:status.getCommandFactory().getCommandProviders()){
+			KomodoObject komodoObject=null;
+			try {
+				komodoObject = provider.resolve(status.getTransaction(), kobject);
+			} catch (KException ex) {
+				KLog.getLogger().error( I18n.bind( ShellI18n.internalError) , ex );
+				continue;
+			}
+			if(komodoObject instanceof RelationalObject){
+				return ((RelationalObject)komodoObject).getTypeDisplayName();
+			}
+		}
+		return super.getTypeDisplay(status.getTransaction(), kobject);
+	}
     
 }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalShellCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalShellCommand.java
@@ -58,7 +58,7 @@ public abstract class RelationalShellCommand extends BuiltInShellCommand {
 
     protected String getDisplayType( final KomodoObject kobject ) throws Exception {
         if ( kobject instanceof RelationalObject ) {
-            return ( ( RelationalObject )kobject ).getTypeDisplayName();
+            return getWorkspaceStatus().getLabelProvider().getTypeDisplay(getWorkspaceStatus().getTransaction(), kobject);
         }
 
         throw new KException( I18n.bind( WorkspaceCommandsI18n.invalidObjectType, kobject.getAbsolutePath() ) );

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalShellCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/RelationalShellCommand.java
@@ -56,10 +56,10 @@ public abstract class RelationalShellCommand extends BuiltInShellCommand {
         return getDisplayType( get() );
     }
 
-    protected String getDisplayType( final KomodoObject kobject ) throws Exception {
-        if ( kobject instanceof RelationalObject ) {
-            return getWorkspaceStatus().getLabelProvider().getTypeDisplay(getWorkspaceStatus().getTransaction(), kobject);
-        }
+	protected String getDisplayType(final KomodoObject kobject) throws Exception {
+		if (kobject instanceof RelationalObject) {
+			return getWorkspaceStatus().getTypeDisplay( kobject );
+		}
 
         throw new KException( I18n.bind( WorkspaceCommandsI18n.invalidObjectType, kobject.getAbsolutePath() ) );
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/column/ColumnCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/column/ColumnCommandProvider.java
@@ -61,18 +61,6 @@ public class ColumnCommandProvider implements ShellCommandProvider {
     }
 
     @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Column resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
     public String getStatusMessage ( final Repository.UnitOfWork uow, final KomodoObject kObj ) {
         return null;
     }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/condition/ConditionCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/condition/ConditionCommandProvider.java
@@ -60,12 +60,6 @@ public class ConditionCommandProvider implements ShellCommandProvider {
         return null;
     }
 
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Condition resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datarole/DataRoleCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datarole/DataRoleCommandProvider.java
@@ -67,12 +67,6 @@ public class DataRoleCommandProvider implements ShellCommandProvider {
         return null;
     }
 
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final DataRole resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
     /**
      * @throws KException the exception
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datarole/ShowPermissionsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datarole/ShowPermissionsCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.datarole;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.vdb.DataRole;
 import org.komodo.relational.vdb.Permission;
@@ -67,7 +68,8 @@ public final class ShowPermissionsCommand extends DataRoleShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 permission.getName( getTransaction() ),
-                                                permission.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), permission)
+ ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datarole/ShowPermissionsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datarole/ShowPermissionsCommand.java
@@ -68,7 +68,7 @@ public final class ShowPermissionsCommand extends DataRoleShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 permission.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), permission)
+                                                getWorkspaceStatus().getTypeDisplay(permission)
  ) );
                 }
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datasource/DatasourceCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datasource/DatasourceCommandProvider.java
@@ -62,18 +62,6 @@ public class DatasourceCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Datasource resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datatyperesultset/DataTypeResultSetCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/datatyperesultset/DataTypeResultSetCommandProvider.java
@@ -63,18 +63,6 @@ public class DataTypeResultSetCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final DataTypeResultSet resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/entry/EntryCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/entry/EntryCommandProvider.java
@@ -60,12 +60,6 @@ public class EntryCommandProvider implements ShellCommandProvider {
         return null;
     }
 
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Entry resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/AddReferenceColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/AddReferenceColumnCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.foreignkey;
 
 import java.util.List;
+
 import org.komodo.relational.commands.FindCommand;
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.ForeignKey;
@@ -53,7 +54,7 @@ public final class AddReferenceColumnCommand extends ForeignKeyShellCommand {
             // get reference of the column at the specified path
             Column column = null;
             { // see if valid column
-                String repoPath = getWorkspaceStatus().getLabelProvider().getPath( columnPath );
+                String repoPath = getWorkspaceStatus().getCurrentContextLabelProvider().getPath( columnPath );
 
                 if ( StringUtils.isBlank( repoPath ) ) {
                     repoPath = columnPath;
@@ -83,7 +84,7 @@ public final class AddReferenceColumnCommand extends ForeignKeyShellCommand {
                 if ( parentTable.equals( column.getParent( getTransaction() ) ) ) {
                     result = new CommandResultImpl( false,
                                                     I18n.bind( ForeignKeyCommandsI18n.invalidColumn,
-                                                               getWorkspaceStatus().getLabelProvider()
+                                                               getWorkspaceStatus().getCurrentContextLabelProvider()
                                                                                    .getDisplayPath( column.getAbsolutePath() ),
                                                                foreignKey.getName( getTransaction() ) ),
                                                     null );
@@ -161,7 +162,7 @@ public final class AddReferenceColumnCommand extends ForeignKeyShellCommand {
 
             final Table parent = getForeignKey().getTable( uow );
             final String parentPath = parent.getAbsolutePath();
-            final String parentDisplayPath = getWorkspaceStatus().getLabelProvider().getDisplayPath( parentPath );
+            final String parentDisplayPath = getWorkspaceStatus().getCurrentContextLabelProvider().getDisplayPath( parentPath );
 
             // only add columns NOT found in the parent table
             for ( final String displayPath : allDisplayPaths ) {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/DeleteReferenceColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/DeleteReferenceColumnCommand.java
@@ -51,7 +51,7 @@ public final class DeleteReferenceColumnCommand extends ForeignKeyShellCommand {
             // get reference of the column at the specified path
             Column column = null;
             { // see if valid column
-                String repoPath = getWorkspaceStatus().getLabelProvider().getPath( columnPathArg );
+                String repoPath = getWorkspaceStatus().getCurrentContextLabelProvider().getPath( columnPathArg );
 
                 if ( StringUtils.isBlank( repoPath ) ) {
                     repoPath = columnPathArg;
@@ -150,7 +150,7 @@ public final class DeleteReferenceColumnCommand extends ForeignKeyShellCommand {
             final boolean noLastArg = StringUtils.isBlank( lastArgument );
 
             for ( final Column column : refCols ) {
-                final String displayPath = getWorkspaceStatus().getLabelProvider().getDisplayPath( column );
+                final String displayPath = getWorkspaceStatus().getCurrentContextLabelProvider().getDisplayPath( column );
                 final String absolutePath = column.getAbsolutePath();
 
                 if ( noLastArg || displayPath.startsWith( lastArgument ) || absolutePath.startsWith( lastArgument ) ) {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/ForeignKeyCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/foreignkey/ForeignKeyCommandProvider.java
@@ -62,18 +62,6 @@ public class ForeignKeyCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final ForeignKey resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/index/IndexCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/index/IndexCommandProvider.java
@@ -62,18 +62,6 @@ public class IndexCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Index resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/mask/MaskCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/mask/MaskCommandProvider.java
@@ -63,18 +63,6 @@ public class MaskCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Mask resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ModelCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ModelCommandProvider.java
@@ -88,18 +88,6 @@ public class ModelCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Model resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowPushdownFunctionsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowPushdownFunctionsCommand.java
@@ -8,8 +8,10 @@
 package org.komodo.relational.commands.model;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Function;
 import org.komodo.relational.model.Model;
@@ -87,7 +89,7 @@ public final class ShowPushdownFunctionsCommand extends ModelShellCommand {
                         print( indent,
                                I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                     function.getName( getTransaction() ),
-                                                    function.getTypeDisplayName() ) );
+                                                    getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), function) ) );
                     }
                 }
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowPushdownFunctionsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowPushdownFunctionsCommand.java
@@ -89,7 +89,7 @@ public final class ShowPushdownFunctionsCommand extends ModelShellCommand {
                         print( indent,
                                I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                     function.getName( getTransaction() ),
-                                                    getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), function) ) );
+                                                    getWorkspaceStatus().getTypeDisplay( function) ) );
                     }
                 }
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowSourcesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowSourcesCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.model;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.vdb.ModelSource;
@@ -64,7 +65,7 @@ public final class ShowSourcesCommand extends ModelShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 source.getName( getTransaction() ),
-                                                source.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), source) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowSourcesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowSourcesCommand.java
@@ -65,7 +65,7 @@ public final class ShowSourcesCommand extends ModelShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 source.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), source) ) );
+                                                getWorkspaceStatus().getTypeDisplay(source) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowStoredProceduresCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowStoredProceduresCommand.java
@@ -8,8 +8,10 @@
 package org.komodo.relational.commands.model;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.Procedure;
@@ -85,7 +87,7 @@ public final class ShowStoredProceduresCommand extends ModelShellCommand {
                         print( indent,
                                I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                     storedProc.getName( getTransaction() ),
-                                                    storedProc.getTypeDisplayName() ) );
+                                                    getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), storedProc)) );
                     }
                 }
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowStoredProceduresCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowStoredProceduresCommand.java
@@ -87,7 +87,7 @@ public final class ShowStoredProceduresCommand extends ModelShellCommand {
                         print( indent,
                                I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                     storedProc.getName( getTransaction() ),
-                                                    getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), storedProc)) );
+                                                    getWorkspaceStatus().getTypeDisplay(storedProc)) );
                     }
                 }
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowTablesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowTablesCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.model;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.Table;
@@ -64,7 +65,7 @@ public final class ShowTablesCommand extends ModelShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 table.getName( getTransaction() ),
-                                                table.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), table) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowTablesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowTablesCommand.java
@@ -65,7 +65,7 @@ public final class ShowTablesCommand extends ModelShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 table.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), table) ) );
+                                                getWorkspaceStatus().getTypeDisplay(table) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowUserDefinedFunctionsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowUserDefinedFunctionsCommand.java
@@ -8,8 +8,10 @@
 package org.komodo.relational.commands.model;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Function;
 import org.komodo.relational.model.Model;
@@ -87,7 +89,7 @@ public final class ShowUserDefinedFunctionsCommand extends ModelShellCommand {
                         print( indent,
                                I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                     function.getName( getTransaction() ),
-                                                    function.getTypeDisplayName() ) );
+                                                    getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), function) ) );
                     }
                 }
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowUserDefinedFunctionsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowUserDefinedFunctionsCommand.java
@@ -89,7 +89,7 @@ public final class ShowUserDefinedFunctionsCommand extends ModelShellCommand {
                         print( indent,
                                I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                     function.getName( getTransaction() ),
-                                                    getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), function) ) );
+                                                    getWorkspaceStatus().getTypeDisplay(function) ) );
                     }
                 }
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowViewsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowViewsCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.model;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.View;
@@ -63,7 +64,7 @@ public final class ShowViewsCommand extends ModelShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 view.getName( getTransaction() ),
-                                                view.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), view) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowViewsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowViewsCommand.java
@@ -64,7 +64,7 @@ public final class ShowViewsCommand extends ModelShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 view.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), view) ) );
+                                                getWorkspaceStatus().getTypeDisplay(view) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowVirtualProceduresCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowVirtualProceduresCommand.java
@@ -8,8 +8,10 @@
 package org.komodo.relational.commands.model;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.model.Procedure;
@@ -87,7 +89,7 @@ public final class ShowVirtualProceduresCommand extends ModelShellCommand {
                         print( indent,
                                I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                     virtProc.getName( getTransaction() ),
-                                                    virtProc.getTypeDisplayName() ) );
+                                                    getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), virtProc) ) );
                     }
                 }
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowVirtualProceduresCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/model/ShowVirtualProceduresCommand.java
@@ -89,7 +89,7 @@ public final class ShowVirtualProceduresCommand extends ModelShellCommand {
                         print( indent,
                                I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                     virtProc.getName( getTransaction() ),
-                                                    getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), virtProc) ) );
+                                                    getWorkspaceStatus().getTypeDisplay(virtProc) ) );
                     }
                 }
             }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/modelsource/ModelSourceCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/modelsource/ModelSourceCommandProvider.java
@@ -62,18 +62,6 @@ public class ModelSourceCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final ModelSource resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/parameter/ParameterCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/parameter/ParameterCommandProvider.java
@@ -62,18 +62,6 @@ public class ParameterCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Parameter resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/PermissionCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/PermissionCommandProvider.java
@@ -68,18 +68,6 @@ public class PermissionCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Permission resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/ShowConditionsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/ShowConditionsCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.permission;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.vdb.Condition;
 import org.komodo.relational.vdb.Permission;
@@ -68,7 +69,7 @@ public final class ShowConditionsCommand extends PermissionShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 condition.getName( getTransaction() ),
-                                                condition.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), condition) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/ShowConditionsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/ShowConditionsCommand.java
@@ -69,7 +69,7 @@ public final class ShowConditionsCommand extends PermissionShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 condition.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), condition) ) );
+                                                getWorkspaceStatus().getTypeDisplay(condition) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/ShowMasksCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/ShowMasksCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.permission;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.vdb.Mask;
 import org.komodo.relational.vdb.Permission;
@@ -66,7 +67,7 @@ public final class ShowMasksCommand extends PermissionShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 mask.getName( getTransaction() ),
-                                                mask.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), mask)) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/ShowMasksCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/permission/ShowMasksCommand.java
@@ -67,7 +67,7 @@ public final class ShowMasksCommand extends PermissionShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 mask.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), mask)) );
+                                                getWorkspaceStatus().getTypeDisplay(mask)) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/pushdownfunction/PushdownFunctionCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/pushdownfunction/PushdownFunctionCommandProvider.java
@@ -66,18 +66,6 @@ public class PushdownFunctionCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final PushdownFunction resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/resultsetcolumn/ResultSetColumnCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/resultsetcolumn/ResultSetColumnCommandProvider.java
@@ -59,12 +59,6 @@ public class ResultSetColumnCommandProvider implements ShellCommandProvider {
         return null;
     }
 
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final ResultSetColumn resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
     /**
      * {@inheritDoc}
      *

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/schema/SchemaCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/schema/SchemaCommandProvider.java
@@ -63,18 +63,6 @@ public class SchemaCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Schema resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/server/ServerCommandProvider.java
@@ -86,18 +86,6 @@ public class ServerCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Teiid resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/storedprocedure/StoredProcedureCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/storedprocedure/StoredProcedureCommandProvider.java
@@ -66,18 +66,6 @@ public class StoredProcedureCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final StoredProcedure resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/AddForeignKeyCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/AddForeignKeyCommand.java
@@ -47,7 +47,7 @@ public final class AddForeignKeyCommand extends TableShellCommand {
             Table referencedTable = null;
 
             { // see if valid table path
-                String repoPath = getWorkspaceStatus().getLabelProvider().getPath( tableRefPath );
+                String repoPath = getWorkspaceStatus().getCurrentContextLabelProvider().getPath( tableRefPath );
 
                 if ( StringUtils.isBlank( repoPath ) ) {
                     repoPath = tableRefPath;

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowAccessPatternsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowAccessPatternsCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.table;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.AccessPattern;
 import org.komodo.relational.model.Table;
@@ -65,7 +66,7 @@ public final class ShowAccessPatternsCommand extends TableShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 accessPattern.getName( getTransaction() ),
-                                                accessPattern.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), accessPattern) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowAccessPatternsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowAccessPatternsCommand.java
@@ -66,7 +66,7 @@ public final class ShowAccessPatternsCommand extends TableShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 accessPattern.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), accessPattern) ) );
+                                                getWorkspaceStatus().getTypeDisplay(accessPattern) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowColumnsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowColumnsCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.table;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.Table;
@@ -64,7 +65,7 @@ public final class ShowColumnsCommand extends TableShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 column.getName( getTransaction() ),
-                                                column.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), column) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowColumnsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowColumnsCommand.java
@@ -65,7 +65,7 @@ public final class ShowColumnsCommand extends TableShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 column.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), column) ) );
+                                                getWorkspaceStatus().getTypeDisplay(column) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowIndexesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowIndexesCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.table;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Index;
 import org.komodo.relational.model.Table;
@@ -64,7 +65,7 @@ public final class ShowIndexesCommand extends TableShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 index.getName( getTransaction() ),
-                                                index.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), index) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowIndexesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowIndexesCommand.java
@@ -65,7 +65,7 @@ public final class ShowIndexesCommand extends TableShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 index.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), index) ) );
+                                                getWorkspaceStatus().getTypeDisplay(index) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowUniqueConstraintsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowUniqueConstraintsCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.table;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.UniqueConstraint;
@@ -67,7 +68,7 @@ public final class ShowUniqueConstraintsCommand extends TableShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 constraint.getName( getTransaction() ),
-                                                constraint.getTypeDisplayName() ) );
+                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), constraint) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowUniqueConstraintsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/ShowUniqueConstraintsCommand.java
@@ -68,7 +68,7 @@ public final class ShowUniqueConstraintsCommand extends TableShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                                 constraint.getName( getTransaction() ),
-                                                getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), constraint) ) );
+                                                getWorkspaceStatus().getTypeDisplay(constraint) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/TableCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/table/TableCommandProvider.java
@@ -81,18 +81,6 @@ public class TableCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Table resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommand.java
@@ -9,14 +9,15 @@ package org.komodo.relational.commands.tableconstraint;
 
 import java.util.Arrays;
 import java.util.List;
+
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.CompletionConstants;
 import org.komodo.shell.api.CommandResult;
-import org.komodo.shell.api.TabCompletionModifier;
 import org.komodo.shell.api.KomodoObjectLabelProvider;
+import org.komodo.shell.api.TabCompletionModifier;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
@@ -161,7 +162,7 @@ public final class AddConstraintColumnCommand extends TableConstraintShellComman
                 return TabCompletionModifier.AUTO;
             }
 
-            final KomodoObjectLabelProvider labelProvider = getWorkspaceStatus().getCurrentContextLabelProvider();
+            final KomodoObjectLabelProvider labelProvider =getWorkspaceStatus().getObjectLabelProvider(columns[0]);
 
             for ( final Column column : Arrays.asList( columns ) ) {
                 final String absolutePath = column.getAbsolutePath();

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/AddConstraintColumnCommand.java
@@ -161,7 +161,7 @@ public final class AddConstraintColumnCommand extends TableConstraintShellComman
                 return TabCompletionModifier.AUTO;
             }
 
-            final KomodoObjectLabelProvider labelProvider = getWorkspaceStatus().getLabelProvider();
+            final KomodoObjectLabelProvider labelProvider = getWorkspaceStatus().getCurrentContextLabelProvider();
 
             for ( final Column column : Arrays.asList( columns ) ) {
                 final String absolutePath = column.getAbsolutePath();

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/DeleteConstraintColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/DeleteConstraintColumnCommand.java
@@ -10,11 +10,13 @@ package org.komodo.relational.commands.tableconstraint;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.TableConstraint;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.CompletionConstants;
 import org.komodo.shell.api.CommandResult;
+import org.komodo.shell.api.KomodoObjectLabelProvider;
 import org.komodo.shell.api.TabCompletionModifier;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.spi.repository.KomodoObject;
@@ -148,33 +150,34 @@ public final class DeleteConstraintColumnCommand extends TableConstraintShellCom
 
             // add matching paths of referenced columns
             final boolean noLastArg = StringUtils.isBlank( lastArgument );
+            if(refCols.length!=0){
+				KomodoObjectLabelProvider provider = getWorkspaceStatus().getObjectLabelProvider(refCols[0]);
+				for (final Column column : refCols) {
+					final String displayPath = provider.getDisplayPath(column);
+					final String absolutePath = column.getAbsolutePath();
 
-            for ( final Column column : refCols ) {
-                final String displayPath = getWorkspaceStatus().getCurrentContextLabelProvider().getDisplayPath( column );
-                final String absolutePath = column.getAbsolutePath();
+					if (noLastArg || displayPath.startsWith(lastArgument) || absolutePath.startsWith(lastArgument)) {
+						candidates.add(displayPath);
+					}
+				}
 
-                if ( noLastArg || displayPath.startsWith( lastArgument ) || absolutePath.startsWith( lastArgument ) ) {
-                    candidates.add( displayPath );
-                }
-            }
+				Collections.sort(candidates, new Comparator<CharSequence>() {
 
-            Collections.sort( candidates, new Comparator< CharSequence >() {
-
-                /**
-                 * {@inheritDoc}
-                 *
-                 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
-                 */
-                @Override
-                public int compare( final CharSequence thisPath,
-                                    final CharSequence thatPath ) {
-                    return thisPath.toString().compareTo( thatPath.toString() );
-                }
-            } );
-        }
-
-        // no completions if more than one arg
-        return TabCompletionModifier.AUTO;
-    }
+					/**
+					 * {@inheritDoc}
+					 *
+					 * @see java.util.Comparator#compare(java.lang.Object,
+					 *      java.lang.Object)
+					 */
+					@Override
+					public int compare(final CharSequence thisPath, final CharSequence thatPath) {
+						return thisPath.toString().compareTo(thatPath.toString());
+					}
+				});
+			}
+		}
+		// no completions if more than one arg
+		return TabCompletionModifier.AUTO;
+	}
 
 }

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/DeleteConstraintColumnCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/DeleteConstraintColumnCommand.java
@@ -150,7 +150,7 @@ public final class DeleteConstraintColumnCommand extends TableConstraintShellCom
             final boolean noLastArg = StringUtils.isBlank( lastArgument );
 
             for ( final Column column : refCols ) {
-                final String displayPath = getWorkspaceStatus().getLabelProvider().getDisplayPath( column );
+                final String displayPath = getWorkspaceStatus().getCurrentContextLabelProvider().getDisplayPath( column );
                 final String absolutePath = column.getAbsolutePath();
 
                 if ( noLastArg || displayPath.startsWith( lastArgument ) || absolutePath.startsWith( lastArgument ) ) {

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/TableConstraintCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tableconstraint/TableConstraintCommandProvider.java
@@ -49,19 +49,6 @@ public class TableConstraintCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay( final UnitOfWork uow,
-                                  final KomodoObject kObject ) throws KException {
-        final TableConstraint resolved = resolve( uow, kObject );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#initWorkspaceState(org.komodo.shell.api.WorkspaceStatus)
      */
     @Override

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tabularresultset/TabularResultSetCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/tabularresultset/TabularResultSetCommandProvider.java
@@ -64,18 +64,6 @@ public class TabularResultSetCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final TabularResultSet resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/teiid/TeiidCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/teiid/TeiidCommandProvider.java
@@ -62,18 +62,6 @@ public class TeiidCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Teiid resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/translator/TranslatorCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/translator/TranslatorCommandProvider.java
@@ -63,18 +63,6 @@ public class TranslatorCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Translator resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/userdefinedfunction/UserDefinedFunctionCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/userdefinedfunction/UserDefinedFunctionCommandProvider.java
@@ -64,18 +64,6 @@ public class UserDefinedFunctionCommandProvider implements ShellCommandProvider 
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final UserDefinedFunction resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowDataRolesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowDataRolesCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.vdb;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.vdb.DataRole;
 import org.komodo.relational.vdb.Vdb;
@@ -64,7 +65,7 @@ public final class ShowDataRolesCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       role.getName( getTransaction() ),
-                                      role.getTypeDisplayName() ) );
+                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), role) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowDataRolesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowDataRolesCommand.java
@@ -65,7 +65,7 @@ public final class ShowDataRolesCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       role.getName( getTransaction() ),
-                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), role) ) );
+                                      getWorkspaceStatus().getTypeDisplay(role) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowEntriesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowEntriesCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.vdb;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.vdb.Entry;
 import org.komodo.relational.vdb.Vdb;
@@ -63,7 +64,7 @@ public final class ShowEntriesCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       entry.getName( getTransaction() ),
-                                      entry.getTypeDisplayName() ) );
+                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), entry) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowEntriesCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowEntriesCommand.java
@@ -64,7 +64,7 @@ public final class ShowEntriesCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       entry.getName( getTransaction() ),
-                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), entry) ) );
+                                      getWorkspaceStatus().getTypeDisplay(entry) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowImportsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowImportsCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.vdb;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.vdb.VdbImport;
@@ -63,7 +64,7 @@ public final class ShowImportsCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       theImport.getName( getTransaction() ),
-                                      theImport.getTypeDisplayName() ) );
+                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), theImport) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowImportsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowImportsCommand.java
@@ -64,7 +64,7 @@ public final class ShowImportsCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       theImport.getName( getTransaction() ),
-                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), theImport) ) );
+                                      getWorkspaceStatus().getTypeDisplay(theImport) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowModelsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowModelsCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.vdb;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.vdb.Vdb;
@@ -63,7 +64,7 @@ public final class ShowModelsCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       model.getName( getTransaction() ),
-                                      model.getTypeDisplayName() ) );
+                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), model) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowModelsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowModelsCommand.java
@@ -64,7 +64,7 @@ public final class ShowModelsCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       model.getName( getTransaction() ),
-                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), model) ) );
+                                      getWorkspaceStatus().getTypeDisplay(model) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowTranslatorsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowTranslatorsCommand.java
@@ -8,6 +8,7 @@
 package org.komodo.relational.commands.vdb;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import org.komodo.relational.commands.workspace.WorkspaceCommandsI18n;
 import org.komodo.relational.vdb.Translator;
 import org.komodo.relational.vdb.Vdb;
@@ -64,7 +65,7 @@ public final class ShowTranslatorsCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       translator.getName( getTransaction() ),
-                                      translator.getTypeDisplayName() ) );
+                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), translator) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowTranslatorsCommand.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/ShowTranslatorsCommand.java
@@ -65,7 +65,7 @@ public final class ShowTranslatorsCommand extends VdbShellCommand {
                     print( indent,
                            I18n.bind( WorkspaceCommandsI18n.printRelationalObject,
                                       translator.getName( getTransaction() ),
-                                      getWorkspaceStatus().getLabelProvider().getTypeDisplay(getTransaction(), translator) ) );
+                                      getWorkspaceStatus().getTypeDisplay(translator) ) );
                 }
             }
 

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/VdbCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdb/VdbCommandProvider.java
@@ -84,18 +84,6 @@ public class VdbCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final Vdb resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdbimport/VdbImportCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/vdbimport/VdbImportCommandProvider.java
@@ -63,18 +63,6 @@ public class VdbImportCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final VdbImport resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/view/ViewCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/view/ViewCommandProvider.java
@@ -64,18 +64,6 @@ public class ViewCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final View resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/virtualprocedure/VirtualProcedureCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/virtualprocedure/VirtualProcedureCommandProvider.java
@@ -64,18 +64,6 @@ public class VirtualProcedureCommandProvider implements ShellCommandProvider {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        final VirtualProcedure resolved = resolve( uow, kObj );
-        return ( ( resolved == null ) ? null : resolved.getTypeDisplayName() );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.shell.api.ShellCommandProvider#getStatusMessage(org.komodo.spi.repository.Repository.UnitOfWork,
      *      org.komodo.spi.repository.KomodoObject)
      */

--- a/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/WorkspaceCommandProvider.java
+++ b/plugins/org.komodo.relational.commands/src/org/komodo/relational/commands/workspace/WorkspaceCommandProvider.java
@@ -15,7 +15,6 @@ import org.komodo.shell.api.ShellCommandProvider;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
-import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Repository;
 
 /**
@@ -68,15 +67,6 @@ public class WorkspaceCommandProvider implements ShellCommandProvider {
         WorkspaceManager wkspMgr = WorkspaceManager.getInstance(kObj.getRepository());
         if(wkspMgr.getAbsolutePath().equals(kObj.getAbsolutePath())) {
             return wkspMgr;
-        }
-        return null;
-    }
-
-    @Override
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException {
-        WorkspaceManager wkspMgr = WorkspaceManager.getInstance(kObj.getRepository());
-        if(wkspMgr.getAbsolutePath().equals(kObj.getAbsolutePath())) {
-            return KomodoType.WORKSPACE.getType();
         }
         return null;
     }

--- a/plugins/org.komodo.relational/META-INF/MANIFEST.MF
+++ b/plugins/org.komodo.relational/META-INF/MANIFEST.MF
@@ -21,5 +21,7 @@ Require-Bundle: org.komodo.spi;bundle-version="0.0.3",
  org.komodo.teiid.client;bundle-version="0.0.3",
  org.komodo.modeshape.vdb;bundle-version="0.0.3",
  org.komodo.modeshape.teiid.sql.sequencer;bundle-version="0.0.3",
- org.komodo.importer;bundle-version="0.0.3"
+ org.komodo.importer;bundle-version="0.0.3",
+ org.komodo.shell-api;bundle-version="0.0.3",
+ org.komodo.shell;bundle-version="0.0.3"
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.komodo.relational/pom.xml
+++ b/plugins/org.komodo.relational/pom.xml
@@ -47,6 +47,16 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <artifactId>org.komodo.utils</artifactId>
             <version>${project.version}</version>
         </dependency>
+	    <dependency>
+            <groupId>org.jboss.tools.komodo.plugins</groupId>
+            <artifactId>org.komodo.shell</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+	    <dependency>
+            <groupId>org.jboss.tools.komodo.plugins</groupId>
+            <artifactId>org.komodo.shell-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 	</dependencies>
  
     <build>

--- a/plugins/org.komodo.relational/src/org/komodo/relational/RelationalLabelProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/RelationalLabelProvider.java
@@ -67,14 +67,6 @@ public class RelationalLabelProvider extends DefaultLabelProvider {
 			return getTypeFromObject((RelationalObject) kobject);
 		}
 
-        if ( WORKSPACE_PATH.equals( kobject.getAbsolutePath() ) || WORKSPACE_SLASH_PATH.equals( kobject.getAbsolutePath()  ) ) {
-            return WORKSPACE_DISPLAY_NAME;
-        }
-
-		String areaObjectName=getNameForAreaObject(kobject.getAbsolutePath());
-		if(areaObjectName != null){
-			return areaObjectName;
-		}
 		try {
 			TypeResolver<?> resolver = TypeResolverRegistry.getInstance().getResolver(kobject.getTypeIdentifier(uow));
 			if (resolver != null) {

--- a/plugins/org.komodo.relational/src/org/komodo/relational/RelationalLabelProvider.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/RelationalLabelProvider.java
@@ -67,6 +67,14 @@ public class RelationalLabelProvider extends DefaultLabelProvider {
 			return getTypeFromObject((RelationalObject) kobject);
 		}
 
+        if ( WORKSPACE_PATH.equals( kobject.getAbsolutePath() ) || WORKSPACE_SLASH_PATH.equals( kobject.getAbsolutePath()  ) ) {
+            return WORKSPACE_DISPLAY_NAME;
+        }
+
+		String areaObjectName=getNameForAreaObject(kobject.getAbsolutePath());
+		if(areaObjectName != null){
+			return areaObjectName;
+		}
 		try {
 			TypeResolver<?> resolver = TypeResolverRegistry.getInstance().getResolver(kobject.getTypeIdentifier(uow));
 			if (resolver != null) {
@@ -79,7 +87,7 @@ public class RelationalLabelProvider extends DefaultLabelProvider {
 			KLog.getLogger().error(I18n.bind(ShellI18n.internalError), e);
 		}
 
-		return super.getTypeDisplay(uow, kobject);
+		return null;
 	}
 
 	private String getTypeFromObject(RelationalObject relObject) {

--- a/plugins/org.komodo.relational/src/org/komodo/relational/RelationalObject.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/RelationalObject.java
@@ -129,9 +129,4 @@ public interface RelationalObject extends KomodoObject {
      */
     void setFilters( final Filter[] newFilters );
 
-    /**
-     * @return the short name of the object type used for display purposes (never empty)
-     */
-    String getTypeDisplayName();
-
 }

--- a/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalObjectImpl.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/internal/RelationalObjectImpl.java
@@ -350,16 +350,6 @@ public abstract class RelationalObjectImpl extends ObjectImpl implements Relatio
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.relational.RelationalObject#getTypeDisplayName()
-     */
-    @Override
-    public String getTypeDisplayName() {
-        return org.komodo.relational.Messages.getString( getClass().getSimpleName() + ".typeName" ); //$NON-NLS-1$
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.repository.ObjectImpl#hasChild(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
      */
     @Override

--- a/plugins/org.komodo.relational/src/org/komodo/relational/messages.properties
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/messages.properties
@@ -91,3 +91,4 @@ VdbImpl.typeName = VDB
 VdbImportImpl.typeName = VDB Import
 ViewImpl.typeName = View
 VirtualProcedureImpl.typeName = Virtual Procedure
+WorkspaceManager.typeName = Workspace

--- a/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
+++ b/plugins/org.komodo.relational/src/org/komodo/relational/workspace/WorkspaceManager.java
@@ -147,16 +147,6 @@ public class WorkspaceManager extends ObjectImpl implements RelationalObject {
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.relational.RelationalObject#getTypeDisplayName()
-     */
-    @Override
-    public String getTypeDisplayName() {
-        return Messages.getString( WorkspaceManager.class.getSimpleName() + ".typeName" ); //$NON-NLS-1$
-    }
-
-    /**
-     * {@inheritDoc}
-     *
      * @see org.komodo.repository.ObjectImpl#getTypeId()
      */
     @Override

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoObjectLabelProvider.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoObjectLabelProvider.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 import org.komodo.core.KomodoLexicon;
 import org.komodo.repository.RepositoryImpl;
-import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
 
@@ -155,15 +154,15 @@ public interface KomodoObjectLabelProvider {
     
 	 /**
      * @return Returns a node names which should be omitted from display path
+     *         (Never <code>null</code>. Returns empty list if not grouping nodes are available)
      */
-	List<String> getGroupingNodes();
+	List<String> skippedPathSegmentNames();
 	
     /**
      * Get the type display string for a KomodoObject
-     * @param uow the transaction
-     * @param kObj the KomodoObject
-     * @return the type display string
-     * @throws KException the exception
+     * @param uow the transaction (never <code>null</code>)
+     * @param kObj the KomodoObject (never <code>null</code>)
+     * @return the type display string (never returns <code>null</code>)
      */
     public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj );
 

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoObjectLabelProvider.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoObjectLabelProvider.java
@@ -151,19 +151,19 @@ public interface KomodoObjectLabelProvider {
      *        the workspace status (never <code>null</code>)
      */
     void setWorkspaceStatus( final WorkspaceStatus status );
-    
+
 	 /**
      * @return Returns a node names which should be omitted from display path
      *         (Never <code>null</code>. Returns empty list if not grouping nodes are available)
      */
 	List<String> skippedPathSegmentNames();
-	
+
     /**
      * Get the type display string for a KomodoObject
      * @param uow the transaction (never <code>null</code>)
      * @param kObj the KomodoObject (never <code>null</code>)
      * @return the type display string (never returns <code>null</code>)
      */
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj );
+    String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj );
 
 }

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoObjectLabelProvider.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/KomodoObjectLabelProvider.java
@@ -8,8 +8,12 @@
 package org.komodo.shell.api;
 
 import static org.komodo.spi.constants.StringConstants.FORWARD_SLASH;
+
+import java.util.List;
+
 import org.komodo.core.KomodoLexicon;
 import org.komodo.repository.RepositoryImpl;
+import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository;
 
@@ -148,5 +152,19 @@ public interface KomodoObjectLabelProvider {
      *        the workspace status (never <code>null</code>)
      */
     void setWorkspaceStatus( final WorkspaceStatus status );
+    
+	 /**
+     * @return Returns a node names which should be omitted from display path
+     */
+	List<String> getGroupingNodes();
+	
+    /**
+     * Get the type display string for a KomodoObject
+     * @param uow the transaction
+     * @param kObj the KomodoObject
+     * @return the type display string
+     * @throws KException the exception
+     */
+    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj );
 
 }

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandProvider.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/ShellCommandProvider.java
@@ -44,15 +44,6 @@ public interface ShellCommandProvider {
     public < T extends KomodoObject > T resolve ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException;
 
     /**
-     * Get the type display string for a KomodoObject
-     * @param uow the transaction
-     * @param kObj the KomodoObject
-     * @return the type display string
-     * @throws KException the exception
-     */
-    public String getTypeDisplay ( final Repository.UnitOfWork uow, final KomodoObject kObj ) throws KException;
-
-    /**
      * Initialize workspace state for recognized properties
      * @param wsStatus the workspace status
      * @throws KException the exception

--- a/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
+++ b/plugins/org.komodo.shell-api/src/org/komodo/shell/api/WorkspaceStatus.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+
 import org.komodo.core.KEngine;
 import org.komodo.spi.KException;
 import org.komodo.spi.constants.StringConstants;
@@ -116,7 +117,7 @@ public interface WorkspaceStatus extends StringConstants {
      *         if an error occurs
      */
     Set<ShellCommand> getAvailableCommands() throws Exception;
-    
+
     /**
      * Update the available commands for the current context.
      */
@@ -151,7 +152,7 @@ public interface WorkspaceStatus extends StringConstants {
      *         if an error occurs
      */
     void setProvidedProperties( final Properties props ) throws Exception;
-    
+
     /**
      * Sets the specified provided property value in workspace properties.
      *
@@ -170,7 +171,7 @@ public interface WorkspaceStatus extends StringConstants {
      * @see #setProvidedProperty(String, String)
      */
     Properties getProvidedProperties();
-    
+
     /**
      * Sets global workspace properties on startup
      *
@@ -182,7 +183,7 @@ public interface WorkspaceStatus extends StringConstants {
     void setGlobalProperties( final Properties props ) throws Exception;
 
     /**
-     * Gets a copy of the global workspace properties.  This includes the defined global properties and defined hidden properties. 
+     * Gets a copy of the global workspace properties.  This includes the defined global properties and defined hidden properties.
      *
      * @return the global workspace properties (never <code>null</code> or empty)
      * @see #setGlobalProperty(String, String)
@@ -397,10 +398,17 @@ public interface WorkspaceStatus extends StringConstants {
     < T extends KomodoObject > T resolve ( final KomodoObject kObj ) throws KException;
 
     /**
-     * Get the label provider
+     * Get the label provider for current context
      * @return the current label provider (never <code>null</code>)
      */
-    KomodoObjectLabelProvider getLabelProvider();
+    KomodoObjectLabelProvider getCurrentContextLabelProvider();
+
+    /**
+     * Get the label provider for specified object
+     * @param KomodoObject to be processed by label provider
+     * @return the current label provider (never <code>null</code>)
+     */
+    KomodoObjectLabelProvider getObjectLabelProvider(KomodoObject kobject);
 
     /**
      * Get the object type string for display

--- a/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommand.java
@@ -393,7 +393,7 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
 
 		// Try to locate the object at the specified path
         KomodoObject newContext = null;
-        String repoPath = getWorkspaceStatus().getLabelProvider().getPath(entireDisplayPath);
+        String repoPath = getWorkspaceStatus().getCurrentContextLabelProvider().getPath(entireDisplayPath);
         if(!StringUtils.isBlank(repoPath)) {
             // TODO: probably need to add getFromLibrary method similar to getFromWorkspace instead of the below...
             // /tko:komodo/library
@@ -459,7 +459,7 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
     	if(lastArgument==null) {
     	    KomodoObject[] children = currentContext.getChildren( getTransaction() );
     		for(KomodoObject wsContext : children) {
-    		    final String contextName = this.wsStatus.getLabelProvider().getDisplayName( wsContext );
+    		    final String contextName = this.wsStatus.getCurrentContextLabelProvider().getDisplayName( wsContext );
     			potentialsList.add(contextName+FORWARD_SLASH);
     		}
     		candidates.addAll(potentialsList);
@@ -551,7 +551,7 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
                     result.setPath(prevPath);
                     break;
                 } else {
-                    String currContextPath = wsStatus.getLabelProvider().getDisplayPath(currentContext);
+                    String currContextPath = wsStatus.getCurrentContextLabelProvider().getDisplayPath(currentContext);
                     String displayPath = currContextPath + FORWARD_SLASH + segment;
                     KomodoObject theContext = wsStatus.getContextForDisplayPath(displayPath);
 
@@ -606,7 +606,7 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
         int nMatching = 0;
         try {
             for(KomodoObject theContext : currentContext.getChildren(wsStatus.getTransaction())) {
-                final String contextName = wsStatus.getLabelProvider().getDisplayName( theContext );
+                final String contextName = wsStatus.getCurrentContextLabelProvider().getDisplayName( theContext );
                 if(contextName.startsWith(segmentName)) {
                     nMatching++;
                     if(nMatching>1) break;
@@ -633,7 +633,7 @@ public abstract class BuiltInShellCommand implements ShellCommand, StringConstan
         ArgCheck.isNotEmpty( absolutePath, "absolutePath" ); //$NON-NLS-1$
 
         final String absContextPath = wsStatus.getDisplayPath(context);
-        final String displayPath = wsStatus.getLabelProvider().getDisplayPath( absolutePath );
+        final String displayPath = wsStatus.getCurrentContextLabelProvider().getDisplayPath( absolutePath );
         String path = ( StringUtils.isBlank( displayPath ) ? absolutePath : displayPath );
 
         if ( path.startsWith( absContextPath ) ) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommandProvider.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/BuiltInShellCommandProvider.java
@@ -9,7 +9,7 @@ package org.komodo.shell;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.komodo.repository.ObjectImpl;
+
 import org.komodo.shell.api.ShellCommand;
 import org.komodo.shell.api.ShellCommandProvider;
 import org.komodo.shell.api.WorkspaceStatus;
@@ -67,22 +67,6 @@ public final class BuiltInShellCommandProvider implements ShellCommandProvider {
     public String getStatusMessage( final UnitOfWork transaction,
                                     final KomodoObject kobject ) {
         return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.komodo.shell.api.ShellCommandProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
-     *      org.komodo.spi.repository.KomodoObject)
-     */
-    @Override
-    public String getTypeDisplay( final UnitOfWork transaction,
-                                  final KomodoObject kobject ) {
-        if ( ObjectImpl.class.equals( kobject.getClass() ) ) {
-            return KomodoObject.class.getSimpleName();
-        }
-
-        return kobject.getClass().getSimpleName();
     }
 
     /**

--- a/plugins/org.komodo.shell/src/org/komodo/shell/DefaultLabelProvider.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/DefaultLabelProvider.java
@@ -34,7 +34,7 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
 
 	private static List<String> GROUPING_NODES=new ArrayList<String>(); //default label provider has currently no grouping nodes
     protected static final String TKO_PREFIX = "tko:"; //$NON-NLS-1$
-   
+
 	/**
      * @param kobject
      *        the object being tested (cannot be <code>null</code>)
@@ -49,7 +49,7 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
                  && !WORKSPACE_PATH.equals( path ) );
     }
 
- 
+
     protected Repository repository;
     protected WorkspaceStatus status;
 
@@ -64,24 +64,11 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
 
         final String path = kobject.getAbsolutePath();
 
-        // /tko:komodo
-        if ( ROOT_PATH.equals( path ) || ROOT_SLASH_PATH.equals( path ) ) {
-            return ROOT_DISPLAY_NAME;
-        }
+        // Check whether it is workspace, library or environment
+        String areaObjectName=getNameForAreaObject(path);
 
-        // /tko:komodo/workspace
-        if ( WORKSPACE_PATH.equals( path ) || WORKSPACE_SLASH_PATH.equals( path ) ) {
-            return WORKSPACE_DISPLAY_NAME;
-        }
-
-        // /tko:komodo/library
-        if ( LIB_PATH.equals( path ) || LIB_SLASH_PATH.equals( path ) ) {
-            return LIB_DISPLAY_NAME;
-        }
-
-        // /tko:komodo/environment
-        if ( ENV_PATH.equals( path ) || ENV_SLASH_PATH.equals( path ) ) {
-            return ENV_DISPLAY_NAME;
+        if(areaObjectName != null){
+        	return areaObjectName;
         }
 
         String lastSegment = null;
@@ -90,11 +77,11 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
 		} catch (KException ex) {
 			KLog.getLogger().error( I18n.bind( ShellI18n.internalError) , ex );
 		}
-        
-        if(lastSegment == null || getGroupingNodes().contains( lastSegment )) {
+
+        if(lastSegment == null || skippedPathSegmentNames().contains( lastSegment )) {
             return null;
         }
-        
+
         if ( this.status.isShowingPropertyNamePrefixes() ) {
             final int index = lastSegment.indexOf( COLON );
 
@@ -161,7 +148,7 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
                 continue;
             }
 
-            final boolean skip = getGroupingNodes().contains( segment );
+            final boolean skip = skippedPathSegmentNames().contains( segment );
 
             if ( !firstTime && !skip ) {
                 displayPath.append( FORWARD_SLASH );
@@ -226,7 +213,7 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
                 if (StringConstants.DOT_DOT.equals(segment)) {
                     KomodoObject theParent = parent.getParent(this.status.getTransaction());
                     if(theParent!=null) {
-                        if(getGroupingNodes().contains(theParent.getName(this.status.getTransaction()))) {
+                        if(skippedPathSegmentNames().contains(theParent.getName(this.status.getTransaction()))) {
                             parent = theParent.getParent(this.status.getTransaction());
                         } else {
                             parent = theParent;
@@ -256,7 +243,7 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
                                 childFound = true;
                                 break;
                             }
-                        } else if (getGroupingNodes().contains( name )) {
+                        } else if (skippedPathSegmentNames().contains( name )) {
                             KomodoObject[] children = kid.getChildren(this.status.getTransaction(), segment);
                             if(children.length>0) {
                                 kobject = children[0];
@@ -308,30 +295,64 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
         assert( status != null );
         this.status = status;
     }
-    
+
     /**
      * {@inheritDoc}
      *
-     * @see  org.komodo.shell.api.KomodoObjectLabelProvider#getGroupingNodes(java.lang.String)
+     * @see  org.komodo.shell.api.KomodoObjectLabelProvider#skippedPathSegmentNames()
      */
 	@Override
-	public List<String> getGroupingNodes(){
+	public List<String> skippedPathSegmentNames(){
 		return GROUPING_NODES;
 	}
 
 	/**
 	 * {@inheritDoc}
-	 * 
+	 *
 	 * @see org.komodo.shell.api.KomodoObjectLabelProvider#getTypeDisplay(org.komodo.spi.repository.Repository.UnitOfWork,
 	 *      org.komodo.spi.repository.KomodoObject)
 	 */
 	@Override
 	public String getTypeDisplay(UnitOfWork uow, KomodoObject kobject) {
+
+		String areaObjectName=getNameForAreaObject(kobject.getAbsolutePath());
+		if(areaObjectName != null){
+			return areaObjectName;
+		}
+
 		if (ObjectImpl.class.equals(kobject.getClass())) {
 			return KomodoObject.class.getSimpleName();
 		}
 
 		return kobject.getClass().getSimpleName();
+	}
+	/**
+	 *
+	 * @param path Absolute path to object
+	 * @return Name of the area object (Workspace, Library,..) or null if the path doesn't lead to area object
+	 */
+	private String getNameForAreaObject(String path){
+        // /tko:komodo
+        if ( ROOT_PATH.equals( path ) || ROOT_SLASH_PATH.equals( path ) ) {
+            return ROOT_DISPLAY_NAME;
+        }
+
+        // /tko:komodo/workspace
+        if ( WORKSPACE_PATH.equals( path ) || WORKSPACE_SLASH_PATH.equals( path ) ) {
+            return WORKSPACE_DISPLAY_NAME;
+        }
+
+        // /tko:komodo/library
+        if ( LIB_PATH.equals( path ) || LIB_SLASH_PATH.equals( path ) ) {
+            return LIB_DISPLAY_NAME;
+        }
+
+        // /tko:komodo/environment
+        if ( ENV_PATH.equals( path ) || ENV_SLASH_PATH.equals( path ) ) {
+            return ENV_DISPLAY_NAME;
+        }
+
+        return null;
 	}
 
 }

--- a/plugins/org.komodo.shell/src/org/komodo/shell/DefaultLabelProvider.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/DefaultLabelProvider.java
@@ -331,7 +331,7 @@ public class DefaultLabelProvider implements KomodoObjectLabelProvider {
 	 * @param path Absolute path to object
 	 * @return Name of the area object (Workspace, Library,..) or null if the path doesn't lead to area object
 	 */
-	private String getNameForAreaObject(String path){
+	protected String getNameForAreaObject(String path){
         // /tko:komodo
         if ( ROOT_PATH.equals( path ) || ROOT_SLASH_PATH.equals( path ) ) {
             return ROOT_DISPLAY_NAME;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/ShellI18n.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/ShellI18n.java
@@ -196,6 +196,7 @@ public final class ShellI18n extends I18n {
     public static String invalidPropValue;
     public static String invalidStartupArgs;
     public static String invalidStartupFile;
+    public static String internalError;
     public static String listHeader;
     public static String localRepositoryStarting;
     public static String localRepositoryTimeoutError;

--- a/plugins/org.komodo.shell/src/org/komodo/shell/ShellI18n.properties
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/ShellI18n.properties
@@ -227,6 +227,7 @@ helpGetHelp2 = To execute a specific command, try "<command-name> <args>". Also 
 helpInvalidCommand = No help available: '%s' is not a valid command.
 helpNoAliases = None
 helpUsageHeading = USAGE
+internalError = Internal Error
 invalidArg = Invalid argument: '%s'
 invalidArgMsgEntryPath = An entry path is required.
 invalidArgMsgFileName = Please specify the command file name.

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
@@ -853,37 +853,10 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
         this.currentContextLabelProvider = (resultLabelProvider!=null) ? resultLabelProvider : defaultLabelProvider;
     }
 
-    @Override
-    public String getTypeDisplay ( final KomodoObject kObj ) {
-        if ( !this.commandFactory.getCommandProviders().isEmpty() ) {
-            ShellCommandProvider defaultProvider = null;
-
-            try {
-                for ( ShellCommandProvider provider : this.commandFactory.getCommandProviders() ) {
-                    try {
-                        if ( provider instanceof BuiltInShellCommandProvider ) {
-                            defaultProvider = provider;
-                            continue;
-                        }
-
-                        String typeString = provider.getTypeDisplay( getTransaction(), kObj );
-                        if ( typeString != null ) return typeString;
-                    } catch ( final Exception e ) {
-                        KLog.getLogger().error( "WorkspaceStatusImpl.getTypeDisplay error in provider \"{0}\"", e, provider ); //$NON-NLS-1$
-                        // continue on to next provider
-                    }
-                }
-
-                return defaultProvider.getTypeDisplay( getTransaction(), kObj );
-            } catch ( KException ex ) {
-                KLog.getLogger().error( "WorkspaceStatusImpl.getTypeDisplay error in built-in provider", ex ); //$NON-NLS-1$
-            }
-        }
-
-        assert false;
-        KLog.getLogger().error( "WorkspaceStatusImpl.getTypeDisplay: no type display found for \"{0}\"", kObj.getAbsolutePath() ); //$NON-NLS-1$
-        return kObj.getClass().getSimpleName();
-    }
+	@Override
+	public String getTypeDisplay(final KomodoObject kObj) {
+			return  getLabelProvider().getTypeDisplay(uow, kObj);
+	}
 
     @Override
     public List<String> getProvidedStatusMessages( final KomodoObject kObj ) {

--- a/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/WorkspaceStatusImpl.java
@@ -43,6 +43,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+
 import org.komodo.core.KEngine;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.repository.RepositoryImpl;
@@ -675,7 +676,7 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
             }
         }
     }
-    
+
     /* (non-Javadoc)
      * @see org.komodo.shell.api.WorkspaceStatus#setStateProperty(java.lang.String, java.lang.String)
      */
@@ -844,7 +845,7 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
         KomodoObjectLabelProvider resultLabelProvider = null;
         if(!this.alternateLabelProviders.isEmpty()) {
             for(KomodoObjectLabelProvider altProvider : this.alternateLabelProviders) {
-                if( !StringUtils.isEmpty(altProvider.getDisplayPath(context)) ) {
+                if( !StringUtils.isEmpty(altProvider.getTypeDisplay(getTransaction(),context)) ) {
                     resultLabelProvider = altProvider;
                     break;
                 }
@@ -855,7 +856,13 @@ public class WorkspaceStatusImpl implements WorkspaceStatus {
 
 	@Override
 	public String getTypeDisplay(final KomodoObject kObj) {
-			return  getLabelProvider().getTypeDisplay(uow, kObj);
+		String type=currentContextLabelProvider.getTypeDisplay(getTransaction(), kObj);
+		if(type!=null){
+			return type;
+		}else{
+			return  defaultLabelProvider.getTypeDisplay(getTransaction(), kObj);
+		}
+
 	}
 
     @Override

--- a/plugins/org.komodo.shell/src/org/komodo/shell/commands/RenameCommand.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/commands/RenameCommand.java
@@ -192,7 +192,7 @@ public class RenameCommand extends BuiltInShellCommand {
     		// --------------------------------------------------------------
     		} else {
     			for (String item : potentialsList) {
-    				if (item.toUpperCase().startsWith(lastArgument.toUpperCase())) {
+    				if (item.startsWith(lastArgument)) {
     					candidates.add(item);
     				}
     			}

--- a/plugins/org.komodo.shell/src/org/komodo/shell/util/KomodoObjectUtils.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/util/KomodoObjectUtils.java
@@ -10,6 +10,7 @@ package org.komodo.shell.util;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.komodo.repository.RepositoryTools;
 import org.komodo.shell.ShellI18n;
 import org.komodo.shell.api.KomodoObjectLabelProvider;
@@ -122,14 +123,14 @@ public class KomodoObjectUtils implements StringConstants {
                     for(String absPath : splitPaths) {
                         if(!absPath.isEmpty()) {
                             if(!first) sb.append(","); //$NON-NLS-1$
-                            sb.append(wsStatus.getCurrentContextLabelProvider().getDisplayPath(absPath));
+                            sb.append(wsStatus.getObjectLabelProvider(resolvedObj).getDisplayPath(absPath));
                             first = false;
                         }
                     }
                     sb.append("]"); //$NON-NLS-1$
                     return sb.toString();
                 } else {
-                    return wsStatus.getCurrentContextLabelProvider().getDisplayPath(displayValue);
+                    return wsStatus.getObjectLabelProvider(resolvedObj).getDisplayPath(displayValue);
                 }
             }
 
@@ -211,7 +212,7 @@ public class KomodoObjectUtils implements StringConstants {
      */
     public static String getShortName( final WorkspaceStatus wsStatus,
                                       final KomodoObject kobject ) {
-        final String name = wsStatus.getCurrentContextLabelProvider().getDisplayName( kobject );
+        final String name = wsStatus.getObjectLabelProvider(kobject).getDisplayName( kobject );
 
         if ( StringUtils.isBlank( name ) ) {
             final String[] segments = kobject.getAbsolutePath().split( FORWARD_SLASH );
@@ -342,7 +343,7 @@ public class KomodoObjectUtils implements StringConstants {
                                                                          property.getRepository(),
                                                                          value.toString() );
                 valueAsText = ( StringUtils.isBlank( path ) ? value.toString()
-                                                            : status.getCurrentContextLabelProvider().getDisplayPath( path ) );
+                                                            : status.getObjectLabelProvider(context).getDisplayPath( path ) );
             } else {
                 valueAsText = value.toString();
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/util/KomodoObjectUtils.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/util/KomodoObjectUtils.java
@@ -122,14 +122,14 @@ public class KomodoObjectUtils implements StringConstants {
                     for(String absPath : splitPaths) {
                         if(!absPath.isEmpty()) {
                             if(!first) sb.append(","); //$NON-NLS-1$
-                            sb.append(wsStatus.getLabelProvider().getDisplayPath(absPath));
+                            sb.append(wsStatus.getCurrentContextLabelProvider().getDisplayPath(absPath));
                             first = false;
                         }
                     }
                     sb.append("]"); //$NON-NLS-1$
                     return sb.toString();
                 } else {
-                    return wsStatus.getLabelProvider().getDisplayPath(displayValue);
+                    return wsStatus.getCurrentContextLabelProvider().getDisplayPath(displayValue);
                 }
             }
 
@@ -211,7 +211,7 @@ public class KomodoObjectUtils implements StringConstants {
      */
     public static String getShortName( final WorkspaceStatus wsStatus,
                                       final KomodoObject kobject ) {
-        final String name = wsStatus.getLabelProvider().getDisplayName( kobject );
+        final String name = wsStatus.getCurrentContextLabelProvider().getDisplayName( kobject );
 
         if ( StringUtils.isBlank( name ) ) {
             final String[] segments = kobject.getAbsolutePath().split( FORWARD_SLASH );
@@ -342,7 +342,7 @@ public class KomodoObjectUtils implements StringConstants {
                                                                          property.getRepository(),
                                                                          value.toString() );
                 valueAsText = ( StringUtils.isBlank( path ) ? value.toString()
-                                                            : status.getLabelProvider().getDisplayPath( path ) );
+                                                            : status.getCurrentContextLabelProvider().getDisplayPath( path ) );
             } else {
                 valueAsText = value.toString();
 

--- a/plugins/org.komodo.shell/src/org/komodo/shell/util/PrintUtils.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/util/PrintUtils.java
@@ -8,6 +8,7 @@
 package org.komodo.shell.util;
 
 import static org.komodo.shell.CompletionConstants.MESSAGE_INDENT;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.TreeMap;
+
 import org.komodo.shell.ShellI18n;
 import org.komodo.shell.api.ShellApiI18n;
 import org.komodo.shell.api.WorkspaceStatus;
@@ -397,7 +399,7 @@ public class PrintUtils implements StringConstants {
                 maxNameWidth = name.length();
             }
 
-            final String type = wsStatus.getTypeDisplay(childList.get(0));
+            final String type = wsStatus.getTypeDisplay(childList.get(i));
 
             if ( maxTypeWidth < type.length() ) {
                 maxTypeWidth = type.length();

--- a/plugins/org.komodo.shell/src/org/komodo/shell/util/PrintUtils.java
+++ b/plugins/org.komodo.shell/src/org/komodo/shell/util/PrintUtils.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import java.util.TreeMap;
 
 import org.komodo.shell.ShellI18n;
+import org.komodo.shell.api.KomodoObjectLabelProvider;
 import org.komodo.shell.api.ShellApiI18n;
 import org.komodo.shell.api.WorkspaceStatus;
 import org.komodo.spi.KException;
@@ -393,13 +394,14 @@ public class PrintUtils implements StringConstants {
 
         // loop through children getting name, type, and finding widest child name
         for ( int i = 0, size = childList.size(); i < size; ++i ) {
-            final String name = wsStatus.getLabelProvider().getDisplayName( childList.get( i ) );
+        	KomodoObjectLabelProvider labelProvider=wsStatus.getObjectLabelProvider(childList.get( i ));
+            final String name = labelProvider.getDisplayName( childList.get( i ) );
 
             if ( maxNameWidth < name.length() ) {
                 maxNameWidth = name.length();
             }
 
-            final String type = wsStatus.getTypeDisplay(childList.get(i));
+            final String type = labelProvider.getTypeDisplay(wsStatus.getTransaction(),childList.get(i));
 
             if ( maxTypeWidth < type.length() ) {
                 maxTypeWidth = type.length();
@@ -418,12 +420,14 @@ public class PrintUtils implements StringConstants {
             public int compare( final KomodoObject thisContext,
                                 final KomodoObject thatContext ) {
                 try {
+                	KomodoObjectLabelProvider thisLabelProvider=wsStatus.getObjectLabelProvider(thisContext);
+                	KomodoObjectLabelProvider thatLabelProvider=wsStatus.getObjectLabelProvider(thatContext);
                     final String thisType = wsStatus.getTypeDisplay(thisContext);
                     int result = thisType.compareTo( wsStatus.getTypeDisplay(thatContext) );
 
                     if ( result == 0 ) {
-                        final String thisName = wsStatus.getLabelProvider().getDisplayName( thisContext );
-                        final String thatName = wsStatus.getLabelProvider().getDisplayName( thatContext );
+                        final String thisName = thisLabelProvider.getDisplayName( thisContext );
+                        final String thatName = thatLabelProvider.getDisplayName( thatContext );
                         return thisName.compareTo( thatName );
                     }
 
@@ -449,8 +453,9 @@ public class PrintUtils implements StringConstants {
 
         // Print each child
         for ( final KomodoObject childContext : childList ) {
-            final String childName = wsStatus.getLabelProvider().getDisplayName( childContext );
-            final String childType = wsStatus.getTypeDisplay(childContext);
+        	KomodoObjectLabelProvider labelProvider=wsStatus.getObjectLabelProvider(childContext);
+            final String childName = labelProvider.getDisplayName( childContext );
+            final String childType = labelProvider.getTypeDisplay(wsStatus.getTransaction(),childContext);
             print( writer, MESSAGE_INDENT, String.format( format, childName, childType ) );
         }
     }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/AbstractCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/AbstractCommandTest.java
@@ -290,7 +290,7 @@ public abstract class AbstractCommandTest extends AbstractLocalRepositoryTest {
  * @param expectedCandidates expected candidas of autocompletion
  * @throws Exception
  */
-    protected void assertTabCompletion(String line, List<CharSequence> expectedCandidates) throws Exception{
+    protected void assertTabCompletion(String line, final List<? extends CharSequence> expectedCandidates) throws Exception{
     	List<CharSequence> candidates=new LinkedList<>();
     	Arguments arguments = null;
 		try {
@@ -307,7 +307,7 @@ public abstract class AbstractCommandTest extends AbstractLocalRepositoryTest {
 		command.setArguments(arguments);
 		command.tabCompletion(lastArgument, candidates);
 		String compareMessage="Expected: "+Arrays.toString(expectedCandidates.toArray())+" Actual: "+Arrays.toString(candidates.toArray());
-        assertThat("Invalid number of autocompletion candidates "+compareMessage,expectedCandidates.size(), is(candidates.size()));
+        assertThat("Invalid number of autocompletion candidates "+compareMessage,candidates.size(), is(expectedCandidates.size()));
         assertThat("Invalid elements: "+compareMessage, candidates.containsAll(expectedCandidates), is(true));
     }
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CdCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/CdCommandTest.java
@@ -16,6 +16,9 @@
 package org.komodo.shell.commands;
 
 import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+
 import org.junit.Test;
 import org.komodo.repository.RepositoryImpl;
 import org.komodo.shell.AbstractCommandTest;
@@ -71,6 +74,29 @@ public class CdCommandTest extends AbstractCommandTest {
 
         String contextPath = wsStatus.getCurrentContextDisplayPath();
         assertEquals("/workspace", contextPath);
+    }
+    
+    @Test
+    public void testTabCompleter()throws Exception{
+    	ArrayList<CharSequence> candidates=new ArrayList<>();
+       	setup("commandFiles","addChildren.cmd");
+       	assertTabCompletion("cd invalid", candidates);
+       	    
+    	candidates.add("myChild1/");
+    	candidates.add("myChild2/");
+    	assertTabCompletion("cd myCh", candidates);
+
+    	candidates.add("MyChild3/");
+    	candidates.add("..");
+    	assertTabCompletion("cd ", candidates);
+
+    	candidates.clear();
+    	candidates.add("myChild1/mySubChild1/");
+    	candidates.add("myChild1/mySubChild2/");
+    	assertTabCompletion("cd myChild1/myS", candidates);
+
+    	candidates.add("myChild1/MySubChild3/");
+    	assertTabCompletion("cd myChild1/", candidates);
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/HelpCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/HelpCommandTest.java
@@ -73,5 +73,6 @@ public class HelpCommandTest extends AbstractCommandTest {
     	assertTabCompletion("help show-s", candidates);
 
     	assertTabCompletion("help ", Arrays.asList(wsStatus.getAvailableCommandNames()));
+    	
     }
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ListCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ListCommandTest.java
@@ -16,6 +16,9 @@
 package org.komodo.shell.commands;
 
 import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
@@ -66,6 +69,29 @@ public class ListCommandTest extends AbstractCommandTest {
         // workspace is empty
         String writerOutput = getCommandOutput();
         assertTrue( writerOutput.contains( "no children" ) );
+    }
+    
+    @Test
+    public void testTabCompleter()throws Exception{
+    	ArrayList<CharSequence> candidates=new ArrayList<>();
+       	setup("commandFiles","addChildren.cmd");
+       	assertTabCompletion("list invalid", candidates);
+       	    
+    	candidates.add("myChild1/");
+    	candidates.add("myChild2/");
+    	assertTabCompletion("list myCh", candidates);
+
+    	candidates.add("MyChild3/");
+    	candidates.add("..");
+    	assertTabCompletion("list ", candidates);
+
+    	candidates.clear();
+    	candidates.add("myChild1/mySubChild1/");
+    	candidates.add("myChild1/mySubChild2/");
+    	assertTabCompletion("list myChild1/myS", candidates);
+
+    	candidates.add("myChild1/MySubChild3/");
+    	assertTabCompletion("list myChild1/", candidates);
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/RenameCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/RenameCommandTest.java
@@ -17,6 +17,9 @@ package org.komodo.shell.commands;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
@@ -60,6 +63,23 @@ public class RenameCommandTest extends AbstractCommandTest {
         final KomodoObject workspace = _repo.komodoWorkspace( getTransaction() );
         assertThat( workspace.getChildren( getTransaction() ).length, is( 1 ) );
         assertThat( workspace.getChildren( getTransaction() )[ 0 ].getName( getTransaction() ), is( newChildName ) );
+    }
+    
+    @Test
+    public void testTabCompleter()throws Exception{
+    	ArrayList<CharSequence> candidates=new ArrayList<>();
+       	setup("commandFiles","addChildren.cmd");
+       	
+    	candidates.add("myChild1");
+    	candidates.add("myChild2");
+
+    	assertTabCompletion("rename myChil", candidates);
+
+    	candidates.add("MyChild3");
+    	assertTabCompletion("rename ", candidates);
+       	
+       	
+
     }
 
 }

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ResetGlobalPropertyCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ResetGlobalPropertyCommandTest.java
@@ -81,7 +81,7 @@ public class ResetGlobalPropertyCommandTest extends AbstractCommandTest {
     @Test
     public void testTabCompleter()throws Exception{
 
-        List<CharSequence> defaultValues = new LinkedList<>(WorkspaceStatus.GLOBAL_PROPS.keySet());
+        List<String> defaultValues = new LinkedList<>(WorkspaceStatus.GLOBAL_PROPS.keySet());
         defaultValues.add(0,"--all");
         assertTabCompletion("reset-global ", defaultValues);
 

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetGlobalPropertyCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/SetGlobalPropertyCommandTest.java
@@ -68,7 +68,7 @@ public class SetGlobalPropertyCommandTest extends AbstractCommandTest {
     @Test
     public void testTabCompleter()throws Exception{
 
-        List<CharSequence> defaultValues = new LinkedList<>(WorkspaceStatus.GLOBAL_PROPS.keySet());
+        List<String> defaultValues = new LinkedList<>(WorkspaceStatus.GLOBAL_PROPS.keySet());
         assertTabCompletion("set-global ", defaultValues);
 
         defaultValues.clear();

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowSummaryCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowSummaryCommandTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
 import org.komodo.shell.api.KomodoObjectLabelProvider;
-import org.komodo.spi.repository.KomodoObject;
 
 /**
  * Test Class to test {@link ShowSummaryCommand}.
@@ -46,7 +45,7 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
         assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
-        assertThat( writerOutput, writerOutput.contains( KomodoObject.class.getSimpleName()
+        assertThat( writerOutput, writerOutput.contains( KomodoObjectLabelProvider.LIB_DISPLAY_NAME
                                                          + " '"
                                                          + KomodoObjectLabelProvider.LIB_DISPLAY_PATH
                                                          + '\'' ),
@@ -60,9 +59,9 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
         assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
-        assertThat( writerOutput, writerOutput.contains( KomodoObject.class.getSimpleName()
+        assertThat( writerOutput, writerOutput.contains( KomodoObjectLabelProvider.ROOT_DISPLAY_NAME
                                                          + " '"
-                                                         + KomodoObjectLabelProvider.ROOT_DISPLAY_NAME
+                                                         + KomodoObjectLabelProvider.ROOT_DISPLAY_PATH
                                                          + '\'' ),
                     is( true ) );
     }
@@ -75,19 +74,19 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
         assertCommandResultOk( result );
 
         String writerOutput = getCommandOutput();
-        assertThat( writerOutput, writerOutput.contains( KomodoObject.class.getSimpleName()
+        assertThat( writerOutput, writerOutput.contains( KomodoObjectLabelProvider.WORKSPACE_DISPLAY_NAME
                                                          + " '"
                                                          + KomodoObjectLabelProvider.WORKSPACE_DISPLAY_PATH
                                                          + '\'' ),
                     is( true ) );
     }
-    
+
     @Test
     public void testTabCompleter()throws Exception{
     	ArrayList<CharSequence> candidates=new ArrayList<>();
        	setup("commandFiles","addChildren.cmd");
        	assertTabCompletion("show-summary invalid", candidates);
-       	    
+
     	candidates.add("myChild1/");
     	candidates.add("myChild2/");
     	assertTabCompletion("show-summary myCh", candidates);

--- a/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowSummaryCommandTest.java
+++ b/tests/org.komodo.shell.test/src/org/komodo/shell/commands/ShowSummaryCommandTest.java
@@ -17,6 +17,9 @@ package org.komodo.shell.commands;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+
 import org.junit.Test;
 import org.komodo.shell.AbstractCommandTest;
 import org.komodo.shell.api.CommandResult;
@@ -77,6 +80,29 @@ public class ShowSummaryCommandTest extends AbstractCommandTest {
                                                          + KomodoObjectLabelProvider.WORKSPACE_DISPLAY_PATH
                                                          + '\'' ),
                     is( true ) );
+    }
+    
+    @Test
+    public void testTabCompleter()throws Exception{
+    	ArrayList<CharSequence> candidates=new ArrayList<>();
+       	setup("commandFiles","addChildren.cmd");
+       	assertTabCompletion("show-summary invalid", candidates);
+       	    
+    	candidates.add("myChild1/");
+    	candidates.add("myChild2/");
+    	assertTabCompletion("show-summary myCh", candidates);
+
+    	candidates.add("MyChild3/");
+    	candidates.add("..");
+    	assertTabCompletion("show-summary ", candidates);
+
+    	candidates.clear();
+    	candidates.add("myChild1/mySubChild1/");
+    	candidates.add("myChild1/mySubChild2/");
+    	assertTabCompletion("show-summary myChild1/myS", candidates);
+
+    	candidates.add("myChild1/MySubChild3/");
+    	assertTabCompletion("show-summary myChild1/", candidates);
     }
 
 }


### PR DESCRIPTION
For #316 and #317
I moved the grouping nodes functionality also into DefaultLabelProvider since this functionality would be useful also in base shell command. Also, all the fixes from RelationalLaberProvider were added into the DefaultLaberProvider so now the RelationalLabelProvider basically uses all methods from DefaultLaberProvider apart from features which are directly related to relational commands.

Method "getTypeDisplay" were moved from CommandProviders into the LabelProviders.  All getTypeDisplay methods from relational commands providers were consolidated into  getTypeDisplay method of RelationalLabelProvider.

I added the unit tests for tab completion of basic shell commands (It wasn't possible to do that before because the DefaultLabelProvider didn't work properly).