### PR TITLE
Support for parameters in SQL search strings

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
@@ -24,6 +24,7 @@ import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.repository.SynchronousCallback;
 import org.komodo.rest.KomodoRestV1Application.V1Constants;
 import org.komodo.rest.RestBasicEntity.ResourceNotFound;
+import org.komodo.rest.relational.RelationalMessages;
 import org.komodo.rest.relational.RestEntityFactory;
 import org.komodo.rest.relational.json.KomodoJsonMarshaller;
 import org.komodo.spi.KException;
@@ -126,6 +127,19 @@ public abstract class KomodoService implements V1Constants {
             responseEntity = errorMessage;
 
         return responseEntity;
+    }
+
+    protected Response createErrorResponse(List<MediaType> mediaTypes, Exception ex,
+                                                                       RelationalMessages.Error errorType, Object... errorMsgInputs) {
+        String errorMsg = ex.getLocalizedMessage() != null ? ex.getLocalizedMessage() : ex.getClass().getSimpleName();
+
+        if (errorMsgInputs == null || errorMsgInputs.length == 0)
+            errorMsg = RelationalMessages.getString(errorType, errorMsg);
+        else
+            errorMsg = RelationalMessages.getString(errorType, errorMsgInputs, errorMsg);
+
+        Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
+        return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
     }
 
     protected ResponseBuilder notAcceptableMediaTypesBuilder() {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoUtilService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoUtilService.java
@@ -7,6 +7,8 @@
 */
 package org.komodo.rest;
 
+import static org.komodo.rest.relational.RelationalMessages.Error.SCHEMA_SERVICE_GET_SCHEMA_ERROR;
+import static org.komodo.rest.relational.RelationalMessages.Error.VDB_SERVICE_GET_VDBS_ERROR;
 import java.io.File;
 import java.io.InputStream;
 import java.util.List;
@@ -95,6 +97,9 @@ public final class KomodoUtilService extends KomodoService {
     @GET
     @Path(V1Constants.ABOUT)
     @ApiOperation( value = "Display status of this rest service", response = String.class )
+    @ApiResponses(value = {
+        @ApiResponse(code = 403, message = "An error has occurred.")
+    })
     public Response about(final @Context HttpHeaders headers,
                                           final @Context UriInfo uriInfo) throws KomodoRestException {
         KomodoStatusObject repoStatus = new KomodoStatusObject();
@@ -130,7 +135,7 @@ public final class KomodoUtilService extends KomodoService {
         try {
             return commit(uow, mediaTypes, repoStatus);
         } catch (Exception ex) {
-            throw new KomodoRestException(ex);
+            return createErrorResponse(mediaTypes, ex, VDB_SERVICE_GET_VDBS_ERROR);
         }
     }
 
@@ -163,6 +168,9 @@ public final class KomodoUtilService extends KomodoService {
     @Produces( MediaType.APPLICATION_JSON )
     @ApiOperation(value = "Import sample data into VdbBuilder and display the status of the operation",
                              response = KomodoStatusObject.class)
+    @ApiResponses(value = {
+        @ApiResponse(code = 403, message = "An error has occurred.")
+    })
     public Response importSampleData() {
 
         KomodoStatusObject status = new KomodoStatusObject("Sample Vdb Import");
@@ -253,7 +261,8 @@ public final class KomodoUtilService extends KomodoService {
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "If ktype is not a recognised type"),
         @ApiResponse(code = 404, message = "If ktype is recognised but not associated with a teiid schema element"),
-        @ApiResponse(code = 406, message = "Only JSON is returned by this operation")
+        @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
+        @ApiResponse(code = 403, message = "An error has occurred.")
     })
     public Response getSchema( final @Context HttpHeaders headers,
                              final @Context UriInfo uriInfo,
@@ -305,9 +314,7 @@ public final class KomodoUtilService extends KomodoService {
                 throw ( KomodoRestException )e;
             }
 
-            String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            throw new KomodoRestException( RelationalMessages.getString(
-                                                                             RelationalMessages.Error.SCHEMA_SERVICE_GET_SCHEMA_ERROR, errorMsg ), e );
+            return createErrorResponse(mediaTypes, e, SCHEMA_SERVICE_GET_SCHEMA_ERROR);
         }
     }
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoSavedSearcher.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoSavedSearcher.java
@@ -21,6 +21,9 @@
  */
 package org.komodo.rest.relational;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import javax.ws.rs.core.MediaType;
 import org.komodo.rest.KRestEntity;
 import org.komodo.utils.ArgCheck;
@@ -41,9 +44,16 @@ public class KomodoSavedSearcher implements KRestEntity {
      */
     public static final String QUERY_LABEL = "query"; //$NON-NLS-1$
 
+    /**
+     * Label for the parameters
+     */
+    public static final String PARAMETER_LABEL = "parameters"; //$NON-NLS-1$
+
     private String name;
 
     private String query;
+
+    private List<String> parameters;
 
     /**
      * Default constructor for deserialization
@@ -83,6 +93,25 @@ public class KomodoSavedSearcher implements KRestEntity {
      */
     public void setQuery(String query) {
         this.query = query;
+    }
+
+    /**
+     * @return the parameters
+     */
+    public List<String> getParameters() {
+        return this.parameters;
+    }
+
+    /**
+     * Set the parameters of the object
+     *
+     * @param parameters the parameters
+     */
+    public void setParameters(Collection<String> parameters) {
+        if (parameters == null || parameters.isEmpty())
+            return;
+
+        this.parameters = new ArrayList<String>(parameters);
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoSearchService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoSearchService.java
@@ -184,7 +184,8 @@ public final class KomodoSearchService extends KomodoService {
     @ApiOperation(value = "Search the workspace using criteria",
                              response = RestBasicEntity[].class)
     @ApiResponses(value = {
-        @ApiResponse(code = 406, message = "Only JSON is returned by this operation")
+        @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
+        @ApiResponse(code = 403, message = "An error has occurred.")
     })
     public Response searchWorkspace( final @Context HttpHeaders headers,
                              final @Context UriInfo uriInfo,
@@ -253,10 +254,7 @@ public final class KomodoSearchService extends KomodoService {
                 throw (KomodoRestException)e;
             }
 
-            String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_GET_SEARCH_ERROR, errorMsg);
-            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
-            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
+            return createErrorResponse(mediaTypes, e, SEARCH_SERVICE_GET_SEARCH_ERROR);
         }
     }
 
@@ -287,7 +285,8 @@ public final class KomodoSearchService extends KomodoService {
                                           " search parameters can be added as key=value properties, eg. {param1}=people",
                              response = RestBasicEntity[].class)
     @ApiResponses(value = {
-        @ApiResponse(code = 406, message = "Only JSON is returned by this operation")
+        @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
+        @ApiResponse(code = 403, message = "An error has occurred.")
     })
     public Response searchWorkspace( final @Context HttpHeaders headers,
                              final @Context UriInfo uriInfo,
@@ -359,10 +358,7 @@ public final class KomodoSearchService extends KomodoService {
                 throw (KomodoRestException)e;
             }
 
-            String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_GET_SEARCH_ERROR, errorMsg);
-            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
-            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
+            return createErrorResponse(mediaTypes, e, SEARCH_SERVICE_GET_SEARCH_ERROR);
         }
     }
 
@@ -383,7 +379,8 @@ public final class KomodoSearchService extends KomodoService {
     @ApiOperation(value = "Fetch saved searches from the workspace",
                              response = RestBasicEntity[].class)
     @ApiResponses(value = {
-        @ApiResponse(code = 406, message = "Only JSON is returned by this operation")
+        @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
+        @ApiResponse(code = 403, message = "An error has occurred.")
     })
     public Response getSavedSearches( final @Context HttpHeaders headers,
                              final @Context UriInfo uriInfo) throws KomodoRestException {
@@ -432,10 +429,7 @@ public final class KomodoSearchService extends KomodoService {
                 throw (KomodoRestException)e;
             }
 
-            String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_WKSP_SEARCHES_ERROR, errorMsg);
-            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
-            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
+            return createErrorResponse(mediaTypes, e, SEARCH_SERVICE_WKSP_SEARCHES_ERROR);
         }
     }
 
