### PR TITLE
Additional relational validation rules added

### DIFF
--- a/komodo-core-tests/src/test/java/org/komodo/repository/validation/ValidationManagerImplTest.java
+++ b/komodo-core-tests/src/test/java/org/komodo/repository/validation/ValidationManagerImplTest.java
@@ -26,7 +26,7 @@ public final class ValidationManagerImplTest extends AbstractLocalRepositoryTest
     private static String RULES_FILE_VERIFY_ERRORS = "verifyValidationErrors.xml";
     private static String RULES_FILE_VERIFY_UNIQUENESS_CHECKS = "verifyUniquenessChecks.xml";
     private static String RULES_FILE_ALL_CONSTRUCTS = "validationAllConstructs.xml";
-    private static String RULES_FILE_RELATIONAL_RULES = "relationalValidationRulesDefault.xml";
+    private static String RULES_FILE_RELATIONAL_EXAMPLE = "relationalRulesExample.xml";
     private static String RULES_FILE_NODE_NAME_RULE = "nodeNameRule.xml";
     private static String RULES_FILE_PROP_REQUIRED_RULE = "propRequiredRule.xml";
     private static String RULES_FILE_PROP_VALUE_RULE = "propValueRule.xml";
@@ -130,7 +130,7 @@ public final class ValidationManagerImplTest extends AbstractLocalRepositoryTest
 
     @Test
     public void shouldParseValidationRulesXmlWithNoErrors() throws Exception {
-        String testFilePath = getClass().getClassLoader().getResource(RULES_FILE_RELATIONAL_RULES).getFile();
+        String testFilePath = getClass().getClassLoader().getResource(RULES_FILE_RELATIONAL_EXAMPLE).getFile();
         final File testFile = new File( testFilePath );
         final List< String > errors = _validationMgr.validateRules( testFile );
         assertThat( errors.isEmpty(), is( true ) );
@@ -184,7 +184,6 @@ public final class ValidationManagerImplTest extends AbstractLocalRepositoryTest
         assertThat( result.isOK(), is( false ) );
         assertThat( result.getPath(), is( kobject.getAbsolutePath() ) );
         assertThat( result.getRuleId(), is( aRule.getName( getTransaction() ) ) );
-        assertThat( result.getMessage(), is( "The VDB name does not match the specified pattern." ));
     }
     
     @Test
@@ -266,7 +265,6 @@ public final class ValidationManagerImplTest extends AbstractLocalRepositoryTest
         assertThat( result.isOK(), is( false ) );
         assertThat( result.getPath(), is( kobject.getAbsolutePath() ) );
         assertThat( result.getRuleId(), is( aRule.getName( getTransaction() ) ) );
-        assertThat( result.getMessage(), is( "The VDB 'vdb:connectionType' property must match the specified pattern." ));
     }
 
     @Test
@@ -319,7 +317,6 @@ public final class ValidationManagerImplTest extends AbstractLocalRepositoryTest
         assertThat( result.isOK(), is( false ) );
         assertThat( result.getPath(), is( kobject.getAbsolutePath() ) );
         assertThat( result.getRuleId(), is( aRule.getName( getTransaction() ) ) );
-        assertThat( result.getMessage(), is( "The value of property 'vdb:version' is invalid." ));
     }
 
     @Test
@@ -372,7 +369,6 @@ public final class ValidationManagerImplTest extends AbstractLocalRepositoryTest
         assertThat( result.isOK(), is( false ) );
         assertThat( result.getPath(), is( kobject.getAbsolutePath() ) );
         assertThat( result.getRuleId(), is( aRule.getName( getTransaction() ) ) );
-        assertThat( result.getMessage(), is( "The VDB version must be between 1 and 5." ));
     }
 
     @Test

--- a/komodo-core-tests/src/test/resources/relationalRulesExample.xml
+++ b/komodo-core-tests/src/test/resources/relationalRulesExample.xml
@@ -205,6 +205,15 @@
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
         
+        <!-- The VdbImport Version property is required and must be a non-zero positive integer -->
+        <propertyValidation jcrName="vdb:version" required="true">
+            <message locale="en">Rules that validate the property 'vdb:version' of the 'vdb:importVdb' node type.
+            </message>
+            <valueValidation id="default.importVdb.version.propertyValue" severity="ERROR">
+                <description locale="en">The VdbImport 'version' property is required and must be a non-zero integer.</description>
+                <pattern>^[1-9]\d*$</pattern>
+            </valueValidation>
+        </propertyValidation>
     </nodeValidation>
 
     <!-- ================================= -->
@@ -316,6 +325,26 @@
             <description locale="en">The ModelSource name must match the specified pattern.</description>
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
+        
+        <!-- The ModelSource sourceTranslator property is required -->
+        <propertyValidation jcrName="vdb:sourceTranslator" required="true">
+            <message locale="en">Rules that validate the 'sourceTranslator' property of the 'vdb:source' node type.
+            </message>
+            <valueValidation id="default.modelSource.sourceTranslator.propertyValue" severity="ERROR">
+                <description locale="en">The ModelSource 'sourceTranslator' property is required.</description>
+                <pattern>.+</pattern>
+            </valueValidation>
+        </propertyValidation>
+        
+        <!-- The ModelSource sourceJndiName property is required -->
+        <propertyValidation jcrName="vdb:sourceJndiName" required="true">
+            <message locale="en">Rules that validate the 'sourceJndiName' property of the 'vdb:source' node type.
+            </message>
+            <valueValidation id="default.modelSource.sourceJndiName.propertyValue" severity="WARNING">
+                <description locale="en">The ModelSource 'sourceJndiName' property is required.</description>
+                <pattern>.+</pattern>
+            </valueValidation>
+        </propertyValidation>
     </nodeValidation>
 
     <!-- =========================== -->
@@ -418,6 +447,16 @@
             <description locale="en">The PrimaryKey name must match the specified pattern.</description>
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
+
+        <!-- The PrimaryKey must reference at least one column.  (tableElementRefs property is required) -->
+        <propertyValidation jcrName="tableElementRefs" required="true">
+            <message locale="en">Rules that validate the 'tableElementRefs' property of the 'teiidddl:tableElementConstraint' node type.
+            </message>
+            <valueValidation id="default.primaryKey.tableElementRefs.propertyValue" severity="ERROR">
+                <description locale="en">The PrimaryKey must reference at least one column.</description>
+                <pattern>.+</pattern>
+            </valueValidation>
+        </propertyValidation>
         
     </nodeValidation>
     
