### PR TITLE
Fixes transactions in rest services to make them synchronous

### DIFF
--- a/server/komodo-rest/src/integration-test/java/org/komodo/rest/service/IT_KomodoTeiidServiceTest.java
+++ b/server/komodo-rest/src/integration-test/java/org/komodo/rest/service/IT_KomodoTeiidServiceTest.java
@@ -289,7 +289,7 @@ public final class IT_KomodoTeiidServiceTest implements StringConstants {
         assertEquals(_uriBuilder.baseUri() + FORWARD_SLASH, vdb.getBaseUri().toString());
         assertEquals(CACHED_TEIID_DATA_PATH + FORWARD_SLASH + "sample", vdb.getDataPath());
         assertEquals(KomodoType.VDB, vdb.getkType());
-        assertFalse(vdb.hasChildren());
+        assertTrue(vdb.hasChildren());
         assertEquals(vdbName, vdb.getName());
 
         for(RestLink link : vdb.getLinks()) {
@@ -335,7 +335,7 @@ public final class IT_KomodoTeiidServiceTest implements StringConstants {
         assertEquals(_uriBuilder.baseUri() + FORWARD_SLASH, vdb.getBaseUri().toString());
         assertEquals(CACHED_TEIID_DATA_PATH + FORWARD_SLASH + "sample", vdb.getDataPath());
         assertEquals(KomodoType.VDB, vdb.getkType());
-        assertFalse(vdb.hasChildren());
+        assertTrue(vdb.hasChildren());
         assertEquals(vdbName, vdb.getName());
 
         for(RestLink link : vdb.getLinks()) {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -176,7 +176,7 @@ public final class RelationalMessages {
         VDB_SAMPLE_CONTENT_SUCCESS,
 
         /**
-         * An error indicating the transaction timeout while awaiting the import of a sample vdb
+         * An error indicating the transaction timeout while awaiting the import of a vdb
          */
         VDB_SAMPLE_IMPORT_TIMEOUT,
 
@@ -273,7 +273,12 @@ public final class RelationalMessages {
         /**
          * An error indicating a teiid vdb status error
          */
-        TEIID_SERVICE_VDBS_STATUS_ERROR;
+        TEIID_SERVICE_VDBS_STATUS_ERROR,
+
+        /**
+         * An error indicating a timeout occurred whilst conducting an import
+         */
+        TEIID_SERVICE_IMPORT_TIMEOUT;
 
         /**
          * {@inheritDoc}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoSearchService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoSearchService.java
@@ -177,7 +177,7 @@ public final class KomodoSearchService extends KomodoService {
             String errorMessage = RelationalMessages.getString(
                                                                RelationalMessages.Error.SEARCH_SERVICE_NO_PARAMETERS_ERROR);
 
-            Object responseEntity = createErrorResponse(mediaTypes, errorMessage);
+            Object responseEntity = createErrorResponseEntity(mediaTypes, errorMessage);
             return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
         }
 
@@ -186,7 +186,7 @@ public final class KomodoSearchService extends KomodoService {
             String errorMessage = RelationalMessages.getString(
                                                                RelationalMessages.Error.SEARCH_SERVICE_PARENT_ANCESTOR_EXCLUSIVE_ERROR);
 
-            Object responseEntity = createErrorResponse(mediaTypes, errorMessage);
+            Object responseEntity = createErrorResponseEntity(mediaTypes, errorMessage);
             return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
         }
 
@@ -347,7 +347,7 @@ public final class KomodoSearchService extends KomodoService {
             String errorMessage = RelationalMessages.getString(
                                                                RelationalMessages.Error.SEARCH_SERVICE_REQUEST_PARSING_ERROR, ex.getMessage());
 
-            Object responseEntity = createErrorResponse(mediaTypes, errorMessage);
+            Object responseEntity = createErrorResponseEntity(mediaTypes, errorMessage);
             return Response.status(Status.FORBIDDEN).entity(responseEntity).build();
         }
 

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -202,7 +202,7 @@ public final class KomodoUtilService extends KomodoService {
             UnitOfWork uow = null;
             try {
                 SynchronousCallback callback = new SynchronousCallback();
-                uow = repo.createTransaction("Import vdb " + sampleName, false, callback); //$NON-NLS-1$
+                uow = createTransaction("Import vdb " + sampleName, false, callback); //$NON-NLS-1$
 
                 String msg = null;
 
@@ -311,7 +311,7 @@ public final class KomodoUtilService extends KomodoService {
             if (komodoType == null) {
                 String msg = RelationalMessages.getString(
                                                           RelationalMessages.Error.SCHEMA_SERVICE_GET_SCHEMA_UNKNOWN_KTYPE, ktype );
-                Object response = createErrorResponse(mediaTypes, msg);
+                Object response = createErrorResponseEntity(mediaTypes, msg);
                 return Response.status(Status.NOT_FOUND).entity(response).build();
             }
 
@@ -319,7 +319,7 @@ public final class KomodoUtilService extends KomodoService {
             if (EMPTY_STRING.equals(schema)) {
                 String msg = RelationalMessages.getString(
                                                           RelationalMessages.Error.SCHEMA_SERVICE_GET_SCHEMA_NOT_FOUND, ktype );
-                Object response = createErrorResponse(mediaTypes, msg);
+                Object response = createErrorResponseEntity(mediaTypes, msg);
                 return Response.status(Status.NOT_FOUND).entity(response).build();
             }
 

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -70,3 +70,4 @@ Error.TEIID_SERVICE_EMPTY_CREDENTIAL_ERROR = Values are required for all the adm
 Error.TEIID_SERVICE_SET_CREDENTIALS_ERROR = An error occurred whilst setting the credentials of the teiid instance: '%s'
 Error.TEIID_SERVICE_GET_VDBS_ERROR = An error occurred constructing the JSON document representing the VDBs on the local teiid server: '%s'
 Error.TEIID_SERVICE_VDBS_STATUS_ERROR = An error occurred while ascertaining the status of the teiid server vdbs: '%s'
+Error.TEIID_SERVICE_IMPORT_TIMEOUT = The import of teiid vdbs timed out.


### PR DESCRIPTION
* Rest service transactions need to await the result of the sequencing in
  order to return the whole answers

* KomodoService
 * Replaces createErrorResponse with createErrorResponseEntity to alleviate
   confusion of the return value
 * Provides single createTransaction method for consumption by subclasses

* KomodoTeiidService
 * Uses 2 transactions in vdb methods to first ensure the default teiid is
   fully imported and second to fetch the requested vdbs

* CachedTeiidImplTest
 * Test to confirm that vdbs in the cached teiid group are being sequenced