@@ -457,7 +451,8 @@ public final class KomodoSearchService extends KomodoService {
     @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Save a search to the workspace")
     @ApiResponses(value = {
-        @ApiResponse(code = 406, message = "Only JSON is returned by this operation")
+        @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
+        @ApiResponse(code = 403, message = "An error has occurred.")
     })
     public Response saveSearch( final @Context HttpHeaders headers,
                              final @Context UriInfo uriInfo,
@@ -492,10 +487,7 @@ public final class KomodoSearchService extends KomodoService {
                 throw (KomodoRestException)e;
             }
 
-            String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_SAVE_SEARCH_ERROR, errorMsg);
-            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
-            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
+            return createErrorResponse(mediaTypes, e, SEARCH_SERVICE_SAVE_SEARCH_ERROR);
         }
     }
 
@@ -515,7 +507,8 @@ public final class KomodoSearchService extends KomodoService {
     @Produces( MediaType.APPLICATION_JSON )
     @ApiOperation(value = "Delete a search from the workspace")
     @ApiResponses(value = {
-        @ApiResponse(code = 406, message = "Only JSON is returned by this operation")
+        @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
+        @ApiResponse(code = 403, message = "An error has occurred.")
     })
     public Response deleteSavedSearch( final @Context HttpHeaders headers,
                              final @Context UriInfo uriInfo,
@@ -551,10 +544,7 @@ public final class KomodoSearchService extends KomodoService {
                 throw (KomodoRestException)e;
             }
 
-            String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_DELETE_SEARCH_ERROR, errorMsg);
-            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
-            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
+            return createErrorResponse(mediaTypes, e, SEARCH_SERVICE_DELETE_SEARCH_ERROR);
         }
     }
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoSearchService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoSearchService.java
@@ -7,11 +7,13 @@
 */
 package org.komodo.rest.relational;
 