@@ -448,6 +487,16 @@
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
         
+        <!-- The UniqueConstraint must reference at least one column.  (tableElementRefs property is required) -->
+        <propertyValidation jcrName="teiidddl:tableElementRefs" required="true">
+            <message locale="en">Rules that validate the 'tableElementRefs' property of UniqueConstraints.
+            </message>
+            <valueValidation id="default.uniqueConstraint.tableElementRefs.propertyValue" severity="ERROR">
+                <description locale="en">The UniqueConstraint must reference at least one column.</description>
+                <pattern>.+</pattern>
+            </valueValidation>
+        </propertyValidation>
+        
     </nodeValidation>
 
     <!-- ================================== -->
@@ -463,6 +512,16 @@
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
         
+        <!-- The StoredProcedure nameInSource property is required and must be valid -->
+        <propertyValidation jcrName="NAMEINSOURCE" required="true">
+            <message locale="en">Rules that validate the 'NAMEINSOURCE' property of the 'vdb:storedProcedure' node type.
+            </message>
+            <valueValidation id="default.storedProcedure.nameInSource.propertyValue" severity="WARNING">
+                <description locale="en">The StoredProcedure 'NAMEINSOURCE' property is required and must match the specified pattern.</description>
+                <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern>
+            </valueValidation>
+        </propertyValidation>
+
     </nodeValidation>
 
     <!-- ================================== -->
@@ -564,18 +623,52 @@
         </nameValidation>
         
         <!-- The datatype  property is required and must be a valid datatype -->
-        <!-- 
-        <propertyValidation jcrName="vdb:datatype" required="true">
+        <propertyValidation jcrName="ddl:datatypeName" required="true">
             <message locale="en">Rules that validate the property 'vdb:datatype' of the 'vdb:parameter' node type.
             </message>
             <valueValidation id="default.parameter.datatype.propertyValue" severity="ERROR">
-                <description locale="en">The Parameter 'vdb:datatype' property must be valid.</description>
+                <description locale="en">The Parameter 'ddl:datatypeName' property is required and must match the specified pattern.</description>
                 <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
             </valueValidation>
         </propertyValidation>
-        -->
     </nodeValidation>
 
+    <!-- ====================================== -->
+    <!-- Parameter(string) Validation Rules     -->
+    <!-- ====================================== -->
+    <nodeValidation jcrName="teiidddl:procedureParameter">
+        <propRestriction value="string">ddl:datatypeName</propRestriction>
+        <message locale="en">Validation rules for the Parameters with datatype 'string'</message>
+
+        <!-- The datatype  property is required and must be a valid datatype -->
+        <propertyValidation jcrName="ddl:datatypeLength" required="true">
+            <message locale="en">Rules that validate the property 'ddl:datatypeLength' of the 'teiidddl:procedureParameter'(string) node type.
+            </message>
+            <valueRangeValidation id="default.parameter.stringDatatype.lengthPropertyValue" severity="ERROR">
+                <description locale="en">The length property of a string Parameter is required and must be 1 or greater.</description>
+                <minValue inclusive="true">1</minValue>
+            </valueRangeValidation>
+        </propertyValidation>
+    </nodeValidation>
+    
+    <!-- ======================================= -->
+    <!-- Parameter(numeric) Validation Rules     -->
+    <!-- ======================================= -->
+    <nodeValidation jcrName="teiidddl:procedureParameter">
+        <propRestriction value="decimal">ddl:datatypeName</propRestriction>
+        <message locale="en">Validation rules for the Parameters with numeric datatypes</message>
+
+        <!-- The datatype  property is required and must be a valid datatype -->
+        <propertyValidation jcrName="ddl:datatypePrecision" required="true">
+            <message locale="en">Rules that validate the property 'ddl:datatypePrecision' of numeric 'teiidddl:procedureParameter' node type.
+            </message>
+            <valueRangeValidation id="default.parameter.numericDatatype.precisionPropertyValue" severity="ERROR">
+                <description locale="en">The precision property of a numeric Parameter is required and must be 1 or greater.</description>
+                <minValue inclusive="true">1</minValue>
+            </valueRangeValidation>
+        </propertyValidation>
+    </nodeValidation>
+    
     <!-- ==================================== -->
     <!-- DataTypeResultSet Validation Rules   -->
     <!-- ==================================== -->

