### PR TITLE
Issue 324 - adds overwrite option to server-get-vdb and server-get-datasource

### DIFF
--- a/komodo-relational-commands/src/main/java/org/komodo/relational/commands/server/ServerCommandsI18n.java
+++ b/komodo-relational-commands/src/main/java/org/komodo/relational/commands/server/ServerCommandsI18n.java
@@ -103,6 +103,7 @@ public final class ServerCommandsI18n extends I18n {
     public static String datasourceDeployFinished;
     public static String datasourceDeploymentOverwriteDisabled;
     public static String datasourceDeploymentTypeNotFound;
+    public static String datasourceOverwriteNotEnabled;
     public static String datasourceTypeDefaultValueLabel;
     public static String datasourceTypeNameLabel;
     public static String datasourceTypePropertiesHeader;
@@ -142,10 +143,11 @@ public final class ServerCommandsI18n extends I18n {
     public static String vdbDeployFailedMissingSourceJndi;
     public static String vdbDeployFinished;
     public static String vdbDeploymentOverwriteDisabled;
+    public static String vdbCopyToRepoFinished;
+    public static String vdbOverwriteNotEnabled;
+    public static String vdbUnDeployFinished;
     public static String workspaceDatasourceNotFound;
     public static String workspaceVdbNotFound;
-    public static String vdbCopyToRepoFinished;
-    public static String vdbUnDeployFinished;
 
     static {
         final ServerCommandsI18n i18n = new ServerCommandsI18n();

--- a/komodo-relational-commands/src/main/java/org/komodo/relational/commands/workspace/UploadVdbCommand.java
+++ b/komodo-relational-commands/src/main/java/org/komodo/relational/commands/workspace/UploadVdbCommand.java
@@ -86,6 +86,11 @@ public final class UploadVdbCommand extends WorkspaceShellCommand {
                 return new CommandResultImpl( false, I18n.bind( WorkspaceCommandsI18n.vdbOverwriteDisabled, fileName, vdbName ), null );
             }
 
+            // If overwriting, delete existing vdb first
+            if(hasVdb) {
+                final KomodoObject vdbToDelete = getWorkspaceManager().getChild(getTransaction(), vdbName, VdbLexicon.Vdb.VIRTUAL_DATABASE);
+                getWorkspaceManager().delete(getTransaction(), vdbToDelete);
+            }
             // create VDB
             final Vdb vdb = getWorkspaceManager().createVdb( uow, null, vdbName, fileName );
             final KomodoObject fileNode = vdb.addChild( uow, JcrLexicon.CONTENT.getString(), null );

--- a/komodo-relational-commands/src/main/resources/org/komodo/relational/commands/server/ServerCommandsI18n.properties
+++ b/komodo-relational-commands/src/main/resources/org/komodo/relational/commands/server/ServerCommandsI18n.properties
@@ -63,14 +63,18 @@ serverDisconnectHelp = \t%s - attempts to disconnect to the default server.
 serverDisconnectUsage = server-disconnect
 
 serverGetDatasourceExamples = \
-\t server-get-datasource aDatasource 
-serverGetDatasourceHelp = \t%s - gets the specified data source from the connected server and puts a copy the workspace.
-serverGetDatasourceUsage = server-get-datasource <datasource-name>
+\t server-get-datasource aDatasource \n \
+\t server-get-datasource aDatasource -o \n \
+\t server-get-datasource aDatasource --overwrite
+serverGetDatasourceHelp = \t%s - gets the specified data source from the connected server and copies it to the workspace.
+serverGetDatasourceUsage = server-get-datasource <datasource-name> [-o | --overwrite]
 
 serverGetVdbExamples = \
-\t server-get-vdb aVdb 
-serverGetVdbHelp = \t%s - gets the specified VDB from the connected server and puts a copy the workspace.
-serverGetVdbUsage = server-get-vdb <vdb-name>
+\t server-get-vdb aVdb \n \
+\t server-get-vdb aVdb -o \n \
+\t server-get-vdb aVdb --overwrite
+serverGetVdbHelp = \t%s - gets the specified VDB from the connected server and copies it to the workspace.
+serverGetVdbUsage = server-get-vdb <vdb-name> [-o | --overwrite]
 
 serverShowPropertiesExamples = \
 \t show-server-properties
@@ -129,6 +133,7 @@ datasourceCopyToRepoFinished = The data source was copied into the workspace.
 datasourceDeployFinished = The data source deployed successfully.
 datasourceDeploymentOverwriteDisabled = Data source with name '%s' cannot be deployed because it already exists on the server. Run "help server-deploy-datasource" for overwrite options.
 datasourceDeploymentTypeNotFound = A data source with type '%s' cannot be deployed - type is not found on the server.
+datasourceOverwriteNotEnabled = Cannot retrieve the server data source - a source with name '%s' already exists in the workspace. Run "help server-get-datasource" for overwrite options.
 datasourceTypeDefaultValueLabel = Default Value
 datasourceTypeNameLabel = Name
 datasourceTypePropertiesHeader = Data source template properties:\n
@@ -171,4 +176,5 @@ vdbDeploymentOverwriteDisabled = VDB with name '%s' and version '%s' cannot be d
 workspaceDatasourceNotFound = The workspace data source '%s' was not found.
 workspaceVdbNotFound = The workspace VDB '%s' was not found.
 vdbCopyToRepoFinished = The VDB was copied into the workspace.
+vdbOverwriteNotEnabled = Cannot retrieve the server VDB - a VDB with name '%s' already exists in the workspace. Run "help server-get-vdb" for overwrite options.
 vdbUnDeployFinished = The VDB undeployed successfully.

--- a/komodo-relational-commands/src/main/resources/org/komodo/relational/commands/workspace/WorkspaceCommandsI18n.properties
+++ b/komodo-relational-commands/src/main/resources/org/komodo/relational/commands/workspace/WorkspaceCommandsI18n.properties
@@ -86,11 +86,11 @@ importVdbHelp = \t%s - imports a VDB manifest from a local file.
 importVdbUsage = import-vdb <file-path>
 
 uploadDatasourceExamples = \
-\t upload-datasource myDS /path/to/datasource/myDS.xml \n \
-\t upload-datasource myDS /path/to/datasource/myDS.xml -o \n \
-\t upload-datasource myDS /path/to/datasource/myDS.xml --overwrite
-uploadDatasourceHelp = \t%s - uploads a *.xml file whose content is a set of datasources.
-uploadDatasourceUsage = upload-datasource <source-name> <local-file-path> [-o | --overwrite]
+\t upload-datasource /path/to/datasource/myDS.xml \n \
+\t upload-datasource /path/to/datasource/myDS.xml -o \n \
+\t upload-datasource /path/to/datasource/myDS.xml --overwrite
+uploadDatasourceHelp = \t%s - uploads datasources defined in a *.xml file.
+uploadDatasourceUsage = upload-datasource <local-file-path> [-o | --overwrite]
 
 uploadVdbExamples = \
 \t upload-vdb myVdb /path/to/vdb/file.xml \n \


### PR DESCRIPTION
- added overwrite options for 'server-get-vdb' and 'server-get-datasource' commands.  If a workspace object with same same already exists, user can supply the overwrite option to replace it.