+import static org.komodo.rest.relational.RelationalMessages.Error.SEARCH_SERVICE_DELETE_SEARCH_ERROR;
 import static org.komodo.rest.relational.RelationalMessages.Error.SEARCH_SERVICE_GET_SEARCH_ERROR;
 import static org.komodo.rest.relational.RelationalMessages.Error.SEARCH_SERVICE_SAVE_SEARCH_ERROR;
 import static org.komodo.rest.relational.RelationalMessages.Error.SEARCH_SERVICE_WKSP_SEARCHES_ERROR;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -252,7 +254,9 @@ public final class KomodoSearchService extends KomodoService {
             }
 
             String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            throw new KomodoRestException(RelationalMessages.getString(SEARCH_SERVICE_GET_SEARCH_ERROR, errorMsg), e);
+            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_GET_SEARCH_ERROR, errorMsg);
+            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
+            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
         }
     }
 
@@ -278,8 +282,9 @@ public final class KomodoSearchService extends KomodoService {
     @ApiOperation(value = "Advanced search of the workspace where the criteria is encapsulated in the request body",
                              notes = "Syntax of the json request body is of the form " +
                                           "{ searchName='x', type, parent='z', ancestor='z', path='a', contain='b', objectName='c' }" +
-                                          " where at least 1 property has been defined, " +
-                                          " parent and ancestor are mutually exclusive",
+                                          " where at least 1 property has been defined; " +
+                                          " parent and ancestor are mutually exclusive;" +
+                                          " search parameters can be added as key=value properties, eg. {param1}=people",
                              response = RestBasicEntity[].class)
     @ApiResponses(value = {
         @ApiResponse(code = 406, message = "Only JSON is returned by this operation")
@@ -322,6 +327,16 @@ public final class KomodoSearchService extends KomodoService {
                                                           sa.getPath(), sa.getContains(), sa.getObjectName());
             }
 
+            // Resolve any parameters if applicable
+            for(Map.Entry<String, String> parameter : sa.getParameters().entrySet()) {
+                String value = parameter.getValue();
+
+                // Maybe a KType used here so convert them
+                value = convertType(value);
+
+                os.setParameterValue(parameter.getKey(), value);
+            }
+
             // Execute the search
             List<KomodoObject> searchObjects = os.searchObjects(uow);
 
@@ -345,7 +360,9 @@ public final class KomodoSearchService extends KomodoService {
             }
 
             String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            throw new KomodoRestException(RelationalMessages.getString(SEARCH_SERVICE_GET_SEARCH_ERROR, errorMsg), e);
+            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_GET_SEARCH_ERROR, errorMsg);
+            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
+            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
         }
     }
 
