### PR TITLE
Teiid dashboard

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/teiid/internal/TeiidImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/teiid/internal/TeiidImpl.java
@@ -42,6 +42,7 @@ import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.vdb.internal.TranslatorImpl;
 import org.komodo.relational.vdb.internal.VdbImpl;
 import org.komodo.relational.workspace.ServerManager;
+import org.komodo.repository.SynchronousCallback;
 import org.komodo.spi.KException;
 import org.komodo.spi.query.TeiidService;
 import org.komodo.spi.repository.KomodoObject;
@@ -67,6 +68,7 @@ import org.komodo.spi.runtime.version.DefaultTeiidVersion;
 import org.komodo.spi.runtime.version.TeiidVersion;
 import org.komodo.spi.runtime.version.TeiidVersionProvider;
 import org.komodo.utils.ArgCheck;
+import org.komodo.utils.KLog;
 import org.komodo.utils.StringUtils;
 import org.modeshape.jcr.JcrLexicon;
 import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
@@ -74,7 +76,7 @@ import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
 /**
  * Implementation of teiid instance model
  */
-public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid, EventManager {
+public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid, TeiidParent, EventManager {
 
     private class TeiidJdbcInfoImpl implements TeiidJdbcInfo {
 
@@ -85,7 +87,7 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
 
         @Override
         public HostProvider getHostProvider() {
-            return teiidParent;
+            return TeiidImpl.this;
         }
 
         @Override
@@ -118,82 +120,115 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
 
         @Override
         public int getPort() {
-            try {
-                return getJdbcPort(transaction);
-            } catch (KException ex) {
-                KEngine.getInstance().getErrorHandler().error(ex);
-                return DEFAULT_PORT;
-            }
+            return TeiidImpl.this.getPort();
         }
 
         @Override
         public void setPort( int port ) {
+            UnitOfWork uow = null;
             try {
-                setJdbcPort(transaction, port);
+               uow = getOrCreateTransaction();
+               setJdbcPort(uow, port);
+               commit(uow);
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
+                if (uow != null)
+                    uow.rollback();
             }
         }
 
         @Override
         public String getUsername() {
+            UnitOfWork uow = null;
             try {
-                return getJdbcUsername(transaction);
+               uow = getOrCreateTransaction();
+               String user = getJdbcUsername(uow);
+               commit(uow);
+               return user;
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
-                return DEFAULT_JDBC_USERNAME;
+                if (uow != null)
+                    uow.rollback();
+                return null;
             }
         }
 
         @Override
         public void setUsername( String userName ) {
+            UnitOfWork uow = null;
             try {
-                setJdbcUsername(transaction, userName);
+               uow = getOrCreateTransaction();
+               setJdbcUsername(uow, userName);
+               commit(uow);
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
+                if (uow != null)
+                    uow.rollback();
             }
         }
 
         @Override
         public String getPassword() {
+            UnitOfWork uow = null;
             try {
-                return getJdbcPassword(transaction);
+               uow = getOrCreateTransaction();
+               String passwd = getJdbcPassword(uow);
+               commit(uow);
+               return passwd;
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
-                return DEFAULT_JDBC_PASSWORD;
+                if (uow != null)
+                    uow.rollback();
+                return null;
             }
         }
 
         @Override
         public void setPassword( String password ) {
+            UnitOfWork uow = null;
             try {
-                setJdbcPassword(transaction, password);
+               uow = getOrCreateTransaction();
+               setJdbcPassword(uow, password);
+               commit(uow);
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
+                if (uow != null)
+                    uow.rollback();
             }
         }
 
         @Override
         public boolean isSecure() {
+            UnitOfWork uow = null;
             try {
-                return isJdbcSecure(transaction);
+               uow = getOrCreateTransaction();
+               boolean secure = isJdbcSecure(uow);
+               commit(uow);
+               return secure;
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
-                return DEFAULT_SECURE;
+                if (uow != null)
+                    uow.rollback();
+                return false;
             }
         }
 
         @Override
         public void setSecure( boolean secure ) {
+            UnitOfWork uow = null;
             try {
-                setJdbcSecure(transaction, secure);
+               uow = getOrCreateTransaction();
+               setJdbcSecure(uow, secure);
+               commit(uow);
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
+                if (uow != null)
+                    uow.rollback();
             }
         }
     }
 
-    private class TeiidAdminInfoImpl implements TeiidAdminInfo {
+    class TeiidAdminInfoImpl implements TeiidAdminInfo {
 
         @Override
         public ConnectivityType getType() {
@@ -213,7 +248,7 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
 
         @Override
         public HostProvider getHostProvider() {
-            return teiidParent;
+            return TeiidImpl.this;
         }
 
         @Override
@@ -223,172 +258,82 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
 
         @Override
         public int getPort() {
-            try {
-                return getAdminPort(transaction);
-            } catch (KException ex) {
-                KEngine.getInstance().getErrorHandler().error(ex);
-                return DEFAULT_PORT;
-            }
+            return TeiidImpl.this.getPort();
         }
 
         @Override
         public void setPort( int port ) {
+            UnitOfWork uow = null;
             try {
-                setAdminPort(transaction, port);
+               uow = getOrCreateTransaction();
+               setAdminPort(uow, port);
+               commit(uow);
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
+                if (uow != null)
+                    uow.rollback();
             }
         }
 
         @Override
         public String getUsername() {
-            try {
-                return getAdminUser(transaction);
-            } catch (KException ex) {
-                KEngine.getInstance().getErrorHandler().error(ex);
-                return DEFAULT_ADMIN_USERNAME;
-            }
+            return TeiidImpl.this.getUsername();
         }
 
         @Override
         public void setUsername( String userName ) {
+            UnitOfWork uow = null;
             try {
-                setAdminUser(transaction, userName);
+               uow = getOrCreateTransaction();
+               setAdminUser(uow, userName);
+               commit(uow);
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
+                if (uow != null)
+                    uow.rollback();
             }
         }
 
         @Override
         public String getPassword() {
-            try {
-                return getAdminPassword(transaction);
-            } catch (KException ex) {
-                KEngine.getInstance().getErrorHandler().error(ex);
-                return DEFAULT_ADMIN_PASSWORD;
-            }
+            return TeiidImpl.this.getPassword();
         }
 
         @Override
         public void setPassword( String password ) {
+            UnitOfWork uow = null;
             try {
-                setAdminPassword(transaction, password);
+               uow = getOrCreateTransaction();
+               setAdminPassword(uow, password);
+               commit(uow);
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
+                if (uow != null)
+                    uow.rollback();
             }
         }
 
         @Override
         public boolean isSecure() {
-            try {
-                return isAdminSecure(transaction);
-            } catch (KException ex) {
-                KEngine.getInstance().getErrorHandler().error(ex);
-                return DEFAULT_SECURE;
-            }
+            return TeiidImpl.this.isSecure();
         }
 
         @Override
         public void setSecure( boolean secure ) {
+            UnitOfWork uow = null;
             try {
-                setAdminSecure(transaction, secure);
+               uow = getOrCreateTransaction();
+               setAdminSecure(uow, secure);
+               commit(uow);
             } catch (KException ex) {
                 KEngine.getInstance().getErrorHandler().error(ex);
+                if (uow != null)
+                    uow.rollback();
             }
         }
     }
 
-    private class TeiidParentImpl implements TeiidParent {
-
-        private TeiidInstance teiidInstance;
-
-        @Override
-        public TeiidInstance getTeiidInstance(TeiidVersion teiidVersion) {
-            if (teiidInstance == null) {
-                try {
-                    TeiidService teiidService = PluginService.getInstance().getTeiidService(teiidVersion);
-                    teiidInstance = teiidService.getTeiidInstance(this, jdbcInfo);
-                } catch (Exception ex) {
-                    KEngine.getInstance().getErrorHandler().error(ex);
-                    return null;
-                }
-            }
-
-            return teiidInstance;
-        }
-
-        @Override
-        public String getHost() {
-            try {
-                return TeiidImpl.this.getHost(transaction);
-            } catch (KException ex) {
-                KEngine.getInstance().getErrorHandler().error(ex);
-                return null;
-            }
-        }
-
-        @Override
-        public Teiid getParentObject() {
-            return TeiidImpl.this;
-        }
-
-        @Override
-        public String getId() {
-            return null;
-        }
-
-        @Override
-        public String getName() {
-            try {
-                return TeiidImpl.this.getName(transaction);
-            } catch (KException ex) {
-                KEngine.getInstance().getErrorHandler().error(ex);
-                return null;
-            }
-        }
-
-        @Override
-        public int getPort() {
-            return adminInfo.getPort();
-        }
-
-        @Override
-        public String getUsername() {
-            return adminInfo.getUsername();
-        }
-
-        @Override
-        public String getPassword() {
-            return adminInfo.getPassword();
-        }
-
-        @Override
-        public boolean isSecure() {
-            return adminInfo.isSecure();
-        }
-
-        @Override
-        public EventManager getEventManager() {
-            return TeiidImpl.this;
-        }
-    }
-
-    /**
-     * Admin info of the teiid connection
-     */
-    private final TeiidAdminInfoImpl adminInfo;
-
-    /**
-     * JDBC info of the teiid connection
-     */
-    private final TeiidJdbcInfoImpl jdbcInfo;
-
-    /**
-     * Parent of the teiid instance
-     */
-    private final TeiidParentImpl teiidParent;
-
-    private UnitOfWork transaction;
+    private volatile UnitOfWork currentTransaction = null;
 
     /**
      * @param uow
@@ -404,9 +349,49 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
                       final Repository repository,
                       final String path ) throws KException {
         super(uow, repository, path);
-        adminInfo = new TeiidAdminInfoImpl();
-        jdbcInfo = new TeiidJdbcInfoImpl();
-        teiidParent = new TeiidParentImpl();
+    }
+
+    /**
+     * @return the new transaction (never <code>null</code>)
+     * @throws KException
+     *         if there is an error creating the transaction
+     */
+    protected UnitOfWork createTransaction() throws KException {
+        final SynchronousCallback callback = new SynchronousCallback();
+        final UnitOfWork result = getRepository().createTransaction(
+                                                                    ( getClass().getSimpleName() + System.currentTimeMillis() ),
+                                                                        false, callback );
+        LOGGER.debug( "createTransaction:created '{0}', rollbackOnly = '{1}'", result.getName(), result.isRollbackOnly() ); //$NON-NLS-1$
+        return result;
+    }
+
+    private void setCurrentTransaction(UnitOfWork currentTransaction) {
+        this.currentTransaction = currentTransaction;
+    }
+
+    private UnitOfWork getOrCreateTransaction() throws KException {
+        if (currentTransaction == null)
+            return createTransaction();
+
+        if (State.NOT_STARTED != currentTransaction.getState()) {
+            //
+            // current tx is no longer valid since its been committed / rolled back
+            //
+            currentTransaction = null;
+            return createTransaction();
+        }
+
+        return currentTransaction;
+    }
+
+    private void commit(UnitOfWork uow) {
+        if (uow == currentTransaction)
+            return; // Don't commit transaction as its being stashed for the moment
+
+        if (! uow.getName().startsWith(getClass().getSimpleName()))
+            return;
+
+        uow.commit();
     }
 
     @Override
@@ -414,9 +399,47 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
         return Teiid.IDENTIFIER;
     }
 
+    protected TeiidInstance getTeiidInstance(UnitOfWork uow, TeiidVersion teiidVersion) {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        try {
+            TeiidService teiidService = PluginService.getInstance().getTeiidService(teiidVersion);
+            TeiidJdbcInfo jdbcInfo = new TeiidJdbcInfoImpl();
+
+            //
+            // The teiid service defers back to this class (as the TeiidParent) for
+            // various settings and we want to try and keep it in the same
+            // transaction if we can
+            //
+            setCurrentTransaction(uow);
+
+            return teiidService.getTeiidInstance(this, jdbcInfo);
+        } catch (Exception ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            return null;
+        }
+    }
+
+    @Override
+    public TeiidInstance getTeiidInstance(TeiidVersion teiidVersion) {
+        UnitOfWork uow = null;
+        try {
+           uow = getOrCreateTransaction();
+           TeiidInstance teiidInstance = getTeiidInstance(uow, teiidVersion);
+           commit(uow);
+           return teiidInstance;
+        } catch (KException ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            return null;
+        }
+    }
+
     @Override
     public TeiidInstance getTeiidInstance(UnitOfWork uow) {
-        this.transaction = uow;
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         TeiidVersion version = null;
         try {
             version = getVersion(uow);
@@ -425,7 +448,7 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
             version = TeiidVersionProvider.getInstance().getTeiidVersion();
         }
 
-        return teiidParent.getTeiidInstance(version);
+        return getTeiidInstance(uow, version);
     }
 
     /**
@@ -437,6 +460,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public TeiidVersion getVersion( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         String version = getObjectProperty(uow, PropertyValueType.STRING, "getVersion", TeiidArchetype.VERSION); //$NON-NLS-1$
         return version != null ? new DefaultTeiidVersion(version) : TeiidVersionProvider.getInstance().getTeiidVersion();
     }
@@ -450,6 +476,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public void setVersion(UnitOfWork uow, TeiidVersion version) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setVersion", TeiidArchetype.VERSION, version.toString()); //$NON-NLS-1$
     }
 
@@ -479,6 +508,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public String getHost( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         String host = getObjectProperty(uow, PropertyValueType.STRING, "getHost", TeiidArchetype.HOST); //$NON-NLS-1$
         return host != null ? host : HostProvider.DEFAULT_HOST;
     }
@@ -492,6 +524,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public void setHost(UnitOfWork uow, String host) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setHost", TeiidArchetype.HOST, host); //$NON-NLS-1$
     }
 
@@ -504,6 +539,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public int getAdminPort( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         Long port = getObjectProperty(uow, PropertyValueType.LONG, "getAdminPort", TeiidArchetype.ADMIN_PORT); //$NON-NLS-1$
         return port != null ? port.intValue() : TeiidAdminInfo.DEFAULT_PORT;
     }
@@ -517,8 +555,10 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      *         if error occurs
      */
     @Override
-    public void setAdminPort( UnitOfWork uow,
-                              int port ) throws KException {
+    public void setAdminPort( UnitOfWork uow, int port ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setAdminPort", TeiidArchetype.ADMIN_PORT, port); //$NON-NLS-1$
     }
 
@@ -531,6 +571,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public String getAdminUser( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         String user = getObjectProperty(uow, PropertyValueType.STRING, "getAdminUser", TeiidArchetype.ADMIN_USER); //$NON-NLS-1$
         return user != null ? user : TeiidAdminInfo.DEFAULT_ADMIN_USERNAME;
     }
@@ -544,8 +587,10 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      *         if error occurs
      */
     @Override
-    public void setAdminUser( UnitOfWork uow,
-                              String userName ) throws KException {
+    public void setAdminUser( UnitOfWork uow, String userName ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setAdminUser", TeiidArchetype.ADMIN_USER, userName); //$NON-NLS-1$
     }
 
@@ -558,6 +603,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public String getAdminPassword( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         String password = getObjectProperty(uow, PropertyValueType.STRING, "getAdminPassword", TeiidArchetype.ADMIN_PSWD); //$NON-NLS-1$
         return password != null ? password : TeiidAdminInfo.DEFAULT_ADMIN_PASSWORD;
     }
@@ -573,6 +621,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
     @Override
     public void setAdminPassword( UnitOfWork uow,
                                   String password ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setAdminPassword", TeiidArchetype.ADMIN_PSWD, password); //$NON-NLS-1$
     }
 
@@ -595,6 +646,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public boolean isAdminSecure( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         Boolean secure = getObjectProperty(uow, PropertyValueType.BOOLEAN, "isSecure", TeiidArchetype.ADMIN_SECURE); //$NON-NLS-1$
         return secure != null ? secure : TeiidAdminInfo.DEFAULT_SECURE;
     }
@@ -608,8 +662,10 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      *         if error occurs
      */
     @Override
-    public void setAdminSecure( UnitOfWork uow,
-                                boolean secure ) throws KException {
+    public void setAdminSecure( UnitOfWork uow, boolean secure ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setAdminSecure", TeiidArchetype.ADMIN_SECURE, secure); //$NON-NLS-1$
     }
 
@@ -622,6 +678,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public int getJdbcPort( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         Long port = getObjectProperty(uow, PropertyValueType.LONG, "getPort", TeiidArchetype.JDBC_PORT); //$NON-NLS-1$
         return port != null ? port.intValue() : TeiidJdbcInfo.DEFAULT_PORT;
     }
@@ -635,8 +694,10 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      *         if error occurs
      */
     @Override
-    public void setJdbcPort( UnitOfWork uow,
-                             int port ) throws KException {
+    public void setJdbcPort( UnitOfWork uow, int port ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setPort", TeiidArchetype.JDBC_PORT, port); //$NON-NLS-1$
     }
 
@@ -649,6 +710,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public String getJdbcUsername( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         String user = getObjectProperty(uow, PropertyValueType.STRING, "getUsername", TeiidArchetype.JDBC_USER); //$NON-NLS-1$
         return user != null ? user : TeiidJdbcInfo.DEFAULT_JDBC_USERNAME;
     }
@@ -662,8 +726,10 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      *         if error occurs
      */
     @Override
-    public void setJdbcUsername( UnitOfWork uow,
-                                 String userName ) throws KException {
+    public void setJdbcUsername( UnitOfWork uow, String userName ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setUsername", TeiidArchetype.JDBC_USER, userName); //$NON-NLS-1$
     }
 
@@ -676,6 +742,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public String getJdbcPassword( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         String password = getObjectProperty(uow, PropertyValueType.STRING, "getPassword", TeiidArchetype.JDBC_PSWD); //$NON-NLS-1$
         return password != null ? password : TeiidJdbcInfo.DEFAULT_JDBC_PASSWORD;
     }
@@ -689,8 +758,10 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      *         if error occurs
      */
     @Override
-    public void setJdbcPassword( UnitOfWork uow,
-                                 String password ) throws KException {
+    public void setJdbcPassword( UnitOfWork uow, String password ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setPassword", TeiidArchetype.JDBC_PSWD, password); //$NON-NLS-1$
     }
 
@@ -703,6 +774,9 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      */
     @Override
     public boolean isJdbcSecure( UnitOfWork uow ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         Boolean secure = getObjectProperty(uow, PropertyValueType.BOOLEAN, "isSecure", TeiidArchetype.JDBC_SECURE); //$NON-NLS-1$
         return secure != null ? secure : TeiidJdbcInfo.DEFAULT_SECURE;
     }
@@ -716,8 +790,10 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
      *         if error occurs
      */
     @Override
-    public void setJdbcSecure( UnitOfWork uow,
-                               boolean secure ) throws KException {
+    public void setJdbcSecure( UnitOfWork uow, boolean secure ) throws KException {
+        ArgCheck.isNotNull( uow, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( uow.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
         setObjectProperty(uow, "setSecure", TeiidArchetype.JDBC_SECURE, secure); //$NON-NLS-1$
     }
 
@@ -730,6 +806,7 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
     @Override
     public CachedTeiid importContent(UnitOfWork transaction) throws KException {
         ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
 
         ServerManager mgr = ServerManager.getInstance(getRepository());
         CachedTeiid cachedTeiid = mgr.createCachedTeiid(transaction, this);
@@ -848,6 +925,235 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
     @Override
     public boolean removeListener( ExecutionConfigurationListener listener ) {
         return false;
+    }
+
+    @Override
+    public String getHost() {
+        UnitOfWork uow = null;
+        try {
+           uow = getOrCreateTransaction();
+           String host = getHost(uow);
+           commit(uow);
+           return host;
+        } catch (KException ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            if (uow != null)
+                uow.rollback();
+            return null;
+        }
+    }
+
+    @Override
+    public int getPort() {
+        UnitOfWork uow = null;
+        try {
+           uow = getOrCreateTransaction();
+           int port = getAdminPort(uow);
+           commit(uow);
+           return port;
+        } catch (KException ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            if (uow != null)
+                uow.rollback();
+            return -1;
+        }
+    }
+
+    @Override
+    public Object getParentObject() {
+        return this;
+    }
+
+    @Override
+    public String getId() {
+        UnitOfWork uow = null;
+        try {
+           uow = getOrCreateTransaction();
+           String id = getId(uow);
+           commit(uow);
+           return id;
+        } catch (KException ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            if (uow != null)
+                uow.rollback();
+            return null;
+        }
+    }
+
+    @Override
+    public String getName() {
+        UnitOfWork uow = null;
+        try {
+           uow = getOrCreateTransaction();
+           String name = getName(uow);
+           commit(uow);
+           return name;
+        } catch (KException ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            if (uow != null)
+                uow.rollback();
+            return null;
+        }
+    }
+
+    @Override
+    public String getUsername() {
+        UnitOfWork uow = null;
+        try {
+           uow = getOrCreateTransaction();
+           String user = getAdminUser(uow);
+           commit(uow);
+           return user;
+        } catch (KException ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            if (uow != null)
+                uow.rollback();
+            return null;
+        }
+    }
+
+    @Override
+    public String getPassword() {
+        UnitOfWork uow = null;
+        try {
+           uow = getOrCreateTransaction();
+           String passwd = getAdminPassword(uow);
+           commit(uow);
+           return passwd;
+        } catch (KException ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            if (uow != null)
+                uow.rollback();
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isSecure() {
+        UnitOfWork uow = null;
+        try {
+           uow = getOrCreateTransaction();
+           boolean secure = isAdminSecure(uow);
+           commit(uow);
+           return secure;
+        } catch (KException ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            if (uow != null)
+                uow.rollback();
+            return false;
+        }
+    }
+
+    @Override
+    public EventManager getEventManager() {
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+
+        UnitOfWork uow = null;
+
+        try {
+            uow = getOrCreateTransaction();
+
+            int nameHash = getName(uow).hashCode();
+            result = prime * result + nameHash;
+
+            int hostHash = getHost(uow).hashCode();
+            result = prime * result + hostHash;
+
+            int versionHash = getVersion(uow).hashCode();
+            result = prime * result + versionHash;
+
+            int adminPwdHash = getAdminPassword(uow).hashCode();
+            result = prime * result + adminPwdHash;
+
+            int adminUserHash = getAdminUser(uow).hashCode();
+            result = prime * result + adminUserHash;
+
+            int adminPortHash = getAdminPort(uow);
+            result = prime * result + adminPortHash;
+
+            int adminSecHash = (isAdminSecure(uow) ? 1231 : 1237);
+            result = prime * result + adminSecHash;
+
+            int jdbcPwdHash = getJdbcPassword(uow).hashCode();
+            result = prime * result + jdbcPwdHash;
+
+            int jdbcUserHash = getJdbcUsername(uow).hashCode();
+            result = prime * result + jdbcUserHash;
+
+            int jdbcPortHash = getJdbcPort(uow);
+            result = prime * result + jdbcPortHash;
+
+            int jdbcSecHash = (isJdbcSecure(uow) ? 1231 : 1237);
+            result = prime * result + jdbcSecHash;
+
+            commit(uow);
+            return result;
+
+        } catch (KException ex) {
+            KLog.getLogger().info("PANIC! HashCode threw an exception" + ex.getMessage());
+            KEngine.getInstance().getErrorHandler().error(ex);
+            if (uow != null)
+                uow.rollback();
+
+            return System.identityHashCode(this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TeiidImpl other = (TeiidImpl)obj;
+        UnitOfWork uow = null;
+
+        try {
+            uow = getOrCreateTransaction();
+
+            if (! getName(uow).equals(other.getName(uow)))
+                return false;
+            if (! getHost(uow).equals(other.getHost(uow)))
+                return false;
+            if (! getVersion(uow).equals(other.getVersion(uow)))
+                return false;
+
+            if (! getAdminPassword(uow).equals(other.getAdminPassword(uow)))
+                return false;
+            if (! getAdminUser(uow).equals(other.getAdminUser(uow)))
+                return false;
+            if (getAdminPort(uow) != other.getAdminPort(uow))
+                return false;
+            if (isAdminSecure(uow) != other.isAdminSecure(uow))
+                return false;
+
+            if (! getJdbcPassword(uow).equals(other.getJdbcPassword(uow)))
+                return false;
+            if (! getJdbcUsername(uow).equals(other.getJdbcUsername(uow)))
+                return false;
+            if (getJdbcPort(uow) != other.getJdbcPort(uow))
+                return false;
+            if (isJdbcSecure(uow) != other.isJdbcSecure(uow))
+                return false;
+
+            commit(uow);
+            return true;
+
+        } catch (KException ex) {
+            KEngine.getInstance().getErrorHandler().error(ex);
+            if (uow != null)
+                uow.rollback();
+
+            return false;
+        }
     }
 
 }

--- a/komodo-spi/src/main/java/org/komodo/spi/query/TeiidService.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/query/TeiidService.java
@@ -81,4 +81,9 @@ public interface TeiidService extends StringConstants {
      * @throws Exception 
      */
     TeiidInstance getTeiidInstance(TeiidParent teiidParent, TeiidJdbcInfo jdbcInfo) throws Exception;
+
+    /**
+     * Dispose of this service
+     */
+    void dispose();
 }

--- a/komodo-spi/src/main/java/org/komodo/spi/runtime/TeiidInstance.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/runtime/TeiidInstance.java
@@ -31,6 +31,11 @@ import org.komodo.spi.runtime.version.TeiidVersion;
 public interface TeiidInstance extends ExecutionAdmin, HostProvider {
 
     /**
+     * Object used for synchronization locking on teiid instance implementations
+     */
+    Object TEIID_INSTANCE_LOCK = new Object();
+
+    /**
      * The data source jndi property name.  Value is {@value} .
      */
     String DATASOURCE_JNDINAME = "jndi-name";  //$NON-NLS-1$

--- a/komodo-utils/src/main/java/org/komodo/utils/KLog.java
+++ b/komodo-utils/src/main/java/org/komodo/utils/KLog.java
@@ -62,7 +62,7 @@ public class KLog implements KLogger {
     }
 
     @Override
-    public void setLogPath(String logPath) throws Exception {
+    public synchronized void setLogPath(String logPath) throws Exception {
         kLogger.setLogPath(logPath);
     }
 
@@ -70,7 +70,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#setLevel(java.util.logging.Level)
      */
     @Override
-    public void setLevel(Level level) throws Exception {
+    public synchronized void setLevel(Level level) throws Exception {
         kLogger.setLevel(level);
     }
 
@@ -78,7 +78,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#info(java.lang.String, java.lang.Object[])
      */
     @Override
-    public void info(String message, Object... args) {
+    public synchronized void info(String message, Object... args) {
         kLogger.info(message, args);
     }
 
@@ -86,7 +86,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#info(java.lang.String, java.lang.Throwable, java.lang.Object[])
      */
     @Override
-    public void info(String message, Throwable throwable, Object... args) {
+    public synchronized void info(String message, Throwable throwable, Object... args) {
         kLogger.info(message, throwable, args);
     }
 
@@ -104,7 +104,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#warn(java.lang.String, java.lang.Object[])
      */
     @Override
-    public void warn(String message, Object... args) {
+    public synchronized void warn(String message, Object... args) {
         kLogger.warn(message, args);
     }
 
@@ -112,7 +112,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#warn(java.lang.String, java.lang.Throwable, java.lang.Object[])
      */
     @Override
-    public void warn(String message, Throwable throwable, Object... args) {
+    public synchronized void warn(String message, Throwable throwable, Object... args) {
         kLogger.warn(message, throwable, args);
     }
 
@@ -130,7 +130,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#error(java.lang.String, java.lang.Object[])
      */
     @Override
-    public void error(String message, Object... args) {
+    public synchronized void error(String message, Object... args) {
         kLogger.error(message, args);
     }
 
@@ -138,7 +138,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#error(java.lang.String, java.lang.Throwable, java.lang.Object[])
      */
     @Override
-    public void error(String message, Throwable throwable, Object... args) {
+    public synchronized void error(String message, Throwable throwable, Object... args) {
         kLogger.error(message, throwable, args);
     }
 
@@ -156,7 +156,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#debug(java.lang.String, java.lang.Object[])
      */
     @Override
-    public void debug(String message, Object... args) {
+    public synchronized void debug(String message, Object... args) {
         kLogger.debug(message, args);
     }
 
@@ -164,7 +164,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#debug(java.lang.String, java.lang.Throwable, java.lang.Object[])
      */
     @Override
-    public void debug(String message, Throwable throwable, Object... args) {
+    public synchronized void debug(String message, Throwable throwable, Object... args) {
         kLogger.debug(message, throwable, args);
     }
 
@@ -182,7 +182,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#trace(java.lang.String, java.lang.Object[])
      */
     @Override
-    public void trace(String message, Object... args) {
+    public synchronized void trace(String message, Object... args) {
         kLogger.trace(message, args);
     }
 
@@ -190,7 +190,7 @@ public class KLog implements KLogger {
      * @see org.komodo.spi.logging.KLogger#trace(java.lang.String, java.lang.Throwable, java.lang.Object[])
      */
     @Override
-    public void trace(String message, Throwable throwable, Object... args) {
+    public synchronized void trace(String message, Throwable throwable, Object... args) {
         kLogger.trace(message, throwable, args);
     }
 

--- a/plugins/komodo-plugin-service/pom.xml
+++ b/plugins/komodo-plugin-service/pom.xml
@@ -50,6 +50,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.felix</groupId>
 			<artifactId>org.apache.felix.framework</artifactId>
 		</dependency>

--- a/plugins/komodo-plugin-service/src/main/java/org/komodo/osgi/Messages.java
+++ b/plugins/komodo-plugin-service/src/main/java/org/komodo/osgi/Messages.java
@@ -43,7 +43,8 @@ public class Messages implements StringConstants {
         BundleNotFound,
         BundleFragmentStartError,
         TeiidServiceBundleFailedToStop,
-        ServiceNotStarted;
+        ServiceNotStarted,
+        CannotModifyCache;
 
         @Override
         public String toString() {

--- a/plugins/komodo-plugin-service/src/main/java/org/komodo/osgi/PluginServiceTracker.java
+++ b/plugins/komodo-plugin-service/src/main/java/org/komodo/osgi/PluginServiceTracker.java
@@ -47,7 +47,8 @@ public class PluginServiceTracker extends BundleTracker<TeiidService> {
         // Get the class of the extension.
         String className = dict.get(TeiidService.CLASS_PROPERTY);
         TeiidProxyService proxy = new TeiidProxyService(className, 
-                                                                                                bundle.getBundleId(), bundle.getBundleContext());
+                                                                                                bundle.getBundleId(), bundle.getBundleContext(),
+                                                                                                service.getCacheExpirationValue(), service.getCacheExpirationUnits());
         service.setTeiidService(proxy);
         return proxy;
     }

--- a/plugins/komodo-plugin-service/src/main/java/org/komodo/osgi/teiid/TeiidProxyService.java
+++ b/plugins/komodo-plugin-service/src/main/java/org/komodo/osgi/teiid/TeiidProxyService.java
@@ -21,14 +21,20 @@
  */
 package org.komodo.osgi.teiid;
 
+import java.util.concurrent.TimeUnit;
 import org.komodo.spi.query.TeiidService;
 import org.komodo.spi.runtime.TeiidInstance;
 import org.komodo.spi.runtime.TeiidJdbcInfo;
 import org.komodo.spi.runtime.TeiidParent;
 import org.komodo.spi.runtime.version.TeiidVersion;
 import org.komodo.spi.type.DataTypeManager;
+import org.komodo.utils.KLog;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
 
 public class TeiidProxyService implements TeiidService {
 
@@ -38,12 +44,34 @@ public class TeiidProxyService implements TeiidService {
 
     private final BundleContext bundleContext;
 
+    private RemovalListener<String, TeiidInstance> removalListener = new RemovalListener<String, TeiidInstance>() {
+
+        @Override
+        public void onRemoval(RemovalNotification<String, TeiidInstance> notification) {
+            TeiidInstance instance = notification.getValue();
+            if (instance == null)
+                return;
+
+            instance.disconnect();
+        }
+    };
+
+    private final Cache<String, TeiidInstance> instanceCache;
+
     private TeiidService delegate;
 
-    public TeiidProxyService(String className, long bundleId, BundleContext bundleContext) {
+    public TeiidProxyService(String className, long bundleId,
+                                                 BundleContext bundleContext,
+                                                 int cacheExpiryValue, TimeUnit cacheExpiryUnits) {
         this.className = className;
         this.bundleId = bundleId;
         this.bundleContext = bundleContext;
+        this.instanceCache = CacheBuilder.newBuilder()
+                                                                      .concurrencyLevel(4)
+                                                                      .expireAfterWrite(cacheExpiryValue, cacheExpiryUnits)
+                                                                      .softValues()
+                                                                      .removalListener(removalListener)
+                                                                      .build();
     }
 
     private synchronized void load() throws Exception {
@@ -94,7 +122,38 @@ public class TeiidProxyService implements TeiidService {
         // teiid uses the latter a lot for recording its progress
         //
         synchronized(TeiidProxyService.class) {
-            return delegate.getTeiidInstance(teiidParent, jdbcInfo);
+            KLog logger = KLog.getLogger();
+
+            StringBuffer buf = new StringBuffer();
+            int parentHash = teiidParent.hashCode();
+            buf.append(parentHash);
+            buf.append(jdbcInfo.getUrl());
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Getting Teiid Instance for host {0} and identity code {1}",
+                                                      teiidParent.getHost(), buf.toString());
+            }
+
+            TeiidInstance instance = instanceCache.getIfPresent(buf.toString());
+            if (instance == null) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Teiid Instance with id {0} not found in cache({1}). Creating new one.",
+                                                          buf.toString(), instanceCache.size());
+                }
+
+                instance = delegate.getTeiidInstance(teiidParent, jdbcInfo);
+                instanceCache.put(buf.toString(), instance);
+            }
+
+            return instance;
         }
+    }
+
+    @Override
+    public void dispose() {
+        instanceCache.invalidateAll();
+
+        if (delegate != null)
+            delegate.dispose();
     }
 }

--- a/plugins/komodo-plugin-service/src/main/resources/org/komodo/osgi/messages.properties
+++ b/plugins/komodo-plugin-service/src/main/resources/org/komodo/osgi/messages.properties
@@ -2,5 +2,6 @@ PluginService.BundleNotFound = Failed to find bundle named {0}
 PluginService.BundleFragmentStartError = Cannot start bundle {0} as it is a fragment
 PluginService.TeiidServiceBundleFailedToStop = The TeiidService bundle {0} failed to stop
 PluginService.ServiceNotStarted = The Plugin Service is not started
+PluginService.CannotModifyCache = Cache configuration values cannot be modified whilst the plugin service is active
 
 Error.UnsupportedTeiid = The teiid version {0} is not supported

--- a/plugins/teiid-8.11/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
+++ b/plugins/teiid-8.11/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
@@ -70,4 +70,9 @@ public class TeiidServiceImpl extends AbstractTeiidService {
     public TeiidInstance getTeiidInstance(TeiidParent teiidParent, TeiidJdbcInfo jdbcInfo) throws Exception {
         return new TeiidInstanceImpl(teiidParent, getVersion(), jdbcInfo);
     }
+
+    @Override
+    public void dispose() {
+        // Nothing required
+    }
 }

--- a/plugins/teiid-8.12/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
+++ b/plugins/teiid-8.12/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
@@ -70,4 +70,9 @@ public class TeiidServiceImpl extends AbstractTeiidService {
     public TeiidInstance getTeiidInstance(TeiidParent teiidParent, TeiidJdbcInfo jdbcInfo) throws Exception {
         return new TeiidInstanceImpl(teiidParent, getVersion(), jdbcInfo);
     }
+
+    @Override
+    public void dispose() {
+        // Nothing required
+    }
 }

--- a/plugins/teiid-template/template/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
+++ b/plugins/teiid-template/template/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
@@ -70,4 +70,9 @@ public class TeiidServiceImpl extends AbstractTeiidService {
     public TeiidInstance getTeiidInstance(TeiidParent teiidParent, TeiidJdbcInfo jdbcInfo) throws Exception {
         return new TeiidInstanceImpl(teiidParent, getVersion(), jdbcInfo);
     }
+
+    @Override
+    public void dispose() {
+        // Nothing required
+    }
 }

--- a/server/komodo-rest/pom.xml
+++ b/server/komodo-rest/pom.xml
@@ -314,6 +314,8 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
+							<!-- Not required if skipping integration tests -->
+							<skip>${integration.skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.as</groupId>
@@ -333,6 +335,8 @@
 							<goal>unpack</goal>
 						</goals>
 						<configuration>
+							<!-- Not required if skipping integration tests -->
+							<skip>${integration.skipTests}</skip>
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.jboss.teiid</groupId>
@@ -361,6 +365,8 @@
 							<goal>run</goal>
 						</goals>
 						<configuration>
+							<!-- Not required if skipping integration tests -->
+							<skip>${integration.skipTests}</skip>
 							<target>
 								<property name="version.resteasy" value="${version.resteasy}" />
 								<property name="destination.resteasy" value="${project.build.directory}/resteasy" />

--- a/server/komodo-rest/src/integration-test/java/org/komodo/rest/service/IT_KomodoTeiidServiceTest.java
+++ b/server/komodo-rest/src/integration-test/java/org/komodo/rest/service/IT_KomodoTeiidServiceTest.java
@@ -56,6 +56,7 @@ import org.komodo.rest.RestLink;
 import org.komodo.rest.relational.KomodoRestUriBuilder;
 import org.komodo.rest.relational.KomodoTeiidAttributes;
 import org.komodo.rest.relational.RestTeiid;
+import org.komodo.rest.relational.RestTeiidStatus;
 import org.komodo.rest.relational.RestVdb;
 import org.komodo.rest.relational.json.KomodoJsonMarshaller;
 import org.komodo.spi.constants.StringConstants;
@@ -200,6 +201,33 @@ public final class IT_KomodoTeiidServiceTest implements StringConstants {
         assertEquals(TeiidJdbcInfo.DEFAULT_JDBC_USERNAME, rt.getJdbcUser());
         assertEquals(TeiidJdbcInfo.DEFAULT_JDBC_PASSWORD, rt.getJdbcPassword());
         assertEquals(TeiidJdbcInfo.DEFAULT_PORT, rt.getJdbcPort());
+    }
+
+    @Test
+    public void shouldGetTeiidStatus() throws Exception {
+        URI uri = UriBuilder.fromUri(_uriBuilder.baseUri())
+                                          .path(V1Constants.TEIID_SEGMENT)
+                                          .path(V1Constants.STATUS_SEGMENT)
+                                          .build();
+
+        this.response = request(uri).get();
+        final String entity = this.response.readEntity(String.class);
+
+        System.out.println("Response:\n" + entity);
+        assertEquals(200, this.response.getStatus());
+
+        RestTeiidStatus status = KomodoJsonMarshaller.unmarshall(entity, RestTeiidStatus.class);
+        assertNotNull(status);
+
+        assertEquals("DefaultServer", status.getId());
+        assertEquals("localhost", status.getHost());
+        assertEquals("8.12.4", status.getVersion());
+        assertTrue(status.isTeiidInstanceAvailable());
+        assertTrue(status.isConnected());
+        assertEquals(1, status.getDataSourceSize());
+        assertEquals(3, status.getDataSourceDriverSize());
+        assertEquals(54, status.getTranslatorSize());
+        assertEquals(1, status.getVdbSize());
     }
 
     @SuppressWarnings( "incomplete-switch" )

--- a/server/komodo-rest/src/integration-test/java/org/komodo/rest/service/IT_KomodoTeiidServiceTest.java
+++ b/server/komodo-rest/src/integration-test/java/org/komodo/rest/service/IT_KomodoTeiidServiceTest.java
@@ -32,6 +32,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.Client;
@@ -59,6 +60,8 @@ import org.komodo.rest.relational.KomodoRestUriBuilder;
 import org.komodo.rest.relational.KomodoTeiidAttributes;
 import org.komodo.rest.relational.RestTeiid;
 import org.komodo.rest.relational.RestTeiidStatus;
+import org.komodo.rest.relational.RestTeiidVdbStatus;
+import org.komodo.rest.relational.RestTeiidVdbStatusVdb;
 import org.komodo.rest.relational.RestVdb;
 import org.komodo.rest.relational.json.KomodoJsonMarshaller;
 import org.komodo.spi.constants.StringConstants;
@@ -230,6 +233,38 @@ public final class IT_KomodoTeiidServiceTest implements StringConstants {
         assertEquals(3, status.getDataSourceDriverSize());
         assertEquals(54, status.getTranslatorSize());
         assertEquals(1, status.getVdbSize());
+    }
+
+    @Test
+    public void shouldGetTeiidVdbStatus() throws Exception {
+        URI uri = UriBuilder.fromUri(_uriBuilder.baseUri())
+                                          .path(V1Constants.TEIID_SEGMENT)
+                                          .path(V1Constants.STATUS_SEGMENT)
+                                          .path(V1Constants.VDBS_SEGMENT)
+                                          .build();
+
+        this.response = request(uri).get();
+        final String entity = this.response.readEntity(String.class);
+
+        System.out.println("Response:\n" + entity);
+        assertEquals(200, this.response.getStatus());
+
+        RestTeiidVdbStatus status = KomodoJsonMarshaller.unmarshall(entity, RestTeiidVdbStatus.class);
+        assertNotNull(status);
+
+        List<RestTeiidVdbStatusVdb> vdbProperties = status.getVdbProperties();
+        assertEquals(1, vdbProperties.size());
+
+        RestTeiidVdbStatusVdb vdb = vdbProperties.get(0);
+        assertNotNull(vdb);
+        
+        assertEquals("sample", vdb.getName());
+        assertEquals("sample-vdb.xml", vdb.getDeployedName());
+        assertEquals(1, vdb.getVersion());
+        assertTrue(vdb.isActive());
+        assertFalse(vdb.isLoading());
+        assertFalse(vdb.isFailed());
+        assertEquals(0, vdb.getErrors().size());
     }
 
     @SuppressWarnings( "incomplete-switch" )

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -302,6 +302,11 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
          * The teiid credentials property for modifying the usernames and passwords
          */
         String TEIID_CREDENTIALS = "credentials";
+
+        /**
+         * The teiid status path segment
+         */
+        String STATUS_SEGMENT = "status";
     }
 
     private static final int TIMEOUT = 1;

--- a/server/komodo-rest/src/main/java/org/komodo/rest/RestBasicEntity.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/RestBasicEntity.java
@@ -122,17 +122,26 @@ public class RestBasicEntity implements KRestEntity {
 
     /**
      * @param baseUri the base uri of the REST request
+     * @throws KException if error occurs
+     */
+    public RestBasicEntity(URI baseUri) throws KException {
+        ArgCheck.isNotNull(baseUri, "baseUri"); //$NON-NLS-1$
+        setBaseUri(baseUri);
+    }
+
+    /**
+     * @param baseUri the base uri of the REST request
      * @param kObject the kObject
      * @param uow the transaction
      * @throws KException if error occurs
      */
     public RestBasicEntity(URI baseUri, KomodoObject kObject, UnitOfWork uow) throws KException {
-        ArgCheck.isNotNull(baseUri, "baseUri"); //$NON-NLS-1$
+        this(baseUri);
+
         ArgCheck.isNotNull(kObject, "kObject"); //$NON-NLS-1$
         ArgCheck.isNotNull(uow, "uow"); //$NON-NLS-1$
 
         setId(kObject.getName(uow));
-        setBaseUri(baseUri);
         setDataPath(kObject.getAbsolutePath());
         setkType(kObject.getTypeIdentifier(uow));
         setHasChildren(kObject.hasChildren(uow));
@@ -331,6 +340,17 @@ public class RestBasicEntity implements KRestEntity {
             this.links = new LinkedHashMap<>();
 
         this.links.put(newLink.getRel(), newLink);
+    }
+
+    /**
+     * Removes the link of given type
+     * @param type of link to remove
+     */
+    public final void removeLink(LinkType type) {
+        if (this.links == null || this.links == RestLink.NO_LINKS)
+            return;
+
+        this.links.remove(type);
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoRestUriBuilder.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoRestUriBuilder.java
@@ -470,6 +470,27 @@ public final class KomodoRestUriBuilder implements KomodoRestV1Application.V1Con
     }
 
     /**
+     * @return the URI to use when requesting the teiid cache  (never <code>null</code>)
+     */
+    public URI generateTeiidStatusUri() {
+        return UriBuilder.fromUri(this.baseUri)
+                                     .path(TEIID_SEGMENT)
+                                     .path(STATUS_SEGMENT)
+                                     .build();
+    }
+
+    /**
+     * @return the URI to use when requesting the teiid cache  (never <code>null</code>)
+     */
+    public URI generateTeiidVdbStatusUri() {
+        return UriBuilder.fromUri(this.baseUri)
+                                     .path(TEIID_SEGMENT)
+                                     .path(STATUS_SEGMENT)
+                                     .path(VDBS_SEGMENT)
+                                     .build();
+    }
+
+    /**
      * @return the URI to use when requesting a specific cached teiid  (never <code>null</code>)
      */
     public URI generateCachedTeiidUri(String teiidId) {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -246,6 +246,11 @@ public final class RelationalMessages {
         SEARCH_SERVICE_REQUEST_PARSING_ERROR,
 
         /**
+         * An error indicating a teiid status error
+         */
+        TEIID_SERVICE_STATUS_ERROR,
+
+        /**
          * The teiid service cannot parse the request body
          */
         TEIID_SERVICE_REQUEST_PARSING_ERROR,

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -268,7 +268,12 @@ public final class RelationalMessages {
         /**
          * An error when getting vdbs
          */
-        TEIID_SERVICE_GET_VDBS_ERROR;
+        TEIID_SERVICE_GET_VDBS_ERROR,
+
+        /**
+         * An error indicating a teiid vdb status error
+         */
+        TEIID_SERVICE_VDBS_STATUS_ERROR;
 
         /**
          * {@inheritDoc}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiid.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiid.java
@@ -28,12 +28,14 @@ import org.komodo.rest.KomodoService;
 import org.komodo.rest.RestBasicEntity;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.runtime.TeiidAdminInfo;
+import org.komodo.spi.runtime.TeiidJdbcInfo;
 import org.komodo.spi.runtime.version.TeiidVersion;
 
 /**
- * A VDB that can be used by GSON to build a JSON document representation.
+ * A Teiid object that can be used by GSON to build a JSON document representation.
  */
-public final class RestTeiid extends RestBasicEntity {
+public class RestTeiid extends RestBasicEntity {
 
     /**
      * Label used to describe teiid version
@@ -142,7 +144,7 @@ public final class RestTeiid extends RestBasicEntity {
 
     public int getAdminPort() {
         Object adminPort = tuples.get(ADMIN_PORT_LABEL);
-        return adminPort != null ? Integer.parseInt(adminPort.toString()) : null;
+        return adminPort != null ? Integer.parseInt(adminPort.toString()) : TeiidAdminInfo.DEFAULT_PORT;
     }
 
     public void setAdminPort(int adminPort) {
@@ -169,7 +171,7 @@ public final class RestTeiid extends RestBasicEntity {
 
     public boolean isAdminSecure() {
         Object adminSecure = tuples.get(ADMIN_SECURE_LABEL);
-        return adminSecure != null ? Boolean.parseBoolean(adminSecure.toString()) : null;
+        return adminSecure != null ? Boolean.parseBoolean(adminSecure.toString()) : false;
     }
 
     public void setAdminSecure(boolean adminSecure) {
@@ -178,7 +180,7 @@ public final class RestTeiid extends RestBasicEntity {
 
     public int getJdbcPort() {
         Object jdbcPort = tuples.get(JDBC_PORT_LABEL);
-        return jdbcPort != null ? Integer.parseInt(jdbcPort.toString()) : null;
+        return jdbcPort != null ? Integer.parseInt(jdbcPort.toString()) : TeiidJdbcInfo.DEFAULT_PORT;
     }
 
     public void setJdbcPort(int jdbcPort) {
@@ -205,7 +207,7 @@ public final class RestTeiid extends RestBasicEntity {
 
     public boolean isJdbcSecure() {
         Object jdbcSecure = tuples.get(JDBC_SECURE_LABEL);
-        return jdbcSecure != null ? Boolean.parseBoolean(jdbcSecure.toString()) : null;
+        return jdbcSecure != null ? Boolean.parseBoolean(jdbcSecure.toString()) : false;
     }
 
     public void setJdbcSecure(boolean jdbcSecure) {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidStatus.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidStatus.java
@@ -1,0 +1,277 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.komodo.relational.teiid.Teiid;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.runtime.DataSourceDriver;
+import org.komodo.spi.runtime.TeiidDataSource;
+import org.komodo.spi.runtime.TeiidInstance;
+import org.komodo.spi.runtime.TeiidTranslator;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * A Teiid Status object that can be used by GSON to build a JSON document representation.
+ */
+public final class RestTeiidStatus extends RestTeiid {
+
+    /**
+     * Label used to describe whether teiid instance is available
+     */
+    public static final String TEIID_INSTANCE_AVAILABLE_LABEL = "instanceAvailable";
+
+    /**
+     * Label used to describe teiid connection url
+     */
+    public static final String TEIID_CONNECTION_URL_LABEL = "connectionUrl";
+
+    /**
+     * Label used to describe whether teiid is connected
+     */
+    public static final String TEIID_CONNECTED_LABEL = "connected";
+
+    /**
+     * Label used to describe the teiid connection error
+     */
+    public static final String TEIID_CONNECTION_ERROR_LABEL = "connectionError";
+
+    /**
+     * Label used to describe number of data sources
+     */
+    public static final String TEIID_DATA_SOURCE_SIZE_LABEL = "dataSourceSize";
+
+    /**
+     * Label used to describe the names of the available data sources
+     */
+    public static final String TEIID_DATA_SOURCE_NAMES_LABEL = "dataSourceNames";
+
+    /**
+     * Label used to describe number of data source drivers
+     */
+    public static final String TEIID_DATA_SOURCE_DRIVER_SIZE_LABEL = "dataSourceDriverSize";
+
+    /**
+     * Label used to describe the names of the available data source drivers
+     */
+    public static final String TEIID_DATA_SOURCE_DRIVER_NAMES_LABEL = "dataSourceDriverNames";
+
+    /**
+     * Label used to describe number of translators
+     */
+    public static final String TEIID_TRANSLATOR_SIZE_LABEL = "translatorSize";
+
+    /**
+     * Label used to describe the names of the available translators
+     */
+    public static final String TEIID_TRANSLATOR_NAMES_LABEL = "translatorNames";
+
+    /**
+     * Label used to describe number of vdbs
+     */
+    public static final String TEIID_VDB_SIZE_LABEL = "vdbSize";
+
+    /**
+     * Label used to describe the names of the available vdbs
+     */
+    public static final String TEIID_VDB_NAMES_LABEL = "vdbNames";
+
+    /**
+     * Constructor for use when deserializing
+     */
+    public RestTeiidStatus() {
+        super();
+    }
+
+    /**
+     * Constructor for use when serializing.
+     * @param baseUri the base uri of the vdb
+     * @param vdb the vdb
+     * @param exportXml whether xml should be exported
+     * @param uow the transaction
+     *
+     * @throws KException if error occurs
+     */
+    public RestTeiidStatus(URI baseUri, Teiid teiid, UnitOfWork uow) throws KException {
+        super(baseUri, teiid, uow);
+
+        TeiidInstance teiidInstance = teiid.getTeiidInstance(uow);
+        setTeiidInstanceAvailable(teiidInstance != null);
+
+        if(teiidInstance == null)
+            return;
+
+        try {
+            teiidInstance.connect();
+
+            setConnectionUrl(teiidInstance.getUrl());
+            setConnected(teiidInstance.isConnected());
+            setConnectionError(teiidInstance.getConnectionError());
+
+            Collection<TeiidDataSource> dataSources = teiidInstance.getDataSources();
+            setDataSourceSize(dataSources.size());
+            setDataSourcesNames(dataSources);
+
+            Collection<DataSourceDriver> dataSourceDrivers = teiidInstance.getDataSourceDrivers();
+            setDataSourceDriverSize(dataSourceDrivers.size());
+            setDataSourceDriverNames(dataSourceDrivers);
+
+            Collection<TeiidTranslator> translators = teiidInstance.getTranslators();
+            setTranslatorSize(translators.size());
+            setTranslatorNames(translators);
+
+            Collection<TeiidVdb> vdbs = teiidInstance.getVdbs();
+            setVdbSize(vdbs.size());
+            setVdbNames(vdbs);
+        } catch (Exception ex) {
+            throw new KException(ex);
+        }
+    }
+
+    public boolean isTeiidInstanceAvailable() {
+        Object hasTeiidInstance = tuples.get(TEIID_INSTANCE_AVAILABLE_LABEL);
+        return hasTeiidInstance != null ? Boolean.parseBoolean(hasTeiidInstance.toString()) : false;
+    }
+
+    protected void setTeiidInstanceAvailable(boolean hasTeiidInstance) {
+        tuples.put(TEIID_INSTANCE_AVAILABLE_LABEL, hasTeiidInstance);
+    }
+
+    public String getConnectionUrl() {
+        Object url = tuples.get(TEIID_CONNECTION_URL_LABEL);
+        return url != null ? url.toString() : null;
+    }
+
+    protected void setConnectionUrl(String url) {
+        tuples.put(TEIID_CONNECTION_URL_LABEL, url);
+    }
+
+    public boolean isConnected() {
+        Object connected = tuples.get(TEIID_CONNECTED_LABEL);
+        return connected != null ? Boolean.parseBoolean(connected.toString()) : false;        
+    }
+
+    protected void setConnected(boolean connected) {
+        tuples.put(TEIID_CONNECTED_LABEL, connected);
+    }
+
+    public String getConnectionError() {
+        Object error = tuples.get(TEIID_CONNECTION_ERROR_LABEL);
+        return error != null ? error.toString() : null;        
+    }
+
+    protected void setConnectionError(String connectionError) {
+        tuples.put(TEIID_CONNECTION_ERROR_LABEL, connectionError);
+    }
+
+    public int getDataSourceSize() {
+        Object size = tuples.get(TEIID_DATA_SOURCE_SIZE_LABEL);
+        return size != null ? Integer.parseInt(size.toString()) : 0;
+    }
+
+    protected void setDataSourceSize(int size) {
+        tuples.put(TEIID_DATA_SOURCE_SIZE_LABEL, size);
+    }
+
+    public String[] getDataSourceNames() {
+        Object names = tuples.get(TEIID_DATA_SOURCE_NAMES_LABEL);
+        return names != null ? (String[]) names : EMPTY_ARRAY;
+    }
+
+    protected void setDataSourcesNames(Collection<TeiidDataSource> dataSources) {
+        List<String> names = new ArrayList<String>(dataSources.size());
+        for (TeiidDataSource source : dataSources)
+            names.add(source.getName());
+
+        tuples.put(TEIID_DATA_SOURCE_NAMES_LABEL, names.toArray(new String[0]));
+    }
+
+    public int getDataSourceDriverSize() {
+        Object size = tuples.get(TEIID_DATA_SOURCE_DRIVER_SIZE_LABEL);
+        return size != null ? Integer.parseInt(size.toString()) : 0;
+    }
+
+    protected void setDataSourceDriverSize(int size) {
+        tuples.put(TEIID_DATA_SOURCE_DRIVER_SIZE_LABEL, size);
+    }
+
+    public String[] getDataSourceDriverNames() {
+        Object names = tuples.get(TEIID_DATA_SOURCE_DRIVER_NAMES_LABEL);
+        return names != null ? (String[]) names : EMPTY_ARRAY;
+    }
+
+    protected void setDataSourceDriverNames(Collection<DataSourceDriver> dataSourceDrivers) {
+        List<String> names = new ArrayList<String>(dataSourceDrivers.size());
+        for (DataSourceDriver driver : dataSourceDrivers)
+            names.add(driver.getName());
+
+        tuples.put(TEIID_DATA_SOURCE_DRIVER_NAMES_LABEL, names.toArray(new String[0]));
+    }
+
+    public int getTranslatorSize() {
+        Object size = tuples.get(TEIID_TRANSLATOR_SIZE_LABEL);
+        return size != null ? Integer.parseInt(size.toString()) : 0;
+    }
+
+    protected void setTranslatorSize(int size) {
+        tuples.put(TEIID_TRANSLATOR_SIZE_LABEL, size);
+    }
+
+    public String[] getTranslatorNames() {
+        Object names = tuples.get(TEIID_TRANSLATOR_NAMES_LABEL);
+        return names != null ? (String[]) names : EMPTY_ARRAY;
+    }
+
+    protected void setTranslatorNames(Collection<TeiidTranslator> translators) {
+        List<String> names = new ArrayList<String>(translators.size());
+        for (TeiidTranslator tr : translators)
+            names.add(tr.getName());
+
+        tuples.put(TEIID_TRANSLATOR_NAMES_LABEL, names.toArray(new String[0]));
+    }
+
+    public int getVdbSize() {
+        Object size = tuples.get(TEIID_VDB_SIZE_LABEL);
+        return size != null ? Integer.parseInt(size.toString()) : 0;
+    }
+
+    protected void setVdbSize(int size) {
+        tuples.put(TEIID_VDB_SIZE_LABEL, size);
+    }
+
+    public String[] getVdbNames() {
+        Object names = tuples.get(TEIID_VDB_NAMES_LABEL);
+        return names != null ? (String[]) names : EMPTY_ARRAY;
+    }
+
+    protected void setVdbNames(Collection<TeiidVdb> vdbs) {
+        List<String> names = new ArrayList<String>(vdbs.size());
+        for (TeiidVdb vdb : vdbs)
+            names.add(vdb.getName());
+
+        tuples.put(TEIID_VDB_NAMES_LABEL, names.toArray(new String[0]));
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidStatus.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidStatus.java
@@ -118,36 +118,38 @@ public final class RestTeiidStatus extends RestTeiid {
     public RestTeiidStatus(URI baseUri, Teiid teiid, UnitOfWork uow) throws KException {
         super(baseUri, teiid, uow);
 
-        TeiidInstance teiidInstance = teiid.getTeiidInstance(uow);
-        setTeiidInstanceAvailable(teiidInstance != null);
+        synchronized (TeiidInstance.TEIID_INSTANCE_LOCK) {
+            TeiidInstance teiidInstance = teiid.getTeiidInstance(uow);
+            setTeiidInstanceAvailable(teiidInstance != null);
 
-        if(teiidInstance == null)
-            return;
+            if (teiidInstance == null)
+                return;
 
-        try {
-            teiidInstance.connect();
+            try {
+                teiidInstance.connect();
 
-            setConnectionUrl(teiidInstance.getUrl());
-            setConnected(teiidInstance.isConnected());
-            setConnectionError(teiidInstance.getConnectionError());
+                setConnectionUrl(teiidInstance.getUrl());
+                setConnected(teiidInstance.isConnected());
+                setConnectionError(teiidInstance.getConnectionError());
 
-            Collection<TeiidDataSource> dataSources = teiidInstance.getDataSources();
-            setDataSourceSize(dataSources.size());
-            setDataSourcesNames(dataSources);
+                Collection<TeiidDataSource> dataSources = teiidInstance.getDataSources();
+                setDataSourceSize(dataSources.size());
+                setDataSourcesNames(dataSources);
 
-            Collection<DataSourceDriver> dataSourceDrivers = teiidInstance.getDataSourceDrivers();
-            setDataSourceDriverSize(dataSourceDrivers.size());
-            setDataSourceDriverNames(dataSourceDrivers);
+                Collection<DataSourceDriver> dataSourceDrivers = teiidInstance.getDataSourceDrivers();
+                setDataSourceDriverSize(dataSourceDrivers.size());
+                setDataSourceDriverNames(dataSourceDrivers);
 
-            Collection<TeiidTranslator> translators = teiidInstance.getTranslators();
-            setTranslatorSize(translators.size());
-            setTranslatorNames(translators);
+                Collection<TeiidTranslator> translators = teiidInstance.getTranslators();
+                setTranslatorSize(translators.size());
+                setTranslatorNames(translators);
 
-            Collection<TeiidVdb> vdbs = teiidInstance.getVdbs();
-            setVdbSize(vdbs.size());
-            setVdbNames(vdbs);
-        } catch (Exception ex) {
-            throw new KException(ex);
+                Collection<TeiidVdb> vdbs = teiidInstance.getVdbs();
+                setVdbSize(vdbs.size());
+                setVdbNames(vdbs);
+            } catch (Exception ex) {
+                throw new KException(ex);
+            }
         }
     }
 

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidStatus.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidStatus.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.komodo.relational.teiid.Teiid;
+import org.komodo.rest.RestLink;
+import org.komodo.rest.RestLink.LinkType;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.komodo.spi.runtime.DataSourceDriver;
@@ -108,15 +110,18 @@ public final class RestTeiidStatus extends RestTeiid {
 
     /**
      * Constructor for use when serializing.
-     * @param baseUri the base uri of the vdb
-     * @param vdb the vdb
-     * @param exportXml whether xml should be exported
+     * @param baseUri the base uri
+     * @param teiid the teiid object
      * @param uow the transaction
      *
      * @throws KException if error occurs
      */
     public RestTeiidStatus(URI baseUri, Teiid teiid, UnitOfWork uow) throws KException {
         super(baseUri, teiid, uow);
+
+        addLink(new RestLink(LinkType.SELF, getUriBuilder().generateTeiidStatusUri()));
+        addLink(new RestLink(LinkType.PARENT, getUriBuilder().generateCachedTeiidUri(teiid.getId(uow))));
+        removeLink(LinkType.CHILDREN);
 
         synchronized (TeiidInstance.TEIID_INSTANCE_LOCK) {
             TeiidInstance teiidInstance = teiid.getTeiidInstance(uow);

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidVdbStatus.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidVdbStatus.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.komodo.relational.teiid.Teiid;
+import org.komodo.rest.RestBasicEntity;
+import org.komodo.rest.RestLink;
+import org.komodo.rest.RestLink.LinkType;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.runtime.TeiidInstance;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * A Teiid Vdb Status object that can be used by GSON to build a JSON document representation.
+ */
+public class RestTeiidVdbStatus extends RestBasicEntity {
+
+    /**
+     * Label for the vdbs collection
+     */
+    public static final String VDBS_LABEL = "vdbs";
+
+    private List<RestTeiidVdbStatusVdb> vdbProps = new ArrayList<>();
+
+    /**
+     * Constructor for use when deserializing
+     */
+    public RestTeiidVdbStatus() {
+        super();
+    }
+
+    /**
+     * Constructor for use when serializing.
+     * @param baseUri the base uri
+     * @param vdb the teiid object
+     * @param uow the transaction
+     *
+     * @throws KException if error occurs
+     */
+    public RestTeiidVdbStatus(URI baseUri, Teiid teiid, UnitOfWork uow) throws KException {
+        super(baseUri);
+
+        addLink(new RestLink(LinkType.SELF, getUriBuilder().generateTeiidVdbStatusUri()));
+        addLink(new RestLink(LinkType.PARENT, getUriBuilder().generateTeiidStatusUri()));
+
+        synchronized (TeiidInstance.TEIID_INSTANCE_LOCK) {
+            TeiidInstance teiidInstance = teiid.getTeiidInstance(uow);
+
+            if (teiidInstance == null)
+                return;
+
+            try {
+                teiidInstance.connect();
+
+                Collection<TeiidVdb> vdbs = teiidInstance.getVdbs();
+                for (TeiidVdb vdb :  vdbs) {
+                    RestTeiidVdbStatusVdb props = new RestTeiidVdbStatusVdb(vdb);
+                    vdbProps .add(props);
+                }
+
+            } catch (Exception ex) {
+                throw new KException(ex);
+            }
+        }
+    }
+
+    public List<RestTeiidVdbStatusVdb> getVdbProperties() {
+        return vdbProps;
+    }
+
+    public void setVdbProperties(List<RestTeiidVdbStatusVdb> props) {
+        if (props == null)
+            props = new ArrayList<>();
+
+        this.vdbProps = props;
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidVdbStatusVdb.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestTeiidVdbStatusVdb.java
@@ -1,0 +1,223 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational;
+
+import java.util.List;
+import javax.ws.rs.core.MediaType;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import org.komodo.rest.KRestEntity;
+import org.komodo.spi.runtime.TeiidVdb;
+
+/**
+ * Object to be serialised by GSON that encapsulates the status of a deployed vdb
+ */
+@JsonSerialize( include = Inclusion.NON_NULL )
+public class RestTeiidVdbStatusVdb implements KRestEntity {
+
+    /**
+     * Label for the name
+     */
+    public static final String TEIID_VDB_STATUS_NAME = "name";
+
+    /**
+     * Label for the deployed name
+     */
+    public static final String TEIID_VDB_STATUS_DEPLOYED_NAME = "deployedName";
+
+    /**
+     * Label for the version
+     */
+    public static final String TEIID_VDB_STATUS_VERSION = "version";
+
+    /**
+     * Label for the active state
+     */
+    public static final String TEIID_VDB_STATUS_ACTIVE = "active";
+
+    /**
+     * Label for the loading state
+     */
+    public static final String TEIID_VDB_STATUS_LOADING = "loading";
+
+    /**
+     * Label for the failed state
+     */
+    public static final String TEIID_VDB_STATUS_FAILED = "failed";
+
+    /**
+     * Label for the errors list
+     */
+    public static final String TEIID_VDB_STATUS_ERROR = "errors";
+
+    private String name;
+
+    private String deployedName;
+
+    private int version;
+
+    private boolean active;
+
+    private boolean failed;
+
+    private boolean loading;
+
+    private List<String> errors;
+
+    /**
+     * Default constructor for deserialization
+     */
+    public RestTeiidVdbStatusVdb() {
+        // do nothing
+    }
+
+    public RestTeiidVdbStatusVdb(TeiidVdb vdb) {
+        name = vdb.getName();
+        deployedName = vdb.getDeployedName();
+        version = vdb.getVersion();
+        active = vdb.isActive();
+        failed = vdb.hasFailed();
+        loading = vdb.isLoading();
+        errors = vdb.getValidityErrors();
+    }
+
+    @Override
+    public boolean supports(MediaType mediaType) {
+        return MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+    }
+
+    @Override
+    public Object getXml() {
+        throw new UnsupportedOperationException();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDeployedName() {
+        return deployedName;
+    }
+
+    public void setDeployedName(String deployedName) {
+        this.deployedName = deployedName;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public boolean isFailed() {
+        return failed;
+    }
+
+    public void setFailed(boolean failed) {
+        this.failed = failed;
+    }
+
+    public boolean isLoading() {
+        return loading;
+    }
+
+    public void setLoading(boolean loading) {
+        this.loading = loading;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (active ? 1231 : 1237);
+        result = prime * result + ((deployedName == null) ? 0 : deployedName.hashCode());
+        result = prime * result + ((errors == null) ? 0 : errors.hashCode());
+        result = prime * result + (failed ? 1231 : 1237);
+        result = prime * result + (loading ? 1231 : 1237);
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + version;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        RestTeiidVdbStatusVdb other = (RestTeiidVdbStatusVdb)obj;
+        if (active != other.active)
+            return false;
+        if (deployedName == null) {
+            if (other.deployedName != null)
+                return false;
+        } else if (!deployedName.equals(other.deployedName))
+            return false;
+        if (errors == null) {
+            if (other.errors != null)
+                return false;
+        } else if (!errors.equals(other.errors))
+            return false;
+        if (failed != other.failed)
+            return false;
+        if (loading != other.loading)
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (version != other.version)
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "RestTeiidVdbStatusProps [name=" + name + ", deployedName=" + deployedName + ", version=" + version + ", active="
+               + active + ", failed=" + failed + ", loading=" + loading + ", errors=" + errors + "]";
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
@@ -32,6 +32,7 @@ import org.komodo.rest.relational.KomodoSearcherAttributes;
 import org.komodo.rest.relational.KomodoStatusObject;
 import org.komodo.rest.relational.KomodoTeiidAttributes;
 import org.komodo.rest.relational.RestTeiid;
+import org.komodo.rest.relational.RestTeiidStatus;
 import org.komodo.rest.relational.RestVdb;
 import org.komodo.rest.relational.RestVdbCondition;
 import org.komodo.rest.relational.RestVdbDataRole;
@@ -77,7 +78,8 @@ public final class KomodoJsonMarshaller {
                                                   .registerTypeAdapter( RestVdbMask.class, new VdbMaskSerializer() )
                                                   .registerTypeAdapter( RestVdbTranslator.class, new VdbTranslatorSerializer() )
                                                   .registerTypeAdapter( RestBasicEntity.class, new BasicEntitySerializer<RestBasicEntity>() )
-                                                  .registerTypeAdapter( RestTeiid.class, new TeiidSerializer() );
+                                                  .registerTypeAdapter( RestTeiid.class, new TeiidSerializer() )
+                                                  .registerTypeAdapter( RestTeiidStatus.class, new TeiidStatusSerializer() );
         BUILDER = temp.create();
         PRETTY_BUILDER = temp.setPrettyPrinting().create();
     }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
@@ -33,6 +33,8 @@ import org.komodo.rest.relational.KomodoStatusObject;
 import org.komodo.rest.relational.KomodoTeiidAttributes;
 import org.komodo.rest.relational.RestTeiid;
 import org.komodo.rest.relational.RestTeiidStatus;
+import org.komodo.rest.relational.RestTeiidVdbStatus;
+import org.komodo.rest.relational.RestTeiidVdbStatusVdb;
 import org.komodo.rest.relational.RestVdb;
 import org.komodo.rest.relational.RestVdbCondition;
 import org.komodo.rest.relational.RestVdbDataRole;
@@ -79,7 +81,9 @@ public final class KomodoJsonMarshaller {
                                                   .registerTypeAdapter( RestVdbTranslator.class, new VdbTranslatorSerializer() )
                                                   .registerTypeAdapter( RestBasicEntity.class, new BasicEntitySerializer<RestBasicEntity>() )
                                                   .registerTypeAdapter( RestTeiid.class, new TeiidSerializer() )
-                                                  .registerTypeAdapter( RestTeiidStatus.class, new TeiidStatusSerializer() );
+                                                  .registerTypeAdapter( RestTeiidStatus.class, new TeiidStatusSerializer() )
+                                                  .registerTypeAdapter( RestTeiidVdbStatus.class, new TeiidVdbStatusSerializer() )
+                                                  .registerTypeAdapter( RestTeiidVdbStatusVdb.class, new TeiidVdbStatusVdbSerializer());
         BUILDER = temp.create();
         PRETTY_BUILDER = temp.setPrettyPrinting().create();
     }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/TeiidStatusSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/TeiidStatusSerializer.java
@@ -3,17 +3,17 @@
  * See the COPYRIGHT.txt file distributed with this work for information
  * regarding copyright ownership.  Some portions may be licensed
  * to Red Hat, Inc. under one or more contributor license agreements.
- *
+ * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- *
+ * 
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -21,21 +21,18 @@
  */
 package org.komodo.rest.relational.json;
 
-import org.komodo.rest.relational.RestTeiid;
+import org.komodo.rest.relational.RestTeiidStatus;
 import org.komodo.utils.StringUtils;
 
-/**
- * A GSON serializer/deserializer for {@link RestTeiid}s.
- */
-public class TeiidSerializer extends BasicEntitySerializer<RestTeiid> {
+public class TeiidStatusSerializer extends BasicEntitySerializer<RestTeiidStatus> {
 
     @Override
-    protected boolean isComplete(final RestTeiid teiid) {
-        return super.isComplete(teiid) && !StringUtils.isBlank(teiid.getHost());
+    protected boolean isComplete(final RestTeiidStatus teiid) {
+        return super.isComplete(teiid) && !StringUtils.isBlank(teiid.getConnectionUrl());
     }
 
     @Override
-    protected RestTeiid createEntity() {
-        return new RestTeiid();
+    protected RestTeiidStatus createEntity() {
+        return new RestTeiidStatus();
     }
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/TeiidVdbStatusVdbSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/TeiidVdbStatusVdbSerializer.java
@@ -1,0 +1,123 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.json;
+
+import static org.komodo.rest.Messages.Error.UNEXPECTED_JSON_TOKEN;
+import static org.komodo.rest.relational.json.KomodoJsonMarshaller.BUILDER;
+import java.io.IOException;
+import java.util.Arrays;
+import org.komodo.rest.Messages;
+import org.komodo.rest.relational.RestTeiidVdbStatusVdb;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * A GSON serializer/deserializer for {@status RestTeiidVdbStatusVdb}s.
+ */
+public final class TeiidVdbStatusVdbSerializer extends TypeAdapter< RestTeiidVdbStatusVdb > {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see com.google.gson.TypeAdapter#read(com.google.gson.stream.JsonReader)
+     */
+    @Override
+    public RestTeiidVdbStatusVdb read( final JsonReader in ) throws IOException {
+        final RestTeiidVdbStatusVdb vdb = new RestTeiidVdbStatusVdb();
+        in.beginObject();
+
+        while ( in.hasNext() ) {
+            final String name = in.nextName();
+
+            switch ( name ) {
+                case RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_NAME:
+                    vdb.setName(in.nextString());
+                    break;
+                case RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_DEPLOYED_NAME:
+                    vdb.setDeployedName(in.nextString());
+                    break;
+                case RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_VERSION:
+                    vdb.setVersion(in.nextInt());
+                    break;
+                case RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_ACTIVE:
+                    vdb.setActive(in.nextBoolean());
+                    break;
+                case RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_LOADING:
+                    vdb.setLoading(in.nextBoolean());
+                    break;
+                case RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_FAILED:
+                    vdb.setFailed(in.nextBoolean());
+                    break;
+                case RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_ERROR:
+                    final String[] errors = BUILDER.fromJson( in, String[].class );
+                    vdb.setErrors(Arrays.asList(errors));
+                    break;
+                default:
+                    throw new IOException( Messages.getString( UNEXPECTED_JSON_TOKEN, name ) );
+            }
+        }
+
+        in.endObject();
+
+        return vdb;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see com.google.gson.TypeAdapter#write(com.google.gson.stream.JsonWriter, java.lang.Object)
+     */
+    @Override
+    public void write( final JsonWriter out,
+                       final RestTeiidVdbStatusVdb value ) throws IOException {
+
+        out.beginObject();
+
+        out.name(RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_NAME);
+        out.value(value.getName());
+
+        out.name(RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_DEPLOYED_NAME);
+        out.value(value.getDeployedName());
+
+        out.name(RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_VERSION);
+        out.value(value.getVersion());
+
+        out.name(RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_ACTIVE);
+        out.value(value.isActive());
+
+        out.name(RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_LOADING);
+        out.value(value.isLoading());
+
+        out.name(RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_FAILED);
+        out.value(value.isFailed());
+
+        out.name(RestTeiidVdbStatusVdb.TEIID_VDB_STATUS_ERROR);
+        out.beginArray();
+        for (String val: value.getErrors()) {
+            out.value(val);
+        }
+        out.endArray();
+
+        out.endObject();
+    }
+}

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -69,3 +69,4 @@ Error.TEIID_SERVICE_REQUEST_PARSING_ERROR = An error occurred while process the 
 Error.TEIID_SERVICE_EMPTY_CREDENTIAL_ERROR = Values are required for all the admin user/password and jdbc user/password credentials
 Error.TEIID_SERVICE_SET_CREDENTIALS_ERROR = An error occurred whilst setting the credentials of the teiid instance: '%s'
 Error.TEIID_SERVICE_GET_VDBS_ERROR = An error occurred constructing the JSON document representing the VDBs on the local teiid server: '%s'
+Error.TEIID_SERVICE_VDBS_STATUS_ERROR = An error occurred while ascertaining the status of the teiid server vdbs: '%s'

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -64,6 +64,7 @@ Error.SEARCH_SERVICE_SAVE_SEARCH_ERROR = An error occurred whilst saving a searc
 Error.SEARCH_SERVICE_DELETE_SEARCH_ERROR = An error occurred whilst deleting a saved search configuration from the repository: '%s'
 Error.SEARCH_SERVICE_REQUEST_PARSING_ERROR = An error occurred while process the request body of the search: '%s'
 
+Error.TEIID_SERVICE_STATUS_ERROR = An error occurred while ascertaining the status of the teiid server: '%s'
 Error.TEIID_SERVICE_REQUEST_PARSING_ERROR = An error occurred while process the request body of the teiid service: '%s'
 Error.TEIID_SERVICE_EMPTY_CREDENTIAL_ERROR = Values are required for all the admin user/password and jdbc user/password credentials
 Error.TEIID_SERVICE_SET_CREDENTIALS_ERROR = An error occurred whilst setting the credentials of the teiid instance: '%s'

--- a/server/komodo-rest/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/server/komodo-rest/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,11 @@
+<jboss-deployment-structure>
+	<deployment>
+		<!-- exclude-subsystem prevents a subsystems deployment unit processors 
+			running on a deployment -->
+		<!-- which gives basically the same effect as removing the subsystem, but 
+			it only affects single deployment -->
+		<exclude-subsystems>
+			<subsystem name="logging" />
+		</exclude-subsystems>
+	</deployment>
+</jboss-deployment-structure>

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbDataRoleSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbDataRoleSerializerTest.java
@@ -49,8 +49,8 @@ public final class VdbDataRoleSerializerTest extends AbstractSerializerTest {
 
     private static final String JSON = EMPTY_STRING +
         OPEN_BRACE + NEW_LINE +
-        "  \"" + ID + "\": \"" + NAME + "\"," + NEW_LINE +
         "  \"" + BASE_URI + "\": \"" + MY_BASE_URI + "\"," + NEW_LINE +
+        "  \"" + ID + "\": \"" + NAME + "\"," + NEW_LINE +
         "  \"" + DATA_PATH + "\": \"" + ROLE_DATA_PATH + "\"," + NEW_LINE +
         "  \"" + KTYPE + "\": \"" + KomodoType.VDB_DATA_ROLE.getType() + "\"," + NEW_LINE +
         "  \"" + HAS_CHILDREN + "\": true," + NEW_LINE +

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbImportSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbImportSerializerTest.java
@@ -42,8 +42,8 @@ public final class VdbImportSerializerTest extends AbstractSerializerTest {
     private static final int VERSION = 2;
     private static final String JSON = EMPTY_STRING +
         OPEN_BRACE + NEW_LINE +
-        "  \"" + ID + "\": \"" + NAME + "\"," + NEW_LINE +
         "  \"" + BASE_URI + "\": \"" + MY_BASE_URI + "\"," + NEW_LINE +
+        "  \"" + ID + "\": \"" + NAME + "\"," + NEW_LINE +
         "  \"" + DATA_PATH + "\": \"" + IMP_DATA_PATH + "\"," + NEW_LINE +
         "  \"" + KTYPE + "\": \"" + KomodoType.VDB_IMPORT.getType() + "\"," + NEW_LINE +
         "  \"" + HAS_CHILDREN + "\": false," + NEW_LINE +

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbPermissionSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbPermissionSerializerTest.java
@@ -53,8 +53,8 @@ public final class VdbPermissionSerializerTest extends AbstractSerializerTest {
 
     private static final String JSON = EMPTY_STRING +
     OPEN_BRACE + NEW_LINE +
-    "  \"" + ID + "\": \"" + NAME + "\"," + NEW_LINE +
     "  \"" + BASE_URI + "\": \"" + MY_BASE_URI + "\"," + NEW_LINE +
+    "  \"" + ID + "\": \"" + NAME + "\"," + NEW_LINE +
     "  \"" + DATA_PATH + "\": \"" + PERM_DATA_PATH + "\"," + NEW_LINE +
     "  \"" + KTYPE + "\": \"" + KomodoType.VDB_PERMISSION.getType() + "\"," + NEW_LINE +
     "  \"" + HAS_CHILDREN + "\": true," + NEW_LINE +

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbSerializerTest.java
@@ -42,8 +42,8 @@ public final class VdbSerializerTest extends AbstractSerializerTest  {
     private static final int VERSION = 1;
 
     private static final String JSON = OPEN_BRACE + NEW_LINE +
-        "  \"keng__id\": \"" + VDB_NAME + "\"," + NEW_LINE +
         "  \"" + BASE_URI + "\": \"" + MY_BASE_URI + "\"," + NEW_LINE +
+        "  \"keng__id\": \"" + VDB_NAME + "\"," + NEW_LINE +
         "  \"keng__dataPath\": \"" + VDB_DATA_PATH + "\"," + NEW_LINE +
         "  \"keng__kType\": \"Vdb\"," + NEW_LINE +
         "  \"keng__hasChildren\": true," + NEW_LINE +

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbTranslatorSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/VdbTranslatorSerializerTest.java
@@ -57,8 +57,8 @@ public final class VdbTranslatorSerializerTest extends AbstractSerializerTest {
 
     private static final String JSON = EMPTY_STRING +
     OPEN_BRACE + NEW_LINE +
-    "  \"" + ID + "\": \"" + NAME + "\"," + NEW_LINE +
     "  \"" + BASE_URI + "\": \"" + MY_BASE_URI + "\"," + NEW_LINE +
+    "  \"" + ID + "\": \"" + NAME + "\"," + NEW_LINE +
     "  \"" + DATA_PATH + "\": \"" + TR_DATA_PATH + "\"," + NEW_LINE +
     "  \"" + KTYPE + "\": \"" + KomodoType.VDB_TRANSLATOR.getType() + "\"," + NEW_LINE +
     "  \"" + HAS_CHILDREN + "\": false," + NEW_LINE +

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoSearchServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoSearchServiceTest.java
@@ -47,11 +47,30 @@ import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
 import org.teiid.modeshape.sequencer.ddl.TeiidDdlLexicon;
 import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 @SuppressWarnings( {"javadoc", "nls"} )
 public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
 
     private final static String PORTFOLIO_DATA_PATH = "/tko:komodo/tko:workspace/Portfolio";
+
+    @Test
+    public void shouldFailNoParameters() throws Exception {
+        // get
+        KomodoProperties properties = new KomodoProperties();
+        URI uri = _uriBuilder.generateSearchUri(properties);
+
+        this.response = request(uri).accept(MediaType.APPLICATION_JSON).get();
+        final String entity = this.response.readEntity(String.class);
+        System.out.println("Response:\n" + entity);
+
+        JsonElement jelement = new JsonParser().parse(entity);
+        assertNotNull(jelement);
+        JsonObject  jobject = jelement.getAsJsonObject();
+        assertEquals("\"The search service requires at least one parameter\"", jobject.get("error").toString());
+    }
 
     @Test
     public void shouldSearchForAnythingContainingView() throws Exception {


### PR DESCRIPTION
Provides the REST operations necessary for gleaning the status of the teiid instance and the status of its vdbs, ie. their validity, errors etc...

Latter commits are concerned with synchronizing concurrent REST calls to avoid deadlocks and creating too many Teiid Client connections to the Teiid server. This is done by caching instances once they are created into an expiration cache (10 min expiry time).

Recommend review on per-commit basis and any questions, feel free to get hold of me in the usual ways.