--- a/komodo-core/src/main/java/org/komodo/repository/validation/RuleImpl.java
+++ b/komodo-core/src/main/java/org/komodo/repository/validation/RuleImpl.java
@@ -455,16 +455,18 @@ public class RuleImpl extends ObjectImpl implements Rule {
                 final Property patternProp = getProperty( transaction, KomodoLexicon.Rule.PATTERN );
                 assert ( patternProp != null );
 
-                final String name = kobject.getName( transaction );
+                final String objName = kobject.getName( transaction );
 
-                if ( !name.matches( patternProp.getStringValue( transaction ) ) ) {
-                    args = new String[] { kobject.getName( transaction ), kobject.getAbsolutePath() };
+                if ( !objName.matches( patternProp.getStringValue( transaction ) ) ) {
+                    args = new String[] { objName, kobject.getAbsolutePath() };
 
                     // Get specific message or description
                     errorMsg = getMessageOrDescription( transaction, MessageKey.PATTERN_RULE_INVALID_NODE_NAME.name() );
                     // If rule does not have message or description for the locale, use a default.
                     if(StringUtils.isBlank(errorMsg)) {
                         errorMsg = Messages.getString( Messages.Validation.PATTERN_RULE_INVALID_NODE_NAME, ( Object[] )args );
+                    } else {
+                        errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                     }
                 }
 
@@ -504,6 +506,7 @@ public class RuleImpl extends ObjectImpl implements Rule {
             propRqd = propRequired.getBooleanValue( transaction );
         }
         
+        final String objName = kobject.getName(transaction);
         String errorMsg = null;
         String[] args = null;
         
@@ -512,8 +515,10 @@ public class RuleImpl extends ObjectImpl implements Rule {
             // Use rule description if found, otherwise use a default 'property not found' message.
             errorMsg = getDescription( transaction );
             if( StringUtils.isBlank(errorMsg) ) {
-                args = new String[] { kobject.getName( transaction ), kobject.getAbsolutePath(), propName };
+                args = new String[] { objName, kobject.getAbsolutePath(), propName };
                 errorMsg = Messages.getString( Messages.Validation.REQUIRED_PROPERTY_NOT_FOUND, ( Object[] )args );
+            } else {
+                errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
             }
             return new ResultImpl( kobject.getAbsolutePath(), getName( transaction ), getSeverity( transaction ), errorMsg );
         }
@@ -527,13 +532,15 @@ public class RuleImpl extends ObjectImpl implements Rule {
                 final String value = kobject.getProperty( transaction, propName ).getStringValue( transaction );
 
                 if ( !value.matches( patternProp.getStringValue( transaction ) ) ) {
-                    args = new String[] { kobject.getName( transaction ), kobject.getAbsolutePath(), propName };
+                    args = new String[] { objName , kobject.getAbsolutePath(), propName };
 
                     // Get specific message or description
                     errorMsg = getMessageOrDescription( transaction, MessageKey.PATTERN_RULE_INVALID_PROPERTY_VALUE.name() );
                     // If rule does not have message or description for the locale, use a default.
                     if(StringUtils.isBlank(errorMsg)) {
                         errorMsg = Messages.getString( Messages.Validation.PATTERN_RULE_INVALID_PROPERTY_VALUE, ( Object[] )args );
+                    } else {
+                        errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                     }
                 }
 
@@ -565,13 +572,15 @@ public class RuleImpl extends ObjectImpl implements Rule {
                                 final int result = Double.compare( value.doubleValue(), minValue.doubleValue() );
 
                                 if ( ( inclusive && ( result < 0 ) ) || ( !inclusive && ( result <= 0 ) ) ) {
-                                    args = new String[] { kobject.getName( transaction ), kobject.getAbsolutePath(), propName, valueString, minString };
+                                    args = new String[] { objName , kobject.getAbsolutePath(), propName, valueString, minString };
 
                                     // Get specific message or description
                                     errorMsg = getMessageOrDescription( transaction, MessageKey.PROPERTY_RULE_VALUE_BELOW_MIN_VALUE.name() );
                                     // If rule does not have message or description for the locale, use a default.
                                     if(StringUtils.isBlank(errorMsg)) {
                                         errorMsg = Messages.getString( Messages.Validation.PROPERTY_RULE_VALUE_BELOW_MIN_VALUE, ( Object[] )args );
+                                    } else {
+                                        errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                                     }
                                 }
                             }
@@ -596,13 +605,15 @@ public class RuleImpl extends ObjectImpl implements Rule {
                                     final int result = Double.compare( value.doubleValue(), maxValue.doubleValue() );
 
                                     if ( ( inclusive && ( result > 0 ) ) || ( !inclusive && ( result >= 0 ) ) ) {
-                                        args = new String[] { kobject.getName( transaction ), kobject.getAbsolutePath(), propName, valueString, maxString };
+                                        args = new String[] { objName , kobject.getAbsolutePath(), propName, valueString, maxString };
 
                                         // Get specific message or description
                                         errorMsg = getMessageOrDescription( transaction, MessageKey.PROPERTY_RULE_VALUE_ABOVE_MAX_VALUE.name() );
                                         // If rule does not have message or description for the locale, use a default.
                                         if(StringUtils.isBlank(errorMsg)) {
                                             errorMsg = Messages.getString( Messages.Validation.PROPERTY_RULE_VALUE_ABOVE_MAX_VALUE, ( Object[] )args );
+                                        } else {
+                                            errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                                         }
                                     }
                                 }
@@ -617,6 +628,8 @@ public class RuleImpl extends ObjectImpl implements Rule {
                             // If rule does not have message or description for the locale, use a default.
                             if(StringUtils.isBlank(errorMsg)) {
                                 errorMsg = Messages.getString( Messages.Validation.NUMBER_RULE_HAS_NO_VALUES, ( Object[] )args );
+                            } else {
+                                errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                             }
                         }
                     } catch ( final ParseException ex ) {
@@ -628,6 +641,8 @@ public class RuleImpl extends ObjectImpl implements Rule {
                         // If rule does not have message or description for the locale, use a default.
                         if(StringUtils.isBlank(errorMsg)) {
                             errorMsg = Messages.getString( Messages.Validation.NUMBER_RULE_NON_NUMERIC_VALUES, ( Object[] )args );
+                        } else {
+                            errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                         }
                     }
                 }
@@ -648,6 +663,8 @@ public class RuleImpl extends ObjectImpl implements Rule {
                                 // If rule does not have message or description for the locale, use a default.
                                 if(StringUtils.isBlank(errorMsg)) {
                                     errorMsg = Messages.getString( Messages.Validation.PROPERTY_RULE_REQUIRED_PROPERTY_NOT_FOUND, ( Object[] )args );
+                                } else {
+                                    errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                                 }
                                 break;
                             }
@@ -665,13 +682,15 @@ public class RuleImpl extends ObjectImpl implements Rule {
                     if ( propAbsentProp != null ) {
                         for ( final String prop : propAbsentProp.getStringValues( transaction ) ) {
                             if ( kobject.hasProperty( transaction, prop ) ) {
-                                args = new String[] { kobject.getName( transaction ), kobject.getAbsolutePath(), propName, prop };
+                                args = new String[] { objName , kobject.getAbsolutePath(), propName, prop };
 
                                 // Get specific message or description
                                 errorMsg = getMessageOrDescription( transaction, MessageKey.PROPERTY_RULE_ABSENT_PROPERTY_FOUND.name() );
                                 // If rule does not have message or description for the locale, use a default.
                                 if(StringUtils.isBlank(errorMsg)) {
                                     errorMsg = Messages.getString( Messages.Validation.PROPERTY_RULE_ABSENT_PROPERTY_FOUND, ( Object[] )args );
+                                } else {
+                                    errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                                 }
                                 break;
                             }
@@ -689,13 +708,15 @@ public class RuleImpl extends ObjectImpl implements Rule {
                     if ( childExistsProp != null ) {
                         for ( final String childType : childExistsProp.getStringValues( transaction ) ) {
                             if ( kobject.getChildrenOfType( transaction, childType ).length == 0 ) {
-                                args = new String[] { kobject.getName( transaction ), kobject.getAbsolutePath(), propName, childType };
+                                args = new String[] { objName, kobject.getAbsolutePath(), propName, childType };
 
                                 // Get specific message or description
                                 errorMsg = getMessageOrDescription( transaction, MessageKey.RELATIONSHIP_RULE_REQUIRED_CHILD_NOT_FOUND.name() );
                                 // If rule does not have message or description for the locale, use a default.
                                 if(StringUtils.isBlank(errorMsg)) {
                                     errorMsg = Messages.getString( Messages.Validation.RELATIONSHIP_RULE_REQUIRED_CHILD_NOT_FOUND, ( Object[] )args );
+                                } else {
+                                    errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                                 }
                                 break;
                             }
@@ -713,13 +734,15 @@ public class RuleImpl extends ObjectImpl implements Rule {
                     if ( childAbsentProp != null ) {
                         for ( final String childType : childAbsentProp.getStringValues( transaction ) ) {
                             if ( kobject.getChildrenOfType( transaction, childType ).length > 0 ) {
-                                args = new String[] { kobject.getName( transaction ), kobject.getAbsolutePath(), propName, childType };
+                                args = new String[] { objName , kobject.getAbsolutePath(), propName, childType };
 
                                 // Get specific message or description
                                 errorMsg = getMessageOrDescription( transaction, MessageKey.PROPERTY_RULE_ABSENT_CHILD_FOUND.name() );
                                 // If rule does not have message or description for the locale, use a default.
                                 if(StringUtils.isBlank(errorMsg)) {
                                     errorMsg = Messages.getString( Messages.Validation.PROPERTY_RULE_ABSENT_CHILD_FOUND, ( Object[] )args );
+                                } else {
+                                    errorMsg = objName + StringConstants.SPACE + StringConstants.COLON + StringConstants.SPACE + errorMsg;
                                 }
                                 break;
                             }

--- a/komodo-core/src/main/resources/komodoValidation.xsd
+++ b/komodo-core/src/main/resources/komodoValidation.xsd
@@ -47,9 +47,9 @@
             <xs:field xpath="@locale" />
         </xs:unique>
 
-        <!-- Make sure the JCR name attribute is unique across all propertyValidations -->
-        <xs:unique name="propertyValidationJcrNameKey">
-            <xs:selector xpath=".//tko:propertyValidation" />
+        <!-- Make sure the JCR name attribute is unique across all propertyValidations in the ruleSet -->
+        <xs:unique name="ruleSetPropertyValidationJcrNameKey">
+            <xs:selector xpath="tko:propertyValidation" />
             <xs:field xpath="@jcrName" />
         </xs:unique>
 
@@ -73,6 +73,12 @@
         <!-- Make sure the JCR name attribute is unique across all childValidation within nodeValidations -->
         <xs:unique name="childValidationJcrNameKey">
             <xs:selector xpath=".//tko:childValidation" />
+            <xs:field xpath="@jcrName" />
+        </xs:unique>
+        
+        <!-- Make sure the JCR name attribute is unique across all propertyValidations -->
+        <xs:unique name="propertyValidationJcrNameKey">
+            <xs:selector xpath=".//tko:propertyValidation" />
             <xs:field xpath="@jcrName" />
         </xs:unique>
         

--- a/komodo-relational-commands/src/main/java/org/komodo/relational/commands/translator/TranslatorCommandsI18n.java
+++ b/komodo-relational-commands/src/main/java/org/komodo/relational/commands/translator/TranslatorCommandsI18n.java
@@ -22,6 +22,8 @@ public final class TranslatorCommandsI18n extends I18n {
     public static String unsetTranslatorPropertyExamples;
     public static String unsetTranslatorPropertyHelp;
     public static String unsetTranslatorPropertyUsage;
+    
+    public static String cannotUnsetTranslatorType;
 
     static {
         final TranslatorCommandsI18n i18n = new TranslatorCommandsI18n();

--- a/komodo-relational-commands/src/main/java/org/komodo/relational/commands/translator/UnsetTranslatorPropertyCommand.java
+++ b/komodo-relational-commands/src/main/java/org/komodo/relational/commands/translator/UnsetTranslatorPropertyCommand.java
@@ -55,8 +55,8 @@ public final class UnsetTranslatorPropertyCommand extends TranslatorShellCommand
             if ( DESCRIPTION.equals( name ) ) {
                 translator.setDescription( transaction, null );
             // TYPE is mandatory and does not have a default so it can't be unset
-            // } else if ( TYPE.equals( name ) ) {
-            //     translator.setType( transaction, null );
+            } else if ( TYPE.equals( name ) ) {
+                errorMsg = I18n.bind( TranslatorCommandsI18n.cannotUnsetTranslatorType );
             } else {
                 errorMsg = I18n.bind( WorkspaceCommandsI18n.invalidPropertyName, name, Translator.class.getSimpleName() );
             }

--- a/komodo-relational-commands/src/main/java/org/komodo/relational/commands/vdb/ValidateVdbCommand.java
+++ b/komodo-relational-commands/src/main/java/org/komodo/relational/commands/vdb/ValidateVdbCommand.java
@@ -40,7 +40,8 @@ public final class ValidateVdbCommand extends VdbShellCommand {
     protected CommandResult doExecute() {
         
         // Default is to do a 'full' validation (validate the node and all its ancestors).  Can specify to validate this node only.
-        final boolean fullValidation = Boolean.getBoolean( optionalArgument( 0, "true" ) ); //$NON-NLS-1$
+        String fullValArg = optionalArgument( 0, Boolean.toString(true) );
+        final boolean fullValidation = Boolean.parseBoolean( fullValArg ); 
         
         try {
             Vdb vdb = getVdb();
@@ -62,17 +63,18 @@ public final class ValidateVdbCommand extends VdbShellCommand {
                 print( MESSAGE_INDENT, I18n.bind( VdbCommandsI18n.vdbValidationErrorsHeader, vdbName ) );
                 for(Result result : results) {
                     if( result.getLevel() == Outcome.Level.ERROR ) {
-                        print( MESSAGE_INDENT, result.getMessage() );
+                        print( MESSAGE_INDENT*2, result.getMessage() );
                     }
                 }
+                print();
             }
 
             // Print validation warnings
             if( hasWarnings ) {
                 print( MESSAGE_INDENT, I18n.bind( VdbCommandsI18n.vdbValidationWarningsHeader, vdbName ) );
                 for(Result result : results) {
-                    if( result.getLevel() == Outcome.Level.ERROR ) {
-                        print( MESSAGE_INDENT, result.getMessage() );
+                    if( result.getLevel() == Outcome.Level.WARNING ) {
+                        print( MESSAGE_INDENT*2, result.getMessage() );
                     }
                 }
             }
@@ -99,7 +101,7 @@ public final class ValidateVdbCommand extends VdbShellCommand {
      */
     @Override
     protected int getMaxArgCount() {
-        return 0;
+        return 1;
     }
 
     /**

--- a/komodo-relational-commands/src/main/resources/org/komodo/relational/commands/translator/TranslatorCommandsI18n.properties
+++ b/komodo-relational-commands/src/main/resources/org/komodo/relational/commands/translator/TranslatorCommandsI18n.properties
@@ -27,3 +27,5 @@ unsetTranslatorPropertyExamples = \
 \t unset-property description
 unsetTranslatorPropertyHelp = \t%s - either removes the translator property or sets it back to its default value.
 unsetTranslatorPropertyUsage = unset-property <property-name>
+
+cannotUnsetTranslatorType = The translator type cannot be unset.  Please use 'set-property'.

--- a/komodo-relational-commands/src/main/resources/org/komodo/relational/commands/vdb/VdbCommandsI18n.properties
+++ b/komodo-relational-commands/src/main/resources/org/komodo/relational/commands/vdb/VdbCommandsI18n.properties
@@ -174,7 +174,7 @@ translatorsHeader = Translators in VDB '%s': \n
 validationError = The VDB is invalid - '%s'.
 validationSuccess = VDB '%s' validated successfully!
 vdbExported = VDB '%s' was successfully exported to '%s' with override flag of '%s'
-vdbValidationErrorsHeader = Validation Errors for VDB '%s' : \n
+vdbValidationErrorsHeader = Validation Errors for VDB '%s' : 
 vdbValidationSuccessMsg = VDB '%s' is Valid!
-vdbValidationWarningsHeader = Validation Warnings for VDB '%s' : \n
+vdbValidationWarningsHeader = Validation Warnings for VDB '%s' : 
 

--- a/komodo-relational-commands/src/test/java/org/komodo/relational/commands/vdb/ValidateVdbCommandTest.java
+++ b/komodo-relational-commands/src/test/java/org/komodo/relational/commands/vdb/ValidateVdbCommandTest.java
@@ -27,11 +27,26 @@ import org.komodo.shell.api.CommandResult;
 public final class ValidateVdbCommandTest extends AbstractCommandTest {
 
     @Test
-    public void testValidateVdb() throws Exception {
+    public void testValidateVdbFull() throws Exception {
         final String[] commands = {
             "create-vdb testVdb vdbPath",
             "cd testVdb",
             "validate-vdb"};
+        final CommandResult result = execute( commands );
+        assertCommandResultOk(result);
+
+        // Check the output
+        String writerOutput = getCommandOutput();
+        assertTrue( writerOutput,
+                    writerOutput.contains( "The VDB 'vdb:connectionType' property is required and must match the specified pattern" ) );
+    }
+
+    @Test
+    public void testValidateVdb() throws Exception {
+        final String[] commands = {
+            "create-vdb testVdb vdbPath",
+            "cd testVdb",
+            "validate-vdb false"};
         final CommandResult result = execute( commands );
         assertCommandResultOk(result);
 

--- a/komodo-relational/src/main/resources/relationalValidationRulesDefault.xml
+++ b/komodo-relational/src/main/resources/relationalValidationRulesDefault.xml
@@ -205,6 +205,15 @@
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
         
+        <!-- The VdbImport Version property is required and must be a non-zero positive integer -->
+        <propertyValidation jcrName="vdb:version" required="true">
+            <message locale="en">Rules that validate the property 'vdb:version' of the 'vdb:importVdb' node type.
+            </message>
+            <valueValidation id="default.importVdb.version.propertyValue" severity="ERROR">
+                <description locale="en">The VdbImport 'version' property is required and must be a non-zero integer.</description>
+                <pattern>^[1-9]\d*$</pattern>
+            </valueValidation>
+        </propertyValidation>
     </nodeValidation>
 
     <!-- ================================= -->
@@ -316,6 +325,26 @@
             <description locale="en">The ModelSource name must match the specified pattern.</description>
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
+        
+        <!-- The ModelSource sourceTranslator property is required -->
+        <propertyValidation jcrName="vdb:sourceTranslator" required="true">
+            <message locale="en">Rules that validate the 'sourceTranslator' property of the 'vdb:source' node type.
+            </message>
+            <valueValidation id="default.modelSource.sourceTranslator.propertyValue" severity="ERROR">
+                <description locale="en">The ModelSource 'sourceTranslator' property is required.</description>
+                <pattern>.+</pattern>
+            </valueValidation>
+        </propertyValidation>
+        
+        <!-- The ModelSource sourceJndiName property is required -->
+        <propertyValidation jcrName="vdb:sourceJndiName" required="true">
+            <message locale="en">Rules that validate the 'sourceJndiName' property of the 'vdb:source' node type.
+            </message>
+            <valueValidation id="default.modelSource.sourceJndiName.propertyValue" severity="WARNING">
+                <description locale="en">The ModelSource 'sourceJndiName' property is required.</description>
+                <pattern>.+</pattern>
+            </valueValidation>
+        </propertyValidation>
     </nodeValidation>
 
     <!-- =========================== -->
@@ -418,6 +447,16 @@
             <description locale="en">The PrimaryKey name must match the specified pattern.</description>
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
+
+        <!-- The PrimaryKey must reference at least one column.  (tableElementRefs property is required) -->
+        <propertyValidation jcrName="tableElementRefs" required="true">
+            <message locale="en">Rules that validate the 'tableElementRefs' property of the 'teiidddl:tableElementConstraint' node type.
+            </message>
+            <valueValidation id="default.primaryKey.tableElementRefs.propertyValue" severity="ERROR">
+                <description locale="en">The PrimaryKey must reference at least one column.</description>
+                <pattern>.+</pattern>
+            </valueValidation>
+        </propertyValidation>
         
     </nodeValidation>
     
@@ -448,6 +487,16 @@
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
         
+        <!-- The UniqueConstraint must reference at least one column.  (tableElementRefs property is required) -->
+        <propertyValidation jcrName="teiidddl:tableElementRefs" required="true">
+            <message locale="en">Rules that validate the 'tableElementRefs' property of UniqueConstraints.
+            </message>
+            <valueValidation id="default.uniqueConstraint.tableElementRefs.propertyValue" severity="ERROR">
+                <description locale="en">The UniqueConstraint must reference at least one column.</description>
+                <pattern>.+</pattern>
+            </valueValidation>
+        </propertyValidation>
+        
     </nodeValidation>
 
     <!-- ================================== -->
@@ -463,6 +512,16 @@
             <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
         </nameValidation>
         
+        <!-- The StoredProcedure nameInSource property is required and must be valid -->
+        <propertyValidation jcrName="NAMEINSOURCE" required="true">
+            <message locale="en">Rules that validate the 'NAMEINSOURCE' property of the 'vdb:storedProcedure' node type.
+            </message>
+            <valueValidation id="default.storedProcedure.nameInSource.propertyValue" severity="WARNING">
+                <description locale="en">The StoredProcedure 'NAMEINSOURCE' property is required and must match the specified pattern.</description>
+                <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern>
+            </valueValidation>
+        </propertyValidation>
+
     </nodeValidation>
 
     <!-- ================================== -->
@@ -564,18 +623,52 @@
         </nameValidation>
         
         <!-- The datatype  property is required and must be a valid datatype -->
-        <!-- 
-        <propertyValidation jcrName="vdb:datatype" required="true">
+        <propertyValidation jcrName="ddl:datatypeName" required="true">
             <message locale="en">Rules that validate the property 'vdb:datatype' of the 'vdb:parameter' node type.
             </message>
             <valueValidation id="default.parameter.datatype.propertyValue" severity="ERROR">
-                <description locale="en">The Parameter 'vdb:datatype' property must be valid.</description>
+                <description locale="en">The Parameter 'ddl:datatypeName' property is required and must match the specified pattern.</description>
                 <pattern>^[a-zA-Z]+[a-zA-Z0-9]*$</pattern> 
             </valueValidation>
         </propertyValidation>
-        -->
     </nodeValidation>
 
+    <!-- ====================================== -->
+    <!-- Parameter(string) Validation Rules     -->
+    <!-- ====================================== -->
+    <nodeValidation jcrName="teiidddl:procedureParameter">
+        <propRestriction value="string">ddl:datatypeName</propRestriction>
+        <message locale="en">Validation rules for the Parameters with datatype 'string'</message>
+
+        <!-- The datatype  property is required and must be a valid datatype -->
+        <propertyValidation jcrName="ddl:datatypeLength" required="true">
+            <message locale="en">Rules that validate the property 'ddl:datatypeLength' of the 'teiidddl:procedureParameter'(string) node type.
+            </message>
+            <valueRangeValidation id="default.parameter.stringDatatype.lengthPropertyValue" severity="ERROR">
+                <description locale="en">The length property of a string Parameter is required and must be 1 or greater.</description>
+                <minValue inclusive="true">1</minValue>
+            </valueRangeValidation>
+        </propertyValidation>
+    </nodeValidation>
+    
+    <!-- ======================================= -->
+    <!-- Parameter(numeric) Validation Rules     -->
+    <!-- ======================================= -->
+    <nodeValidation jcrName="teiidddl:procedureParameter">
+        <propRestriction value="decimal">ddl:datatypeName</propRestriction>
+        <message locale="en">Validation rules for the Parameters with numeric datatypes</message>
+
+        <!-- The datatype  property is required and must be a valid datatype -->
+        <propertyValidation jcrName="ddl:datatypePrecision" required="true">
+            <message locale="en">Rules that validate the property 'ddl:datatypePrecision' of numeric 'teiidddl:procedureParameter' node type.
+            </message>
+            <valueRangeValidation id="default.parameter.numericDatatype.precisionPropertyValue" severity="ERROR">
+                <description locale="en">The precision property of a numeric Parameter is required and must be 1 or greater.</description>
+                <minValue inclusive="true">1</minValue>
+            </valueRangeValidation>
+        </propertyValidation>
+    </nodeValidation>
+    
     <!-- ==================================== -->
     <!-- DataTypeResultSet Validation Rules   -->
     <!-- ==================================== -->

--- a/komodo-relational/src/test/java/org/komodo/relational/validation/VdbValidationTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/validation/VdbValidationTest.java
@@ -49,7 +49,7 @@ public final class VdbValidationTest extends RelationalValidationTest {
     @Test
     public void shouldGetAllRules() throws Exception {
         final Rule[] rules = _repo.getValidationManager().getAllRules(getTransaction());
-        assertThat( rules.length, is( 42 ) );
+        assertThat( rules.length, is( 51 ) );
     }
 
     // ==============================================================================================
@@ -139,8 +139,9 @@ public final class VdbValidationTest extends RelationalValidationTest {
         VdbImport vdbImport = addVdbImport(vdb,"myImport");
 
         final Rule[] rules = _repo.getValidationManager().getRules(getTransaction(),vdbImport);
-        assertThat( rules.length, is( 1 ) );
-        assertThat( getRuleNames( rules ), hasItems( "default.importVdb.nodeName" ) );
+        assertThat( rules.length, is( 2 ) );
+        assertThat( getRuleNames( rules ), hasItems( "default.importVdb.nodeName",
+                                                     "default.importVdb.version.propertyValue") );
     }
 
     @Test
@@ -187,8 +188,10 @@ public final class VdbValidationTest extends RelationalValidationTest {
         ModelSource modelSource = addSource(model,"mySource");
 
         final Rule[] rules = _repo.getValidationManager().getRules(getTransaction(),modelSource);
-        assertThat( rules.length, is( 1 ) );
-        assertThat( getRuleNames( rules ), hasItems( "default.modelSource.nodeName" ) );
+        assertThat( rules.length, is( 3 ) );
+        assertThat( getRuleNames( rules ), hasItems( "default.modelSource.nodeName",
+                                                     "default.modelSource.sourceTranslator.propertyValue",
+                                                     "default.modelSource.sourceJndiName.propertyValue") );
     }
 
     @Test
@@ -235,8 +238,9 @@ public final class VdbValidationTest extends RelationalValidationTest {
         StoredProcedure sp = addStoredProcedure(model,"mySP");
 
         final Rule[] rules = _repo.getValidationManager().getRules(getTransaction(),sp);
-        assertThat( rules.length, is( 1 ) );
-        assertThat( getRuleNames( rules ), hasItems( "default.storedProcedure.nodeName" ) );
+        assertThat( rules.length, is( 2 ) );
+        assertThat( getRuleNames( rules ), hasItems( "default.storedProcedure.nodeName",
+                                                     "default.storedProcedure.nameInSource.propertyValue") );
     }
 
     @Test
@@ -271,8 +275,9 @@ public final class VdbValidationTest extends RelationalValidationTest {
         PrimaryKey pk = addPrimaryKey(table,"myPK");
 
         final Rule[] rules = _repo.getValidationManager().getRules(getTransaction(),pk);
-        assertThat( rules.length, is( 1 ) );
-        assertThat( getRuleNames( rules ), hasItems( "default.primaryKey.nodeName" ) );
+        assertThat( rules.length, is( 2 ) );
+        assertThat( getRuleNames( rules ), hasItems( "default.primaryKey.nodeName",
+                                                     "default.primaryKey.tableElementRefs.propertyValue") );
     }
 
     @Test
@@ -296,8 +301,9 @@ public final class VdbValidationTest extends RelationalValidationTest {
         UniqueConstraint uc = addUniqueConstraint(table,"myUC");
 
         final Rule[] rules = _repo.getValidationManager().getRules(getTransaction(),uc);
-        assertThat( rules.length, is( 1 ) );
-        assertThat( getRuleNames( rules ), hasItems( "default.uniqueConstraint.nodeName" ) );
+        assertThat( rules.length, is( 2 ) );
+        assertThat( getRuleNames( rules ), hasItems( "default.uniqueConstraint.nodeName",
+                                                     "default.uniqueConstraint.tableElementRefs.propertyValue") );
     }
 
     @Test
@@ -351,8 +357,40 @@ public final class VdbValidationTest extends RelationalValidationTest {
         Parameter param = addParameter(sp,"myParam");
 
         final Rule[] rules = _repo.getValidationManager().getRules(getTransaction(),param);
-        assertThat( rules.length, is( 1 ) );
-        assertThat( getRuleNames( rules ), hasItems( "default.parameter.nodeName" ) );
+        assertThat( rules.length, is( 2 ) );
+        assertThat( getRuleNames( rules ), hasItems( "default.parameter.nodeName",
+                                                     "default.parameter.datatype.propertyValue") );
+    }
+
+    @Test
+    public void shouldGetValidRulesForStringParameter() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+        param.setDatatypeName(getTransaction(), "string");
+
+        final Rule[] rules = _repo.getValidationManager().getRules(getTransaction(),param);
+        assertThat( rules.length, is( 3 ) );
+        assertThat( getRuleNames( rules ), hasItems( "default.parameter.nodeName",
+                                                     "default.parameter.datatype.propertyValue",
+                                                     "default.parameter.stringDatatype.lengthPropertyValue" ) );
+    }
+
+    @Test
+    public void shouldGetValidRulesForNumericParameter() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+        param.setDatatypeName(getTransaction(), "decimal");
+
+        final Rule[] rules = _repo.getValidationManager().getRules(getTransaction(),param);
+        assertThat( rules.length, is( 3 ) );
+        assertThat( rules.length, is( 3 ) );
+        assertThat( getRuleNames( rules ), hasItems( "default.parameter.nodeName",
+                                                     "default.parameter.datatype.propertyValue",
+                                                     "default.parameter.numericDatatype.precisionPropertyValue" ) );
     }
 
     @Test
@@ -468,6 +506,18 @@ public final class VdbValidationTest extends RelationalValidationTest {
         assertThat( results.length, is( 1 ) );
         assertThat( results[0].getRuleId(), is( "default.vdb.version.propertyValue" ) );
         assertThat( results[0].isOK(), is( true ));
+    }
+
+    @Test
+    public void shouldTestVdbVersionValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        vdb.setVersion(getTransaction(), -1);
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), vdb, "default.vdb.version.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.vdb.version.propertyValue" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.ERROR));
     }
 
     @Test
@@ -690,7 +740,32 @@ public final class VdbValidationTest extends RelationalValidationTest {
         assertThat( results[0].isOK(), is( false ));
         assertThat( results[0].getLevel(), is( Level.ERROR));
     }
+    
+    @Test
+    public void shouldTestVdbImportVersionValidationSuccess() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        VdbImport vdbImport = addVdbImport(vdb,"myImport");
+        vdbImport.setVersion(getTransaction(), 3);
 
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), vdbImport, "default.importVdb.version.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.importVdb.version.propertyValue" ) );
+        assertThat( results[0].isOK(), is( true ));
+    }
+    
+    @Test
+    public void shouldTestVdbImportVersionValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        VdbImport vdbImport = addVdbImport(vdb,"myImport");
+        vdbImport.setVersion(getTransaction(), -1);
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), vdbImport, "default.importVdb.version.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.importVdb.version.propertyValue" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.ERROR));
+    }
+    
     // ==============================================================================================
     // Model Validation Rules
     // ==============================================================================================
@@ -975,6 +1050,58 @@ public final class VdbValidationTest extends RelationalValidationTest {
         assertThat( results[0].isOK(), is( false ));
         assertThat( results[0].getLevel(), is( Level.ERROR));
     }
+    
+    @Test
+    public void shouldTestModelSourceTranslatorValidationSuccess() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        ModelSource modelSource = addSource(model,"mySource");
+        modelSource.setTranslatorName(getTransaction(), "oracle");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), modelSource, "default.modelSource.sourceTranslator.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.modelSource.sourceTranslator.propertyValue" ) );
+        assertThat( results[0].isOK(), is( true ));
+    }
+
+    @Test
+    public void shouldTestModelSourceTranslatorValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        ModelSource modelSource = addSource(model,"mySource");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), modelSource, "default.modelSource.sourceTranslator.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.modelSource.sourceTranslator.propertyValue" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.ERROR));
+    }
+
+    @Test
+    public void shouldTestModelSourceJndiNameValidationSuccess() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        ModelSource modelSource = addSource(model,"mySource");
+        modelSource.setJndiName(getTransaction(), "java:/test");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), modelSource, "default.modelSource.sourceJndiName.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.modelSource.sourceJndiName.propertyValue" ) );
+        assertThat( results[0].isOK(), is( true ));
+    }
+
+    @Test
+    public void shouldTestModelSourceJndiNameValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        ModelSource modelSource = addSource(model,"mySource");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), modelSource, "default.modelSource.sourceJndiName.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.modelSource.sourceJndiName.propertyValue" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.WARNING));
+    }
 
     // ==============================================================================================
     // PushdownFunction Validation Rules
@@ -1210,6 +1337,32 @@ public final class VdbValidationTest extends RelationalValidationTest {
         assertThat( results[0].getRuleId(), is( "default.storedProcedure.nodeName" ) );
         assertThat( results[0].isOK(), is( false ));
         assertThat( results[0].getLevel(), is( Level.ERROR));
+    }
+
+    @Test
+    public void shouldTestStoredProcedureNameInSourceValidationSuccess() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        sp.setNameInSource(getTransaction(), "aNIS");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), sp, "default.storedProcedure.nameInSource.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.storedProcedure.nameInSource.propertyValue" ) );
+        assertThat( results[0].isOK(), is( true ));
+    }
+
+    @Test
+    public void shouldTestStoredProcedureNameInSourceValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), sp, "default.storedProcedure.nameInSource.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.storedProcedure.nameInSource.propertyValue" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.WARNING));
     }
 
     // ==============================================================================================
@@ -1547,6 +1700,126 @@ public final class VdbValidationTest extends RelationalValidationTest {
         final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), param, "default.parameter.nodeName");
         assertThat( results.length, is( 1 ) );
         assertThat( results[0].getRuleId(), is( "default.parameter.nodeName" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.ERROR));
+    }
+
+    @Test
+    public void shouldTestParameterDatatypeValidationSuccess() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+        param.setDatatypeName(getTransaction(), "string");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), param, "default.parameter.datatype.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.parameter.datatype.propertyValue" ) );
+        assertThat( results[0].isOK(), is( true ));
+    }
+
+    @Test
+    public void shouldTestParameterDatatypeValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), param, "default.parameter.datatype.propertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.parameter.datatype.propertyValue" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.ERROR));
+    }
+
+    @Test
+    public void shouldTestStringParameterLengthValidationSuccess() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+        param.setDatatypeName(getTransaction(), "string");
+        param.setLength(getTransaction(), 1);
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), param, "default.parameter.stringDatatype.lengthPropertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.parameter.stringDatatype.lengthPropertyValue" ) );
+        assertThat( results[0].isOK(), is( true ));
+    }
+
+    @Test
+    public void shouldStringParameterNoLengthValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+        param.setDatatypeName(getTransaction(), "string");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), param, "default.parameter.stringDatatype.lengthPropertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.parameter.stringDatatype.lengthPropertyValue" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.ERROR));
+    }
+
+    @Test
+    public void shouldStringParameterWrongLengthValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+        param.setDatatypeName(getTransaction(), "string");
+        param.setLength(getTransaction(), 0);
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), param, "default.parameter.stringDatatype.lengthPropertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.parameter.stringDatatype.lengthPropertyValue" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.ERROR));
+    }
+
+    @Test
+    public void shouldTestNumericParameterPrecisionValidationSuccess() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+        param.setDatatypeName(getTransaction(), "decimal");
+        param.setPrecision(getTransaction(), 1);
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), param, "default.parameter.numericDatatype.precisionPropertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.parameter.numericDatatype.precisionPropertyValue" ) );
+        assertThat( results[0].isOK(), is( true ));
+    }
+
+    @Test
+    public void shouldTestNumericParameterNoPrecisionValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+        param.setDatatypeName(getTransaction(), "decimal");
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), param, "default.parameter.numericDatatype.precisionPropertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.parameter.numericDatatype.precisionPropertyValue" ) );
+        assertThat( results[0].isOK(), is( false ));
+        assertThat( results[0].getLevel(), is( Level.ERROR));
+    }
+
+    @Test
+    public void shouldTestNumericParameterWrongPrecisionValidationFailure() throws Exception {
+        Vdb vdb = createVdb("myVDB");
+        Model model = addModel(vdb,"myModel");
+        StoredProcedure sp = addStoredProcedure(model,"mySP");
+        Parameter param = addParameter(sp,"myParam");
+        param.setDatatypeName(getTransaction(), "decimal");
+        param.setPrecision(getTransaction(), 0);
+
+        final Result[] results = _repo.getValidationManager().evaluate(getTransaction(), param, "default.parameter.numericDatatype.precisionPropertyValue");
+        assertThat( results.length, is( 1 ) );
+        assertThat( results[0].getRuleId(), is( "default.parameter.numericDatatype.precisionPropertyValue" ) );
         assertThat( results[0].isOK(), is( false ));
         assertThat( results[0].getLevel(), is( Level.ERROR));
     }

--- a/komodo-relational/src/test/resources/vdb/invalid-vdb.xml
+++ b/komodo-relational/src/test/resources/vdb/invalid-vdb.xml
@@ -4,7 +4,7 @@
 
     <description>Invalid vdb with missing end tags for warble model</description>
 
-    <model name="warble" type="PHYSICAL">
-        <source name="warble" translator-name="rest" connection-jndi-name="java:/twitterDS"/>
-    </model>
+    <model name="warble" type="PHYSICAL"
+        <source name="warble" translator-name="rest" connection-jndi-name="java:/twitterDS"
+    </model
 </vdb>

--- a/komodo-ui/.classpath
+++ b/komodo-ui/.classpath
@@ -22,7 +22,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/komodo-ui/pom.xml
+++ b/komodo-ui/pom.xml
@@ -22,23 +22,6 @@
     <name>Komodo Core UI Frameworks and Utilities</name>
     <packaging>jar</packaging>
 
-
-    <!-- ================================================================== -->
-    <!-- Build -->
-    <!-- ================================================================== -->
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
     <!-- ================================================================== -->
     <!-- Dependencies -->
     <!-- ================================================================== -->


### PR DESCRIPTION
- Additional default rules added for relational object validation.  Added unit tests.
- improved rule messages by including the name of the object
- komodoValidation.xsd tweaked - some property jcrNames (such as 'version') are repeated in different objects, which was resulting in duplication errors.
- improved messages in UnsetTranslatorPropertyCommand
- fix problem with ValidateVdbCommand overwrite arg and add unit test
- reverts previous change to invalid-vdb.xml which broke a unit test.