@@ -368,7 +385,7 @@ public final class KomodoSearchService extends KomodoService {
     @ApiResponses(value = {
         @ApiResponse(code = 406, message = "Only JSON is returned by this operation")
     })
-    public Response findWorkspaceSearches( final @Context HttpHeaders headers,
+    public Response getSavedSearches( final @Context HttpHeaders headers,
                              final @Context UriInfo uriInfo) throws KomodoRestException {
 
         List<MediaType> mediaTypes = headers.getAcceptableMediaTypes();
@@ -416,7 +433,9 @@ public final class KomodoSearchService extends KomodoService {
             }
 
             String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            throw new KomodoRestException(RelationalMessages.getString(SEARCH_SERVICE_WKSP_SEARCHES_ERROR, errorMsg), e);
+            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_WKSP_SEARCHES_ERROR, errorMsg);
+            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
+            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
         }
     }
 
@@ -474,7 +493,9 @@ public final class KomodoSearchService extends KomodoService {
             }
 
             String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            throw new KomodoRestException(RelationalMessages.getString(SEARCH_SERVICE_SAVE_SEARCH_ERROR, errorMsg), e);
+            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_SAVE_SEARCH_ERROR, errorMsg);
+            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
+            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
         }
     }
 
@@ -531,7 +552,9 @@ public final class KomodoSearchService extends KomodoService {
             }
 
             String errorMsg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getClass().getSimpleName();
-            throw new KomodoRestException(RelationalMessages.getString(SEARCH_SERVICE_SAVE_SEARCH_ERROR, errorMsg), e);
+            errorMsg = RelationalMessages.getString(SEARCH_SERVICE_DELETE_SEARCH_ERROR, errorMsg);
+            Object responseEntity = createErrorResponse(mediaTypes, errorMsg);
+            return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
         }
     }
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoSearcherAttributes.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoSearcherAttributes.java
@@ -21,6 +21,9 @@
  */
 package org.komodo.rest.relational;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import javax.ws.rs.core.MediaType;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
@@ -71,6 +74,11 @@ public class KomodoSearcherAttributes implements KRestEntity {
      */
     public static final String OBJECT_NAME_LABEL = "objectName"; //$NON-NLS-1$
 
+    /**
+     * Label for the parameters
+     */
+    public static final String PARAMETERS_LABEL = "parameters"; //$NON-NLS-1$
+
     @JsonProperty(SEARCH_NAME_LABEL)
     private String searchName;
 
@@ -91,6 +99,9 @@ public class KomodoSearcherAttributes implements KRestEntity {
 
     @JsonProperty(OBJECT_NAME_LABEL)
     private String objectName;
+
+    @JsonProperty(PARAMETERS_LABEL)
+    private Map<String, String> parameters;
 
     /**
      * Default constructor for deserialization
@@ -216,6 +227,28 @@ public class KomodoSearcherAttributes implements KRestEntity {
      */
     public void setObjectName(String objectName) {
         this.objectName = objectName;
+    }
+
+    /**
+     * @return the parameters
+     */
+    public Map<String, String> getParameters() {
+        if (parameters == null)
+            return Collections.emptyMap();
+
+        return Collections.unmodifiableMap(this.parameters);
+    }
+
+    /**
+     * Add a parameter with value
+     * @param name the name
+     * @param value the value
+     */
+    public void setParameter(String name, String value) {
+        if (this.parameters == null)
+            this.parameters = new HashMap<>();
+
+        this.parameters.put(name, value);
     }
 
     @Override

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -224,6 +224,11 @@ public final class RelationalMessages {
         SEARCH_SERVICE_SAVE_SEARCH_ERROR,
 
         /**
+         * An error indicating a request to delete a saved search configuration failed
+         */
+        SEARCH_SERVICE_DELETE_SEARCH_ERROR,
+
+        /**
          * The search service lacks at least one parameter
          */
         SEARCH_SERVICE_NO_PARAMETERS_ERROR,

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -231,7 +231,12 @@ public final class RelationalMessages {
         /**
          * The search service has both parent and ancestor parameters
          */
-        SEARCH_SERVICE_PARENT_ANCESTOR_EXCLUSIVE_ERROR;
+        SEARCH_SERVICE_PARENT_ANCESTOR_EXCLUSIVE_ERROR,
+
+        /**
+         * The search service cannot parse the request body
+         */
+        SEARCH_SERVICE_REQUEST_PARSING_ERROR;
 
         /**
          * {@inheritDoc}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -24,6 +24,8 @@ package org.komodo.rest.relational;
 import static org.komodo.spi.constants.StringConstants.CLOSE_ANGLE_BRACKET;
 import static org.komodo.spi.constants.StringConstants.DOT;
 import static org.komodo.spi.constants.StringConstants.OPEN_ANGLE_BRACKET;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import org.komodo.spi.repository.KomodoType;
@@ -284,6 +286,18 @@ public final class RelationalMessages {
         }
     }
 
+    private static void expandParameters(Object parameter, List<Object> paramList) {
+        if (parameter instanceof Object[]) {
+            Object[] parameters = (Object[]) parameter;
+            for (Object param : parameters) {
+                expandParameters(param, paramList);
+            }
+            return;
+        }
+
+        paramList.add(parameter);
+    }
+
     /**
      * @param key
      *        the message key (cannot be <code>null</code>)
@@ -305,8 +319,11 @@ public final class RelationalMessages {
             return text;
         }
 
+        List<Object> expandedParam = new ArrayList<>();
+        expandParameters(parameters, expandedParam);
+
         // return formatted message
-        return String.format( text, parameters );
+        return String.format( text, expandedParam.toArray() );
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SavedSearcherSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SavedSearcherSerializer.java
@@ -8,7 +8,9 @@
 package org.komodo.rest.relational.json;
 
 import static org.komodo.rest.Messages.Error.UNEXPECTED_JSON_TOKEN;
+import static org.komodo.rest.relational.json.KomodoJsonMarshaller.BUILDER;
 import java.io.IOException;
+import java.util.Arrays;
 import org.komodo.rest.Messages;
 import org.komodo.rest.relational.KomodoSavedSearcher;
 import com.google.gson.TypeAdapter;
@@ -40,6 +42,10 @@ public final class SavedSearcherSerializer extends TypeAdapter< KomodoSavedSearc
                 case KomodoSavedSearcher.QUERY_LABEL:
                     status.setQuery(in.nextString());
                     break;
+                case KomodoSavedSearcher.PARAMETER_LABEL:
+                    final String[] parameters = BUILDER.fromJson( in, String[].class );
+                    status.setParameters(Arrays.asList(parameters));
+                    break;
                 default:
                     throw new IOException( Messages.getString( UNEXPECTED_JSON_TOKEN, name ) );
             }
@@ -67,6 +73,15 @@ public final class SavedSearcherSerializer extends TypeAdapter< KomodoSavedSearc
 
         out.name(KomodoSavedSearcher.QUERY_LABEL);
         out.value(value.getQuery());
+
+        if (value.getParameters() != null && ! value.getParameters().isEmpty()) {
+            out.name(KomodoSavedSearcher.PARAMETER_LABEL);
+            out.beginArray();
+            for (String val: value.getParameters().toArray(new String[0])) {
+                out.value(val);
+            }
+            out.endArray();
+        }
 
         out.endObject();
     }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SearcherAttributesSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/SearcherAttributesSerializer.java
@@ -7,12 +7,10 @@
 */
 package org.komodo.rest.relational.json;
 
-import static org.komodo.rest.Messages.Error.INCOMPLETE_JSON;
 import static org.komodo.rest.Messages.Error.UNEXPECTED_JSON_TOKEN;
 import java.io.IOException;
 import org.komodo.rest.Messages;
 import org.komodo.rest.relational.KomodoSearcherAttributes;
-import org.komodo.utils.StringUtils;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
@@ -21,26 +19,6 @@ import com.google.gson.stream.JsonWriter;
  * A GSON serializer/deserializer for {@status KomodoSearchObject}s.
  */
 public final class SearcherAttributesSerializer extends TypeAdapter< KomodoSearcherAttributes > {
-
-    private boolean isComplete(KomodoSearcherAttributes sa) {
-        if (sa.getSearchName() == null)
-            return false;
-
-        if (StringUtils.isBlank(sa.getAncestor()) &&
-            StringUtils.isBlank(sa.getContains()) &&
-            StringUtils.isBlank(sa.getObjectName()) &&
-            StringUtils.isBlank(sa.getParent()) &&
-            StringUtils.isBlank(sa.getPath()) &&
-            StringUtils.isBlank(sa.getType()))
-            return false;
-
-        // Mutually exclusive
-        if (! StringUtils.isBlank(sa.getAncestor()) &&
-            ! StringUtils.isBlank(sa.getParent()))
-            return false;
-
-        return true;
-    }
 
     /**
      * {@inheritDoc}
@@ -84,10 +62,6 @@ public final class SearcherAttributesSerializer extends TypeAdapter< KomodoSearc
 
         in.endObject();
 
-        if ( !isComplete( searcherAttr ) ) {
-            throw new IOException( Messages.getString( INCOMPLETE_JSON, getClass().getSimpleName() ) );
-        }
-
         return searcherAttr;
     }
 
@@ -99,10 +73,6 @@ public final class SearcherAttributesSerializer extends TypeAdapter< KomodoSearc
     @Override
     public void write( final JsonWriter out,
                        final KomodoSearcherAttributes value ) throws IOException {
-
-        if (!isComplete(value)) {
-            throw new IOException(Messages.getString(INCOMPLETE_JSON, getClass().getSimpleName()));
-        }
 
         out.beginObject();
 

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -60,5 +60,6 @@ Error.SEARCH_SERVICE_NO_PARAMETERS_ERROR = The search service requires at least 
 Error.SEARCH_SERVICE_PARENT_ANCESTOR_EXCLUSIVE_ERROR = The search service requires either the 'parent' or 'ancestor' parameter but not both
 Error.SEARCH_SERVICE_WKSP_SEARCHES_ERROR = An error occurred whilst fetching the workspace saved searches: '%s'
 Error.SEARCH_SERVICE_SAVE_SEARCH_ERROR = An error occurred whilst saving a search configuration to the repository: '%s'
+Error.SEARCH_SERVICE_DELETE_SEARCH_ERROR = An error occurred whilst deleting a saved search configuration from the repository: '%s'
 Error.SEARCH_SERVICE_REQUEST_PARSING_ERROR = An error occurred while process the request body of the search: '%s'
 Error.VDB_SERVICE_LOAD_SAMPLE_ERROR = The sample VDB '%s' failed to be imported due to the following error: '%s'

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -60,4 +60,5 @@ Error.SEARCH_SERVICE_NO_PARAMETERS_ERROR = The search service requires at least 
 Error.SEARCH_SERVICE_PARENT_ANCESTOR_EXCLUSIVE_ERROR = The search service requires either the 'parent' or 'ancestor' parameter but not both
 Error.SEARCH_SERVICE_WKSP_SEARCHES_ERROR = An error occurred whilst fetching the workspace saved searches: '%s'
 Error.SEARCH_SERVICE_SAVE_SEARCH_ERROR = An error occurred whilst saving a search configuration to the repository: '%s'
-Error.VDB_SERVICE_LOAD_SAMPLE_ERROR = The sample VDB '%s' failed to be imported due to the following error: %s
+Error.SEARCH_SERVICE_REQUEST_PARSING_ERROR = An error occurred while process the request body of the search: '%s'
+Error.VDB_SERVICE_LOAD_SAMPLE_ERROR = The sample VDB '%s' failed to be imported due to the following error: '%s'

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/AbstractKomodoServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/AbstractKomodoServiceTest.java
@@ -47,6 +47,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.komodo.core.KEngine;
 import org.komodo.repository.SynchronousCallback;
+import org.komodo.repository.search.ComparisonOperator;
 import org.komodo.repository.search.ObjectSearcher;
 import org.komodo.rest.KomodoRestV1Application;
 import org.komodo.rest.KomodoRestV1Application.V1Constants;
@@ -58,6 +59,7 @@ import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.test.utils.TestUtilities;
+import org.modeshape.jcr.ModeShapeLexicon;
 import org.modeshape.sequencer.ddl.dialect.teiid.TeiidDdlLexicon;
 import org.modeshape.sequencer.teiid.lexicon.VdbLexicon;
 
@@ -163,6 +165,17 @@ public abstract class AbstractKomodoServiceTest implements V1Constants {
         String columnSearchName = "Columns Search";
         columnsSearch.write(uow, columnSearchName);
 
+        ObjectSearcher columnsWithParamSearch = new ObjectSearcher(repository);
+        columnsWithParamSearch.addFromType(TeiidDdlLexicon.CreateTable.TABLE_ELEMENT, "c");
+        columnsWithParamSearch.addWhereCompareClause(null, "c", ModeShapeLexicon.LOCALNAME.getString(), ComparisonOperator.LIKE, "{valueParam}");
+        String columnsWithParamSearchName = "Columns Search With Where Parameter";
+        columnsWithParamSearch.write(uow, columnsWithParamSearchName);
+
+        ObjectSearcher fromParameterSearch = new ObjectSearcher(repository);
+        fromParameterSearch.addFromType("{fromTypeParam}", "c");
+        String fromParamSearchName = "From Parameter Search";
+        fromParameterSearch.write(uow, fromParamSearchName);
+
         uow.commit();
 
         if (!callback.await(3, TimeUnit.MINUTES)) {
@@ -174,6 +187,8 @@ public abstract class AbstractKomodoServiceTest implements V1Constants {
 
         searchNames.add(vdbSearchName);
         searchNames.add(columnSearchName);
+        searchNames.add(columnsWithParamSearchName);
+        searchNames.add(fromParamSearchName);
 
         return searchNames;
     }

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/KomodoSearchServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/KomodoSearchServiceTest.java
@@ -218,7 +218,7 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
     }
 
     @Test
-    public void shouldSearchByKTypeAndLocalNameParameter() throws Exception {
+    public void shouldSearchByKTypeAndLocalName() throws Exception {
         loadVdbs();
 
         // get
@@ -331,6 +331,260 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         assertEquals(searchNames.size() - 1, children.length);
         for (KomodoObject child : children) {
             assertNotEquals(searchName, child.getName(uow));
+        }
+    }
+
+    @Test
+    public void shouldAdvancedSearchForAnythingContainingView() throws Exception {
+        loadVdbs();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setContains("view");
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(19, entities.length);
+
+        for (RestBasicEntity e : entities) {
+            assertNotNull(e.getId());
+            assertNotNull(e.getBaseUri());
+            assertNotNull(e.getDataPath());
+            assertNotNull(e.getkType());
+            assertNotNull(e.hasChildren());
+            assertNotEquals(KomodoType.UNKNOWN, e.getkType());
+        }
+    }
+
+    @Test
+    public void shouldAdvancedSearchForAnyModelContainingView() throws Exception {
+        loadVdbs();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setType(VdbLexicon.Vdb.DECLARATIVE_MODEL);
+        searchAttr.setContains("view");
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(5, entities.length);
+
+        for (RestBasicEntity e : entities) {
+            assertNotNull(e.getId());
+            assertNotNull(e.getBaseUri());
+            assertNotNull(e.getDataPath());
+            assertNotNull(e.getkType());
+            assertNotNull(e.hasChildren());
+            assertEquals(KomodoType.MODEL, e.getkType());
+        }
+    }
+
+    @Test
+    public void shouldAdvancedSearchForAnyModelUnderPortfolioContainingView() throws Exception {
+        loadVdbs();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setType(VdbLexicon.Vdb.DECLARATIVE_MODEL);
+        searchAttr.setParent(PORTFOLIO_DATA_PATH);
+        searchAttr.setContains("view");
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(2, entities.length);
+
+        for (RestBasicEntity e : entities) {
+            assertNotNull(e.getId());
+            assertNotNull(e.getBaseUri());
+            assertNotNull(e.getDataPath());
+            assertNotNull(e.getkType());
+            assertNotNull(e.hasChildren());
+            assertEquals(KomodoType.MODEL, e.getkType());
+            assertTrue(e.getDataPath().startsWith(PORTFOLIO_DATA_PATH));
+        }
+    }
+
+    @Test
+    public void shouldAdvancedSearchByPath() throws Exception {
+        loadVdbs();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setPath(PORTFOLIO_DATA_PATH);
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(1, entities.length);
+
+        RestBasicEntity basicEntity = entities[0];
+        RestVdb vdb = RestEntityFactory.resolve(basicEntity, RestVdb.class);
+        assertNotNull(vdb);
+
+        assertPortfolio(vdb);
+    }
+
+    @Test
+    public void shouldAdvancedSearchByParent() throws Exception {
+        loadVdbs();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setParent(PORTFOLIO_DATA_PATH);
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(5, entities.length);
+
+        for (RestBasicEntity basicEntity : entities) {
+            RestVdbModel model = RestEntityFactory.resolve(basicEntity, RestVdbModel.class);
+            assertNotNull(model);
+        }
+    }
+
+    @Test
+    public void shouldAdvancedSearchByAncestor() throws Exception {
+        loadVdbs();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setAncestor(PORTFOLIO_DATA_PATH);
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(94, entities.length);
+
+        for (RestBasicEntity basicEntity : entities) {
+            System.out.println(basicEntity.getDataPath());
+        }
+    }
+
+    @Test
+    public void shouldAdvancedSearchByType() throws Exception {
+        loadVdbs();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setType(TeiidDdlLexicon.CreateTable.TABLE_ELEMENT);
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(38, entities.length);
+
+        for (RestBasicEntity basicEntity : entities) {
+            KomodoType kType = basicEntity.getkType();
+            assertEquals(KomodoType.COLUMN, kType);
+        }
+    }
+
+    @Test
+    public void shouldAdvancedSearchByKType() throws Exception {
+        loadVdbs();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setType(KomodoType.COLUMN.getType());
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(38, entities.length);
+
+        for (RestBasicEntity basicEntity : entities) {
+            KomodoType kType = basicEntity.getkType();
+            assertEquals(KomodoType.COLUMN, kType);
+        }
+    }
+
+    @Test
+    public void shouldAdvancedSearchByKTypeAndLocalName() throws Exception {
+        loadVdbs();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setType(KomodoType.COLUMN.getType());
+        searchAttr.setObjectName("%ID%");
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(12, entities.length);
+
+        for (RestBasicEntity basicEntity : entities) {
+            KomodoType kType = basicEntity.getkType();
+            assertEquals(KomodoType.COLUMN, kType);
+            assertTrue(basicEntity.getId().contains("ID"));
+            System.out.println(basicEntity.getDataPath());
+        }
+    }
+
+    @Test
+    public void shouldAdvancedExecuteSavedSearch()  throws Exception {
+        loadVdbs();
+        List<String> searchNames = loadSampleSearches();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setSearchName(searchNames.get(0));
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+        RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
+        assertEquals(4, entities.length);
+
+        for (RestBasicEntity basicEntity : entities) {
+            KomodoType kType = basicEntity.getkType();
+            assertEquals(KomodoType.VDB, kType);
+            System.out.println(basicEntity.getDataPath());
         }
     }
 }

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/KomodoSearchServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/KomodoSearchServiceTest.java
@@ -644,6 +644,28 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
     }
 
     @Test
+    public void shouldFailToSavedSearchDueToLackofParameter()  throws Exception {
+        loadVdbs();
+        List<String> searchNames = loadSampleSearches();
+
+        // post
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
+        searchAttr.setSearchName(searchNames.get(2));
+
+        this.response = request(uri).post(Entity.json(searchAttr));
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), this.response.getStatus());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, this.response.getMediaType());
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+        assertEquals("An error occurred whilst searching the workspace: " +
+                            "'Search requires the parameter valueParam but has not been provided a value'", entity);
+
+    }
+
+    @Test
     public void shouldAdvancedExecuteSavedSearchWithKTypeParameter()  throws Exception {
         loadVdbs();
         List<String> searchNames = loadSampleSearches();


### PR DESCRIPTION
SELECT * FROM {param1}

param1 is a parameter and will require a value to be set on the ObjectSearcher instance prior to the instance's search methods being called. This allows a search to be saved in the repository as a 'template' and executed using different parameters at runtime.