### PR TITLE
Introduces Dataservice and Folder repo objects

### DIFF
--- a/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
+++ b/komodo-core/src/main/java/org/komodo/core/KomodoLexicon.java
@@ -43,6 +43,23 @@ public interface KomodoLexicon extends StringConstants {
     }
 
     /**
+     * The JCR names associated with a data service node type.
+     */
+    public interface DataService extends LibraryComponent, WorkspaceItem {
+
+        /**
+         * The node type name of a data service. Value is {@value} .
+         */
+        String NODE_TYPE = Namespace.PREFIX + COLON + "dataService"; //$NON-NLS-1$
+
+        /**
+         * The name and node type name of the data services grouping node. Value is {@value} .
+         */
+        String GROUP_NODE = Namespace.PREFIX + COLON + "dataServices"; //$NON-NLS-1$
+
+    }
+
+    /**
      * The JCR names associated with a data source node type.
      */
     public interface DataSource extends LibraryComponent, WorkspaceItem {
@@ -117,6 +134,18 @@ public interface KomodoLexicon extends StringConstants {
          * The name and node type name of the Komodo Teiid Cache. Value is {@value}.
          */
         String TEIID_CACHE = Namespace.PREFIX + COLON + "teiidCache"; //$NON-NLS-1$
+    }
+
+    /**
+     * The JCR names associated with a folder node type.
+     */
+    public interface Folder extends LibraryComponent, WorkspaceItem {
+
+        /**
+         * The node type name of a folder. Value is {@value} .
+         */
+        String NODE_TYPE = Namespace.PREFIX + COLON + "folder"; //$NON-NLS-1$
+
     }
 
     /**

--- a/komodo-core/src/main/java/org/komodo/repository/KomodoTypeRegistry.java
+++ b/komodo-core/src/main/java/org/komodo/repository/KomodoTypeRegistry.java
@@ -120,7 +120,11 @@ public class KomodoTypeRegistry implements StringConstants {
 
         index(KomodoType.DATA_TYPE_RESULT_SET, TeiidDdlLexicon.CreateProcedure.RESULT_DATA_TYPE);
 
+        index(KomodoType.DATASERVICE, KomodoLexicon.DataService.NODE_TYPE);
+
         index(KomodoType.DATASOURCE, KomodoLexicon.DataSource.NODE_TYPE);
+
+        index(KomodoType.FOLDER, KomodoLexicon.Folder.NODE_TYPE);
 
         index(KomodoType.FOREIGN_KEY, TeiidDdlLexicon.Constraint.FOREIGN_KEY_CONSTRAINT);
 

--- a/komodo-core/src/main/resources/config/komodo.cnd
+++ b/komodo-core/src/main/resources/config/komodo.cnd
@@ -55,7 +55,7 @@
 
 /*
  * The Komodo workspace keeps track of the Teiid servers, Komodo repositories, Teiid 
- * data sources, and other resources created and being worked on by the user.
+ * data sources, dataservices, folders and other resources created and being worked on by the user.
  */
 [tko:workspace] > nt:unstructured
 
@@ -149,6 +149,16 @@
   + tko:dataSources (tko:dataSources) copy
 
 /*
+ * A folder
+ */
+[tko:folder] > nt:unstructured
+  + * (tko:folder) copy
+  + * (tko:vdb) copy
+  + * (tko:dataSource) copy
+  + * (tko:dataService) copy
+  + * (tko:schema) copy
+
+/*
  * The schemas/models grouping node used by the library. Child nodes represent Teiid DDL.
  */
 [tko:schemas] > nt:unstructured
@@ -172,6 +182,18 @@
  */
 [tko:vdb] > vdb:virtualDatabase, tko:libraryComponent
 
+/*
+ * The data service grouping node used by the workspace. Child nodes are data services.
+ */
+[tko:dataServices] > nt:unstructured
+  + * (tko:dataService) copy
+
+/*
+ * A data service known by the workspace.
+ */
+[tko:dataService] > tko:vdb
+  + * (tko:vdb) copy
+ 
 /*
  * The VDB imports grouping node used by the library. Child nodes represent Import VDB definitions.
  */

--- a/komodo-relational/src/main/java/org/komodo/relational/RelationalModelFactory.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/RelationalModelFactory.java
@@ -22,8 +22,12 @@
 package org.komodo.relational;
 
 import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.dataservice.internal.DataserviceImpl;
 import org.komodo.relational.datasource.Datasource;
 import org.komodo.relational.datasource.internal.DatasourceImpl;
+import org.komodo.relational.folder.Folder;
+import org.komodo.relational.folder.internal.FolderImpl;
 import org.komodo.relational.model.AbstractProcedure;
 import org.komodo.relational.model.AccessPattern;
 import org.komodo.relational.model.Column;
@@ -249,6 +253,43 @@ public final class RelationalModelFactory {
      *        the repository where the model object will be created (cannot be <code>null</code>)
      * @param parentWorkspacePath
      *        the parent path (can be empty)
+     * @param serviceName
+     *        the name of the dataservice fragment to create (cannot be empty)
+     * @return the Dataservice model object (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static Dataservice createDataservice( final UnitOfWork transaction,
+                                                 final Repository repository,
+                                                 final String parentWorkspacePath,
+                                                 final String serviceName ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotNull( repository, "repository" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( serviceName, "serviceName" ); //$NON-NLS-1$
+
+        // make sure path is in the library
+        String parentPath = parentWorkspacePath;
+        final String workspacePath = repository.komodoWorkspace( transaction ).getAbsolutePath();
+
+        if ( StringUtils.isBlank( parentWorkspacePath ) ) {
+            parentPath = workspacePath;
+        } else if ( !parentPath.startsWith( workspacePath ) ) {
+            parentPath = ( workspacePath + parentPath );
+        }
+        
+        final KomodoObject kobject = repository.add( transaction, parentPath, serviceName, KomodoLexicon.DataService.NODE_TYPE );
+        final Dataservice result = new DataserviceImpl( transaction, repository, kobject.getAbsolutePath() );
+        return result;
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param repository
+     *        the repository where the model object will be created (cannot be <code>null</code>)
+     * @param parentWorkspacePath
+     *        the parent path (can be empty)
      * @param sourceName
      *        the name of the datasource fragment to create (cannot be empty)
      * @return the Datasource model object (never <code>null</code>)
@@ -346,6 +387,43 @@ public final class RelationalModelFactory {
         } catch (final Exception e) {
             throw handleError( e );
         }
+    }
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param repository
+     *        the repository where the model object will be created (cannot be <code>null</code>)
+     * @param parentWorkspacePath
+     *        the parent path (can be empty)
+     * @param folderName
+     *        the name of the folder to create (cannot be empty)
+     * @return the Folder object (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    public static Folder createFolder( final UnitOfWork transaction,
+                                       final Repository repository,
+                                       final String parentWorkspacePath,
+                                       final String folderName ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotNull( repository, "repository" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( folderName, "folderName" ); //$NON-NLS-1$
+
+        // make sure path is in the workspace
+        String parentPath = parentWorkspacePath;
+        final String workspacePath = repository.komodoWorkspace( transaction ).getAbsolutePath();
+
+        if ( StringUtils.isBlank( parentWorkspacePath ) ) {
+            parentPath = workspacePath;
+        } else if ( !parentPath.startsWith( workspacePath ) ) {
+            parentPath = ( workspacePath + parentPath );
+        }
+        
+        final KomodoObject kobject = repository.add( transaction, parentPath, folderName, KomodoLexicon.Folder.NODE_TYPE );
+        final Folder result = new FolderImpl( transaction, repository, kobject.getAbsolutePath() );
+        return result;
     }
 
     /**
@@ -854,7 +932,7 @@ public final class RelationalModelFactory {
      * @param parentWorkspacePath
      *        the parent path (can be empty)
      * @param id
-     *        the name of the schema fragment to create (cannot be empty)
+     *        the name of the teiid object to create (cannot be empty)
      * @return the Teiid model object (never <code>null</code>)
      * @throws KException
      *         if an error occurs

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
@@ -1,0 +1,157 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.dataservice;
+
+import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.RelationalProperties;
+import org.komodo.relational.TypeResolver;
+import org.komodo.relational.dataservice.internal.DataserviceImpl;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.relational.workspace.WorkspaceManager;
+import org.komodo.repository.ObjectImpl;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+
+/**
+ * A model of a dataservice instance
+ */
+public interface Dataservice extends Vdb {
+
+    /**
+     * The type identifier.
+     */
+    int TYPE_ID = Dataservice.class.hashCode();
+
+    /**
+     * Identifier of this object
+     */
+    KomodoType IDENTIFIER = KomodoType.DATASERVICE;
+
+    /**
+     * An empty array of Dataservices.
+     */
+    Dataservice[] NO_DATASERVICES = new Dataservice[0];
+    
+    /**
+     * The resolver of a {@link Dataservice}.
+     */
+    public static final TypeResolver< Dataservice > RESOLVER = new TypeResolver< Dataservice >() {
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Dataservice create( final UnitOfWork transaction,
+                                   final Repository repository,
+                                   final KomodoObject parent,
+                                   final String id,
+                                   final RelationalProperties properties ) throws KException {
+            final WorkspaceManager mgr = WorkspaceManager.getInstance( repository );
+            return mgr.createDataservice( transaction, parent, id );
+        }
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#identifier()
+         */
+        @Override
+        public KomodoType identifier() {
+            return IDENTIFIER;
+        }
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#owningClass()
+         */
+        @Override
+        public Class< DataserviceImpl > owningClass() {
+            return DataserviceImpl.class;
+        }
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.KomodoObject)
+         */
+        @Override
+        public boolean resolvable( final UnitOfWork transaction,
+                                   final KomodoObject kobject ) throws KException {
+            return ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, KomodoLexicon.DataService.NODE_TYPE );
+        }
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.KomodoObject)
+         */
+        @Override
+        public Dataservice resolve( final UnitOfWork transaction,
+                                    final KomodoObject kobject ) throws KException {
+            if ( kobject.getTypeId() == Dataservice.TYPE_ID ) {
+                return ( Dataservice )kobject;
+            }
+            return new DataserviceImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
+        }
+    
+    };
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param vdbName
+     *        the name of the VDB to create (cannot be empty)
+     * @param externalFilePath
+     *        the VDB file path on the local file system (cannot be empty)
+     * @return the VDB (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    Vdb addVdb( final UnitOfWork uow,
+                final String vdbName,
+                final String externalFilePath ) throws KException;
+    
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param namePatterns
+     *        optional name patterns (can be <code>null</code> or empty but cannot have <code>null</code> or empty elements)
+     * @return the VDBs (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    Vdb[] getVdbs( final UnitOfWork uow,
+                   final String... namePatterns ) throws KException;
+    
+}

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceImpl.java
@@ -1,0 +1,243 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.dataservice.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.komodo.relational.RelationalModelFactory;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.relational.vdb.internal.VdbImpl;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.repository.Repository.UnitOfWork.State;
+import org.komodo.utils.ArgCheck;
+import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
+
+/**
+ * Implementation of Dataservice instance model
+ */
+public class DataserviceImpl extends VdbImpl implements Dataservice {
+
+    /**
+     * The allowed child types.
+     */
+    private static final KomodoType[] KID_TYPES;
+
+    static {
+        KID_TYPES = new KomodoType[ CHILD_TYPES.length + 1 ];
+        System.arraycopy( CHILD_TYPES, 0, KID_TYPES, 0, CHILD_TYPES.length );
+        KID_TYPES[ CHILD_TYPES.length ] = Vdb.IDENTIFIER;
+    }
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param repository
+     *        the repository
+     * @param path
+     *        the path
+     * @throws KException
+     *         if error occurs
+     */
+    public DataserviceImpl( final UnitOfWork uow,
+                      final Repository repository,
+                      final String path ) throws KException {
+        super(uow, repository, path);
+    }
+
+    @Override
+    public KomodoType getTypeIdentifier(UnitOfWork uow) {
+        return Dataservice.IDENTIFIER;
+    }
+
+    /* (non-Javadoc)
+     * @see org.komodo.spi.repository.Exportable#export(org.komodo.spi.repository.Repository.UnitOfWork, java.util.Properties)
+     */
+    @Override
+    public String export(UnitOfWork transaction,
+                         Properties exportProperties) throws KException {
+
+        // TODO: implement
+        return null;
+    }
+    
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.repository.ObjectImpl#getChildTypes()
+     */
+    @Override
+    public KomodoType[] getChildTypes() {
+        return KID_TYPES;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#getChildren(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String[])
+     */
+    @Override
+    public KomodoObject[] getChildren( final UnitOfWork transaction,
+                                       final String... namePatterns ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        final Vdb[] vdbs = getVdbs( transaction, namePatterns );
+        final KomodoObject[] superChildren = super.getChildren(transaction, namePatterns);
+
+        final KomodoObject[] result = new KomodoObject[ vdbs.length + superChildren.length ];
+        System.arraycopy( vdbs, 0, result, 0, vdbs.length );
+        System.arraycopy( superChildren, 0, result, vdbs.length, superChildren.length );
+
+        return result;
+    }
+    
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#hasChild(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public boolean hasChild( final UnitOfWork transaction,
+                             final String name ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state must be NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
+
+        return ( getVdbs( transaction, name ).length != 0 || super.hasChild(transaction, name) );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#hasChild(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String, java.lang.String)
+     */
+    @Override
+    public boolean hasChild( final UnitOfWork transaction,
+                             final String name,
+                             final String typeName ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state must be NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( typeName, "typeName" ); //$NON-NLS-1$
+
+        if ( VdbLexicon.Vdb.VIRTUAL_DATABASE.equals( typeName ) ) {
+            return ( getVdbs( transaction, name ).length != 0 );
+        }
+
+        return super.hasChild(transaction, name, typeName);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#hasChildren(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public boolean hasChildren( final UnitOfWork transaction ) throws KException {
+        if ( getVdbs( transaction ).length !=0 ) {
+            return true;
+        }
+        
+        return super.hasChildren(transaction);
+    }
+    
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#getChild(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String)
+     */
+    @Override
+    public KomodoObject getChild( final UnitOfWork transaction,
+                                  final String name ) throws KException {
+        // check data roles
+        KomodoObject[] kids = getVdbs( transaction, name );
+
+        if ( kids.length != 0 ) {
+            return kids[ 0 ];
+        }
+        
+        return super.getChild(transaction, name);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#getChild(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String, java.lang.String)
+     */
+    @Override
+    public KomodoObject getChild( final UnitOfWork transaction,
+                                  final String name,
+                                  final String typeName ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state must be NOT_STARTED" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( name, "name" ); //$NON-NLS-1$
+        ArgCheck.isNotEmpty( typeName, "typeName" ); //$NON-NLS-1$
+
+        if ( VdbLexicon.Vdb.VIRTUAL_DATABASE.equals( typeName ) ) {
+            final KomodoObject[] vdbs = getVdbs( transaction, name );
+
+            if ( vdbs.length != 0 ) {
+                return vdbs[ 0 ];
+            }
+        }
+
+        return super.getChild(transaction, name, typeName);
+    }
+    
+    @Override
+    public Vdb addVdb( final UnitOfWork uow,
+                       final String vdbName,
+                       final String externalFilePath ) throws KException {
+        return RelationalModelFactory.createVdb( uow, getRepository(), this.getAbsolutePath(), vdbName, externalFilePath );
+    }
+
+    @Override
+    public Vdb[] getVdbs( final UnitOfWork transaction,
+                          final String... namePatterns ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        final List< Vdb > result = new ArrayList< Vdb >();
+
+        for ( final KomodoObject kobject : super.getChildrenOfType( transaction, VdbLexicon.Vdb.VIRTUAL_DATABASE, namePatterns ) ) {
+            final Vdb vdb = new VdbImpl( transaction, getRepository(), kobject.getAbsolutePath() );
+            result.add( vdb );
+        }
+
+        if ( result.isEmpty() ) {
+            return Vdb.NO_VDBS;
+        }
+
+        return result.toArray( new Vdb[ result.size() ] );
+    }
+
+}

--- a/komodo-relational/src/main/java/org/komodo/relational/folder/Folder.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/folder/Folder.java
@@ -1,0 +1,260 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.folder;
+
+import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.RelationalObject;
+import org.komodo.relational.RelationalProperties;
+import org.komodo.relational.TypeResolver;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.datasource.Datasource;
+import org.komodo.relational.folder.internal.FolderImpl;
+import org.komodo.relational.model.Schema;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.relational.workspace.WorkspaceManager;
+import org.komodo.repository.ObjectImpl;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+
+/**
+ * A model of a Folder instance
+ */
+public interface Folder extends RelationalObject {
+
+    /**
+     * The type identifier.
+     */
+    int TYPE_ID = Folder.class.hashCode();
+
+    /**
+     * Identifier of this object
+     */
+    KomodoType IDENTIFIER = KomodoType.FOLDER;
+
+    /**
+     * An empty array of folders.
+     */
+    Folder[] NO_FOLDERS = new Folder[0];
+
+    /**
+     * The resolver of a {@link Folder}.
+     */
+    public static final TypeResolver< Folder > RESOLVER = new TypeResolver< Folder >() {
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#create(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.Repository, org.komodo.spi.repository.KomodoObject, java.lang.String,
+         *      org.komodo.relational.RelationalProperties)
+         */
+        @Override
+        public Folder create( final UnitOfWork transaction,
+                              final Repository repository,
+                              final KomodoObject parent,
+                              final String id,
+                              final RelationalProperties properties ) throws KException {
+            final WorkspaceManager mgr = WorkspaceManager.getInstance( repository );
+            return mgr.createFolder( transaction, parent, id );
+        }
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#identifier()
+         */
+        @Override
+        public KomodoType identifier() {
+            return IDENTIFIER;
+        }
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#owningClass()
+         */
+        @Override
+        public Class< FolderImpl > owningClass() {
+            return FolderImpl.class;
+        }
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#resolvable(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.KomodoObject)
+         */
+        @Override
+        public boolean resolvable( final UnitOfWork transaction,
+                                   final KomodoObject kobject ) throws KException {
+            return ObjectImpl.validateType( transaction, kobject.getRepository(), kobject, KomodoLexicon.Folder.NODE_TYPE );
+        }
+    
+        /**
+         * {@inheritDoc}
+         *
+         * @see org.komodo.relational.TypeResolver#resolve(org.komodo.spi.repository.Repository.UnitOfWork,
+         *      org.komodo.spi.repository.KomodoObject)
+         */
+        @Override
+        public Folder resolve( final UnitOfWork transaction,
+                               final KomodoObject kobject ) throws KException {
+            if ( kobject.getTypeId() == Folder.TYPE_ID ) {
+                return ( Folder )kobject;
+            }
+            return new FolderImpl( transaction, kobject.getRepository(), kobject.getAbsolutePath() );
+        }
+    
+    };
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param serviceName
+     *        the name of the dataservice to create (cannot be empty)
+     * @return the Dataservice object (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    Dataservice addDataservice( final UnitOfWork uow,
+                                final String serviceName ) throws KException;
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param sourceName
+     *        the name of the datasource to create (cannot be empty)
+     * @return the Datasource object (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    Datasource addDatasource( final UnitOfWork uow,
+                              final String sourceName ) throws KException;
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param folderName
+     *        the name of the folder to create (cannot be empty)
+     * @return the Folder object (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    Folder addFolder( final UnitOfWork uow,
+                      final String folderName ) throws KException;
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param schemaName
+     *        the name of the schema to create (cannot be empty)
+     * @return the schema object (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    Schema addSchema( final UnitOfWork uow,
+                      final String schemaName ) throws KException;
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param vdbName
+     *        the name of the VDB to create (cannot be empty)
+     * @param externalFilePath
+     *        the VDB file path on the local file system (cannot be empty)
+     * @return the VDB (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    Vdb addVdb( final UnitOfWork uow,
+                final String vdbName,
+                final String externalFilePath ) throws KException;
+    
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param namePatterns
+     *        optional name patterns (can be <code>null</code> or empty but cannot have <code>null</code> or empty elements)
+     * @return the data sources (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    Datasource[] getDatasources( final UnitOfWork uow,
+                                 final String... namePatterns ) throws KException;
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param namePatterns
+     *        optional name patterns (can be <code>null</code> or empty but cannot have <code>null</code> or empty elements)
+     * @return the data services (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    Dataservice[] getDataservices( final UnitOfWork uow,
+                                   final String... namePatterns ) throws KException;
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param namePatterns
+     *        optional name patterns (can be <code>null</code> or empty but cannot have <code>null</code> or empty elements)
+     * @return the vdbs (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    Vdb[] getVdbs( final UnitOfWork uow,
+                   final String... namePatterns ) throws KException;
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param namePatterns
+     *        optional name patterns (can be <code>null</code> or empty but cannot have <code>null</code> or empty elements)
+     * @return the schemas (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    Schema[] getSchemas( final UnitOfWork uow,
+                         final String... namePatterns ) throws KException;
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param namePatterns
+     *        optional name patterns (can be <code>null</code> or empty but cannot have <code>null</code> or empty elements)
+     * @return the folders (never <code>null</code> but can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    Folder[] getFolders( final UnitOfWork uow,
+                         final String... namePatterns ) throws KException;
+
+}

--- a/komodo-relational/src/main/java/org/komodo/relational/folder/internal/FolderImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/folder/internal/FolderImpl.java
@@ -1,0 +1,287 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.folder.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.RelationalModelFactory;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.dataservice.internal.DataserviceImpl;
+import org.komodo.relational.datasource.Datasource;
+import org.komodo.relational.datasource.internal.DatasourceImpl;
+import org.komodo.relational.folder.Folder;
+import org.komodo.relational.internal.RelationalObjectImpl;
+import org.komodo.relational.model.Schema;
+import org.komodo.relational.model.internal.SchemaImpl;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.relational.vdb.internal.VdbImpl;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.repository.Repository.UnitOfWork.State;
+import org.komodo.spi.runtime.EventManager;
+import org.komodo.spi.runtime.ExecutionConfigurationEvent;
+import org.komodo.spi.runtime.ExecutionConfigurationListener;
+import org.komodo.utils.ArgCheck;
+import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
+
+/**
+ * Implementation of Folder instance model
+ */
+public class FolderImpl extends RelationalObjectImpl implements Folder, EventManager {
+
+    /**
+     * The allowed child types.
+     */
+    private static final KomodoType[] CHILD_TYPES = new KomodoType[] { Datasource.IDENTIFIER, Vdb.IDENTIFIER,
+                                                                       Schema.IDENTIFIER, Dataservice.IDENTIFIER, Folder.IDENTIFIER };
+    
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param repository
+     *        the repository
+     * @param path
+     *        the path
+     * @throws KException
+     *         if error occurs
+     */
+    public FolderImpl( final UnitOfWork uow,
+                       final Repository repository,
+                       final String path ) throws KException {
+        super(uow, repository, path);
+    }
+
+    @Override
+    public KomodoType getTypeIdentifier(UnitOfWork uow) {
+        return Folder.IDENTIFIER;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.spi.repository.KomodoObject#getTypeId()
+     */
+    @Override
+    public int getTypeId() {
+        return TYPE_ID;
+    }
+
+    @Override
+    public Dataservice addDataservice( final UnitOfWork uow,
+                                       final String serviceName ) throws KException {
+         return RelationalModelFactory.createDataservice( uow, getRepository(), this.getAbsolutePath(), serviceName );
+    }
+
+    @Override
+    public Datasource addDatasource( final UnitOfWork uow,
+                                     final String sourceName ) throws KException {
+         return RelationalModelFactory.createDatasource( uow, getRepository(), this.getAbsolutePath(), sourceName );
+    }
+
+    @Override
+    public Folder addFolder( final UnitOfWork uow,
+                             final String folderName ) throws KException {
+        return RelationalModelFactory.createFolder( uow, getRepository(), this.getAbsolutePath(), folderName );
+    }
+
+    @Override
+    public Schema addSchema( final UnitOfWork uow,
+                             final String schemaName ) throws KException {
+         return RelationalModelFactory.createSchema( uow, getRepository(), this.getAbsolutePath(), schemaName );
+    }
+
+    @Override
+    public Vdb addVdb( final UnitOfWork uow,
+                       final String vdbName,
+                       final String externalFilePath ) throws KException {
+        return RelationalModelFactory.createVdb( uow, getRepository(), this.getAbsolutePath(), vdbName, externalFilePath );
+    }
+
+    @Override
+    public Dataservice[] getDataservices( final UnitOfWork transaction,
+                                          final String... namePatterns ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        final List< Dataservice > result = new ArrayList< Dataservice >();
+
+        for ( final KomodoObject kobject : super.getChildrenOfType( transaction, KomodoLexicon.DataService.NODE_TYPE, namePatterns ) ) {
+            final Dataservice service = new DataserviceImpl( transaction, getRepository(), kobject.getAbsolutePath() );
+            result.add( service );
+        }
+
+        if ( result.isEmpty() ) {
+            return Dataservice.NO_DATASERVICES;
+        }
+
+        return result.toArray( new Dataservice[ result.size() ] );
+    }
+
+    @Override
+    public Datasource[] getDatasources( final UnitOfWork transaction,
+                                        final String... namePatterns ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        final List< Datasource > result = new ArrayList< Datasource >();
+
+        for ( final KomodoObject kobject : super.getChildrenOfType( transaction, KomodoLexicon.DataSource.NODE_TYPE, namePatterns ) ) {
+            final Datasource ds = new DatasourceImpl( transaction, getRepository(), kobject.getAbsolutePath() );
+            result.add( ds );
+        }
+
+        if ( result.isEmpty() ) {
+            return Datasource.NO_DATASOURCES;
+        }
+
+        return result.toArray( new Datasource[ result.size() ] );
+    }
+
+    @Override
+    public Vdb[] getVdbs( final UnitOfWork transaction,
+                          final String... namePatterns ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        final List< Vdb > result = new ArrayList< Vdb >();
+
+        for ( final KomodoObject kobject : super.getChildrenOfType( transaction, VdbLexicon.Vdb.VIRTUAL_DATABASE, namePatterns ) ) {
+            final Vdb vdb = new VdbImpl( transaction, getRepository(), kobject.getAbsolutePath() );
+            result.add( vdb );
+        }
+
+        if ( result.isEmpty() ) {
+            return Vdb.NO_VDBS;
+        }
+
+        return result.toArray( new Vdb[ result.size() ] );
+    }
+
+    @Override
+    public Schema[] getSchemas( final UnitOfWork transaction,
+                                final String... namePatterns ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        final List< Schema > result = new ArrayList< Schema >();
+
+        for ( final KomodoObject kobject : super.getChildrenOfType( transaction, KomodoLexicon.Schema.NODE_TYPE, namePatterns ) ) {
+            final Schema schema = new SchemaImpl( transaction, getRepository(), kobject.getAbsolutePath() );
+            result.add( schema );
+        }
+
+        if ( result.isEmpty() ) {
+            return Schema.NO_SCHEMAS;
+        }
+
+        return result.toArray( new Schema[ result.size() ] );
+    }
+
+    @Override
+    public Folder[] getFolders( final UnitOfWork transaction,
+                                final String... namePatterns ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        final List< Folder > result = new ArrayList< Folder >();
+
+        for ( final KomodoObject kobject : super.getChildrenOfType( transaction, KomodoLexicon.Folder.NODE_TYPE, namePatterns ) ) {
+            final Folder folder = new FolderImpl( transaction, getRepository(), kobject.getAbsolutePath() );
+            result.add( folder );
+        }
+
+        if ( result.isEmpty() ) {
+            return Folder.NO_FOLDERS;
+        }
+
+        return result.toArray( new Folder[ result.size() ] );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.relational.internal.RelationalObjectImpl#getChildrenOfType(org.komodo.spi.repository.Repository.UnitOfWork,
+     *      java.lang.String, java.lang.String[])
+     */
+    @Override
+    public KomodoObject[] getChildrenOfType( final UnitOfWork transaction,
+                                             final String type,
+                                             final String... namePatterns ) throws KException {
+        ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
+        ArgCheck.isTrue( ( transaction.getState() == State.NOT_STARTED ), "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
+
+        KomodoObject[] result = null;
+
+        if ( KomodoLexicon.Folder.NODE_TYPE.equals( type ) ) {
+            result = getFolders( transaction, namePatterns );
+        } else if ( KomodoLexicon.Schema.NODE_TYPE.equals( type ) ) {
+            result = getSchemas( transaction, namePatterns );
+        } else if ( KomodoLexicon.DataSource.NODE_TYPE.equals( type ) ) {
+            result = getDatasources( transaction, namePatterns );
+        } else if ( KomodoLexicon.DataService.NODE_TYPE.equals( type ) ) {
+            result = getDataservices( transaction, namePatterns );
+        } else if ( VdbLexicon.Vdb.VIRTUAL_DATABASE.equals( type ) ) {
+            result = getVdbs( transaction, namePatterns );
+        } else {
+            result = KomodoObject.EMPTY_ARRAY;
+        }
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.komodo.repository.ObjectImpl#getChildTypes()
+     */
+    @Override
+    public KomodoType[] getChildTypes() {
+        return CHILD_TYPES;
+    }
+
+    @Override
+    public boolean addListener( ExecutionConfigurationListener listener ) {
+        return false;
+    }
+
+    @Override
+    public void permitListeners( boolean enable ) {
+        // TODO
+        // Consider whether this is still required.
+    }
+
+    @Override
+    public void notifyListeners( ExecutionConfigurationEvent event ) {
+        // TODO
+        // Consider whether this is still required.
+    }
+
+    @Override
+    public boolean removeListener( ExecutionConfigurationListener listener ) {
+        return false;
+    }
+
+}

--- a/komodo-relational/src/main/java/org/komodo/relational/internal/TypeResolverRegistry.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/internal/TypeResolverRegistry.java
@@ -26,7 +26,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.komodo.relational.TypeResolver;
+import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.datasource.Datasource;
+import org.komodo.relational.folder.Folder;
 import org.komodo.relational.model.AccessPattern;
 import org.komodo.relational.model.Column;
 import org.komodo.relational.model.DataTypeResultSet;
@@ -98,9 +100,13 @@ public class TypeResolverRegistry {
 
         index(KomodoType.COLUMN, Column.RESOLVER);
 
+        index(KomodoType.DATASERVICE, Dataservice.RESOLVER);
+
         index(KomodoType.DATASOURCE, Datasource.RESOLVER);
 
         index(KomodoType.DATA_TYPE_RESULT_SET, DataTypeResultSet.RESOLVER);
+
+        index(KomodoType.FOLDER, Folder.RESOLVER);
 
         index(KomodoType.FOREIGN_KEY, ForeignKey.RESOLVER);
 

--- a/komodo-relational/src/main/java/org/komodo/relational/vdb/internal/VdbImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/vdb/internal/VdbImpl.java
@@ -65,13 +65,13 @@ import org.xml.sax.InputSource;
 /**
  * An implementation of a virtual database manifest.
  */
-public final class VdbImpl extends RelationalObjectImpl implements Vdb {
+public class VdbImpl extends RelationalObjectImpl implements Vdb {
 
     /**
      * The allowed child types.
      */
-    private static final KomodoType[] CHILD_TYPES = new KomodoType[] { DataRole.IDENTIFIER, Entry.IDENTIFIER, Model.IDENTIFIER,
-                                                                      Translator.IDENTIFIER, VdbImport.IDENTIFIER };
+    protected static final KomodoType[] CHILD_TYPES = new KomodoType[] { DataRole.IDENTIFIER, Entry.IDENTIFIER, Model.IDENTIFIER,
+                                                                         Translator.IDENTIFIER, VdbImport.IDENTIFIER };
 
 	/**
 	 * Include the special properties into the primary type descriptor.
@@ -540,7 +540,7 @@ public final class VdbImpl extends RelationalObjectImpl implements Vdb {
         } else if ( VdbLexicon.Translator.TRANSLATOR.equals( type ) ) {
             result = getTranslators( transaction, namePatterns );
         } else {
-            result = KomodoObject.EMPTY_ARRAY;
+            result = super.getChildrenOfType(transaction, type, namePatterns);
         }
 
         return result;

--- a/komodo-relational/src/main/java/org/komodo/relational/workspace/WorkspaceManager.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/workspace/WorkspaceManager.java
@@ -30,8 +30,10 @@ import org.komodo.relational.RelationalObject;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.RelationalProperty;
 import org.komodo.relational.TypeResolver;
+import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.datasource.Datasource;
 import org.komodo.relational.datasource.internal.DatasourceImpl;
+import org.komodo.relational.folder.Folder;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.TypeResolverRegistry;
 import org.komodo.relational.model.Model;
@@ -69,7 +71,8 @@ public class WorkspaceManager extends ObjectImpl implements RelationalObject {
      * The allowed child types.
      */
     private static final KomodoType[] CHILD_TYPES = new KomodoType[] { Datasource.IDENTIFIER, Vdb.IDENTIFIER,
-                                                                       Schema.IDENTIFIER, Teiid.IDENTIFIER };
+                                                                       Schema.IDENTIFIER, Teiid.IDENTIFIER, 
+                                                                       Dataservice.IDENTIFIER, Folder.IDENTIFIER };
 
     /**
      * The type identifier.
@@ -209,6 +212,26 @@ public class WorkspaceManager extends ObjectImpl implements RelationalObject {
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @param parent
+     *        the parent of the dataservice object being created (can be <code>null</code>)
+     * @param serviceName
+     *        the name of the dataservice to create (cannot be empty)
+     * @return the Dataservice object (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    public Dataservice createDataservice( final UnitOfWork uow,
+                                        final KomodoObject parent,
+                                        final String serviceName ) throws KException {
+        final String path = ( ( parent == null ) ? getRepository().komodoWorkspace( uow ).getAbsolutePath()
+                                                 : parent.getAbsolutePath() );
+         return RelationalModelFactory.createDataservice( uow, getRepository(), path, serviceName );
+    }
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param parent
      *        the parent of the datasource object being created (can be <code>null</code>)
      * @param sourceName
      *        the name of the datasource to create (cannot be empty)
@@ -222,6 +245,26 @@ public class WorkspaceManager extends ObjectImpl implements RelationalObject {
         final String path = ( ( parent == null ) ? getRepository().komodoWorkspace( uow ).getAbsolutePath()
                                                  : parent.getAbsolutePath() );
          return RelationalModelFactory.createDatasource( uow, getRepository(), path, sourceName );
+    }
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @param parent
+     *        the parent of the folder object being created (can be <code>null</code>)
+     * @param folderName
+     *        the name of the folder to create (cannot be empty)
+     * @return the Folder object (never <code>null</code>)
+     * @throws KException
+     *         if an error occurs
+     */
+    public Folder createFolder( final UnitOfWork uow,
+                                final KomodoObject parent,
+                                final String folderName ) throws KException {
+        final String path = ( ( parent == null ) ? getRepository().komodoWorkspace( uow ).getAbsolutePath()
+            : parent.getAbsolutePath() );
+        return RelationalModelFactory.createFolder( uow, getRepository(), path, folderName );
     }
 
     /**

--- a/komodo-relational/src/test/java/org/komodo/relational/RelationalModelTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/RelationalModelTest.java
@@ -24,8 +24,11 @@ package org.komodo.relational;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.datasource.Datasource;
+import org.komodo.relational.folder.Folder;
 import org.komodo.relational.model.Model;
+import org.komodo.relational.model.Schema;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.teiid.Teiid;
 import org.komodo.relational.vdb.Vdb;
@@ -94,6 +97,24 @@ public class RelationalModelTest extends AbstractLocalRepositoryTest {
         return vdb;
     }
 
+    protected Schema createSchema() throws Exception {
+        return createSchema( getDefaultSchemaName() );
+    }
+
+    protected Schema createSchema( final String schemaName ) throws Exception {
+        return createSchema( schemaName, null );
+    }
+
+    protected Schema createSchema( final String schemaName,
+                                   final KomodoObject parent ) throws Exception {
+        final WorkspaceManager mgr = WorkspaceManager.getInstance( _repo );
+        final Schema schema = mgr.createSchema( getTransaction(), parent, schemaName );
+
+        assertThat( schema.getPrimaryType( getTransaction() ).getName(), is( KomodoLexicon.Schema.NODE_TYPE ) );
+        assertThat( schema.getName( getTransaction() ), is( schemaName ) );
+        return schema;
+    }
+
     protected Teiid createTeiid() throws Exception {
         return createTeiid( getDefaultTeiidName() );
     }
@@ -112,8 +133,26 @@ public class RelationalModelTest extends AbstractLocalRepositoryTest {
         return teiid;
     }
 
+    protected Dataservice createDataservice() throws Exception {
+        return createDataservice( getDefaultDataserviceName() );
+    }
+
+    protected Dataservice createDataservice( final String serviceName ) throws Exception {
+        return createDataservice( serviceName, null );
+    }
+
+    protected Dataservice createDataservice( final String serviceName,
+                                             final KomodoObject parent ) throws Exception {
+        final WorkspaceManager mgr = WorkspaceManager.getInstance( _repo );
+        final Dataservice ds = mgr.createDataservice( getTransaction(), parent, serviceName );
+
+        assertThat( ds.getPrimaryType( getTransaction() ).getName(), is( KomodoLexicon.DataService.NODE_TYPE ) );
+        assertThat( ds.getName( getTransaction() ), is( serviceName ) );
+        return ds;
+    }
+
     protected Datasource createDatasource() throws Exception {
-        return createDatasource( getDefaultTeiidName() );
+        return createDatasource( getDefaultDatasourceName() );
     }
 
     protected Datasource createDatasource( final String dsName ) throws Exception {
@@ -121,13 +160,31 @@ public class RelationalModelTest extends AbstractLocalRepositoryTest {
     }
 
     protected Datasource createDatasource( final String dsName,
-                                      final KomodoObject parent ) throws Exception {
+                                           final KomodoObject parent ) throws Exception {
         final WorkspaceManager mgr = WorkspaceManager.getInstance( _repo );
         final Datasource ds = mgr.createDatasource( getTransaction(), parent, dsName );
 
         assertThat( ds.getPrimaryType( getTransaction() ).getName(), is( KomodoLexicon.DataSource.NODE_TYPE ) );
         assertThat( ds.getName( getTransaction() ), is( dsName ) );
         return ds;
+    }
+
+    protected Folder createFolder() throws Exception {
+        return createFolder( getDefaultFolderName() );
+    }
+
+    protected Folder createFolder( final String folderName ) throws Exception {
+        return createFolder( folderName, null );
+    }
+
+    protected Folder createFolder( final String folderName,
+                                             final KomodoObject parent ) throws Exception {
+        final WorkspaceManager mgr = WorkspaceManager.getInstance( _repo );
+        final Folder folder = mgr.createFolder( getTransaction(), parent, folderName );
+
+        assertThat( folder.getPrimaryType( getTransaction() ).getName(), is( KomodoLexicon.Folder.NODE_TYPE ) );
+        assertThat( folder.getName( getTransaction() ), is( folderName ) );
+        return folder;
     }
 
     protected String getDefaultModelName() {
@@ -142,12 +199,24 @@ public class RelationalModelTest extends AbstractLocalRepositoryTest {
         return ( this.name.getMethodName() + "-Vdb" );
     }
 
+    protected String getDefaultSchemaName() {
+        return ( this.name.getMethodName() + "-Schema" );
+    }
+
     protected String getDefaultTeiidName() {
         return ( this.name.getMethodName() + "-Teiid" );
     }
 
+    protected String getDefaultDataserviceName() {
+        return ( this.name.getMethodName() + "-Dataservice" );
+    }
+
     protected String getDefaultDatasourceName() {
         return ( this.name.getMethodName() + "-Datasource" );
+    }
+
+    protected String getDefaultFolderName() {
+        return ( this.name.getMethodName() + "-Folder" );
     }
 
 }

--- a/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
@@ -1,0 +1,131 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.dataservice.internal;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import org.junit.Before;
+import org.junit.Test;
+import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.RelationalModelTest;
+import org.komodo.relational.RelationalObject.Filter;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.spi.repository.KomodoType;
+import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
+
+@SuppressWarnings( { "javadoc", "nls" } )
+public final class DataserviceImplTest extends RelationalModelTest {
+
+    private static final String SERVICE_NAME = "myService";
+
+    protected Dataservice dataservice;
+
+    @Before
+    public void init() throws Exception {
+        this.dataservice = createDataservice( SERVICE_NAME );
+    }
+
+    @Test
+    public void shouldHaveName() throws Exception {
+        assertThat( this.dataservice.getName( getTransaction() ), is( SERVICE_NAME ) );
+    }
+
+    @Test
+    public void shouldHaveMoreRawProperties() throws Exception {
+        final String[] filteredProps = this.dataservice.getPropertyNames( getTransaction() );
+        final String[] rawProps = this.dataservice.getRawPropertyNames( getTransaction() );
+        assertThat( ( rawProps.length > filteredProps.length ), is( true ) );
+    }
+
+    @Test
+    public void shouldNotContainFilteredProperties() throws Exception {
+        final String[] filteredProps = this.dataservice.getPropertyNames( getTransaction() );
+        final Filter[] filters = this.dataservice.getFilters();
+
+        for ( final String name : filteredProps ) {
+            for ( final Filter filter : filters ) {
+                assertThat( filter.rejectProperty( name ), is( false ) );
+            }
+        }
+    }
+    
+    @Test
+    public void shouldHaveCorrectPrimaryType() throws Exception {
+        assertThat( this.dataservice.getPrimaryType( getTransaction() ).getName(), is( KomodoLexicon.DataService.NODE_TYPE ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.dataservice.getTypeIdentifier( getTransaction() ), is(KomodoType.DATASERVICE));
+    }
+    
+    @Test
+    public void shouldAddVdb() throws Exception {
+        final String name = "childVdb";
+        final Vdb vdb = this.dataservice.addVdb(getTransaction(), name, "externalPath");
+        
+        assertThat( vdb, is( notNullValue() ) );
+        assertThat( vdb.getName( getTransaction() ), is( name ) );
+        assertThat( this.dataservice.getVdbs( getTransaction() ).length, is( 1 ) );
+        assertThat( this.dataservice.getChildren( getTransaction() )[0], is( instanceOf( Vdb.class ) ) );
+
+        assertThat( this.dataservice.hasChild( getTransaction(), name ), is( true ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), name, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( true ) );
+        assertThat( this.dataservice.hasChildren( getTransaction() ), is( true ) );
+        assertThat( this.dataservice.getChild( getTransaction(), name ), is( vdb ) );
+        assertThat( this.dataservice.getChild( getTransaction(), name, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( vdb ) );
+    }
+
+    @Test
+    public void shouldGetVdbs() throws Exception {
+        final String name1 = "childVdb1";
+        final String name2 = "childVdb2";
+        final Vdb vdb1 = this.dataservice.addVdb(getTransaction(), name1, "externalPath1");
+        final Vdb vdb2 = this.dataservice.addVdb(getTransaction(), name2, "externalPath1");
+        
+        assertThat( vdb1, is( notNullValue() ) );
+        assertThat( vdb2, is( notNullValue() ) );
+        assertThat( vdb1.getName( getTransaction() ), is( name1 ) );
+        assertThat( vdb2.getName( getTransaction() ), is( name2 ) );
+        assertThat( this.dataservice.getVdbs( getTransaction() ).length, is( 2 ) );
+        assertThat( this.dataservice.getChildren( getTransaction() )[1], is( instanceOf( Vdb.class ) ) );
+
+        assertThat( this.dataservice.hasChild( getTransaction(), name1 ), is( true ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), name2 ), is( true ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), name1, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( true ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), name2, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( true ) );
+        assertThat( this.dataservice.hasChildren( getTransaction() ), is( true ) );
+        assertThat( this.dataservice.getChild( getTransaction(), name1 ), is( vdb1 ) );
+        assertThat( this.dataservice.getChild( getTransaction(), name2 ), is( vdb2 ) );
+        assertThat( this.dataservice.getChild( getTransaction(), name1, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( vdb1) );
+        assertThat( this.dataservice.getChild( getTransaction(), name2, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( vdb2) );
+    }
+
+    @Test
+    public void shouldExport() throws Exception {
+        // TBD. 
+    }
+
+}

--- a/komodo-relational/src/test/java/org/komodo/relational/folder/internal/FolderImplTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/folder/internal/FolderImplTest.java
@@ -1,0 +1,172 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.folder.internal;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import org.junit.Before;
+import org.junit.Test;
+import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.RelationalModelTest;
+import org.komodo.relational.RelationalObject.Filter;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.datasource.Datasource;
+import org.komodo.relational.folder.Folder;
+import org.komodo.relational.model.Schema;
+import org.komodo.relational.vdb.Vdb;
+import org.komodo.spi.repository.KomodoType;
+import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
+
+@SuppressWarnings( { "javadoc", "nls" } )
+public final class FolderImplTest extends RelationalModelTest {
+
+    private static final String FOLDER_NAME = "myFolder";
+
+    protected Folder folder;
+
+    @Before
+    public void init() throws Exception {
+        this.folder = createFolder( FOLDER_NAME );
+    }
+
+    @Test
+    public void shouldHaveId() throws Exception {
+        assertThat( this.folder.getName( getTransaction() ), is( FOLDER_NAME ) );
+    }
+
+    @Test
+    public void shouldHaveMoreRawProperties() throws Exception {
+        final String[] filteredProps = this.folder.getPropertyNames( getTransaction() );
+        final String[] rawProps = this.folder.getRawPropertyNames( getTransaction() );
+        assertThat( ( rawProps.length > filteredProps.length ), is( true ) );
+    }
+
+    @Test
+    public void shouldNotContainFilteredProperties() throws Exception {
+        final String[] filteredProps = this.folder.getPropertyNames( getTransaction() );
+        final Filter[] filters = this.folder.getFilters();
+
+        for ( final String name : filteredProps ) {
+            for ( final Filter filter : filters ) {
+                assertThat( filter.rejectProperty( name ), is( false ) );
+            }
+        }
+    }
+    
+    @Test
+    public void shouldHaveCorrectPrimaryType() throws Exception {
+        assertThat( this.folder.getPrimaryType( getTransaction() ).getName(), is( KomodoLexicon.Folder.NODE_TYPE ) );
+    }
+
+    @Test
+    public void shouldHaveCorrectTypeIdentifier() throws Exception {
+        assertThat(this.folder.getTypeIdentifier( getTransaction() ), is(KomodoType.FOLDER));
+    }
+
+    @Test
+    public void shouldAddFolder() throws Exception {
+        final String name = "aFolder";
+        final Folder anotherFolder = this.folder.addFolder(getTransaction(), name);
+        
+        assertThat( anotherFolder, is( notNullValue() ) );
+        assertThat( anotherFolder.getName( getTransaction() ), is( name ) );
+        assertThat( this.folder.getFolders( getTransaction() ).length, is( 1 ) );
+        assertThat( this.folder.getChildren( getTransaction() )[0], is( instanceOf( Folder.class ) ) );
+
+        assertThat( this.folder.hasChild( getTransaction(), name ), is( true ) );
+        assertThat( this.folder.hasChild( getTransaction(), name, KomodoLexicon.Folder.NODE_TYPE ), is( true ) );
+        assertThat( this.folder.hasChildren( getTransaction() ), is( true ) );
+        assertThat( this.folder.getChild( getTransaction(), name ), is( anotherFolder ) );
+        assertThat( this.folder.getChild( getTransaction(), name, KomodoLexicon.Folder.NODE_TYPE ), is( anotherFolder ) );
+    }
+
+    @Test
+    public void shouldAddVdb() throws Exception {
+        final String name = "aVdb";
+        final Vdb vdb = this.folder.addVdb(getTransaction(), name, "externalPath");
+        
+        assertThat( vdb, is( notNullValue() ) );
+        assertThat( vdb.getName( getTransaction() ), is( name ) );
+        assertThat( this.folder.getVdbs( getTransaction() ).length, is( 1 ) );
+        assertThat( this.folder.getChildren( getTransaction() )[0], is( instanceOf( Vdb.class ) ) );
+
+        assertThat( this.folder.hasChild( getTransaction(), name ), is( true ) );
+        assertThat( this.folder.hasChild( getTransaction(), name, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( true ) );
+        assertThat( this.folder.hasChildren( getTransaction() ), is( true ) );
+        assertThat( this.folder.getChild( getTransaction(), name ), is( vdb ) );
+        assertThat( this.folder.getChild( getTransaction(), name, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( vdb ) );
+    }
+
+    @Test
+    public void shouldAddSchema() throws Exception {
+        final String name = "schema";
+        final Schema schema = this.folder.addSchema(getTransaction(), name);
+        
+        assertThat( schema, is( notNullValue() ) );
+        assertThat( schema.getName( getTransaction() ), is( name ) );
+        assertThat( this.folder.getSchemas( getTransaction() ).length, is( 1 ) );
+        assertThat( this.folder.getChildren( getTransaction() )[0], is( instanceOf( Schema.class ) ) );
+
+        assertThat( this.folder.hasChild( getTransaction(), name ), is( true ) );
+        assertThat( this.folder.hasChild( getTransaction(), name, KomodoLexicon.Schema.NODE_TYPE ), is( true ) );
+        assertThat( this.folder.hasChildren( getTransaction() ), is( true ) );
+        assertThat( this.folder.getChild( getTransaction(), name ), is( schema ) );
+        assertThat( this.folder.getChild( getTransaction(), name, KomodoLexicon.Schema.NODE_TYPE ), is( schema ) );
+    }
+    
+    @Test
+    public void shouldAddDatasource() throws Exception {
+        final String name = "dataSource";
+        final Datasource ds = this.folder.addDatasource(getTransaction(), name);
+        
+        assertThat( ds, is( notNullValue() ) );
+        assertThat( ds.getName( getTransaction() ), is( name ) );
+        assertThat( this.folder.getDatasources( getTransaction() ).length, is( 1 ) );
+        assertThat( this.folder.getChildren( getTransaction() )[0], is( instanceOf( Datasource.class ) ) );
+
+        assertThat( this.folder.hasChild( getTransaction(), name ), is( true ) );
+        assertThat( this.folder.hasChild( getTransaction(), name, KomodoLexicon.DataSource.NODE_TYPE ), is( true ) );
+        assertThat( this.folder.hasChildren( getTransaction() ), is( true ) );
+        assertThat( this.folder.getChild( getTransaction(), name ), is( ds ) );
+        assertThat( this.folder.getChild( getTransaction(), name, KomodoLexicon.DataSource.NODE_TYPE ), is( ds ) );
+    }
+    
+    @Test
+    public void shouldAddDataservice() throws Exception {
+        final String name = "dataService";
+        final Dataservice service = this.folder.addDataservice(getTransaction(), name);
+        
+        assertThat( service, is( notNullValue() ) );
+        assertThat( service.getName( getTransaction() ), is( name ) );
+        assertThat( this.folder.getDataservices( getTransaction() ).length, is( 1 ) );
+        assertThat( this.folder.getChildren( getTransaction() )[0], is( instanceOf( Dataservice.class ) ) );
+
+        assertThat( this.folder.hasChild( getTransaction(), name ), is( true ) );
+        assertThat( this.folder.hasChild( getTransaction(), name, KomodoLexicon.DataService.NODE_TYPE ), is( true ) );
+        assertThat( this.folder.hasChildren( getTransaction() ), is( true ) );
+        assertThat( this.folder.getChild( getTransaction(), name ), is( service ) );
+        assertThat( this.folder.getChild( getTransaction(), name, KomodoLexicon.DataService.NODE_TYPE ), is( service ) );
+    }
+    
+}

--- a/komodo-relational/src/test/java/org/komodo/relational/workspace/WorkspaceManagerTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/workspace/WorkspaceManagerTest.java
@@ -34,7 +34,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalProperty;
+import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.datasource.Datasource;
+import org.komodo.relational.folder.Folder;
 import org.komodo.relational.model.AccessPattern;
 import org.komodo.relational.model.DataTypeResultSet;
 import org.komodo.relational.model.ForeignKey;
@@ -87,6 +89,27 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
     public void uncacheWorkspaceManager() {
         WorkspaceManager.uncacheInstance(_repo);
         wsMgr = null;
+    }
+
+    @Test
+    public void shouldCreateDatasource() throws Exception {
+        final Datasource datasource = this.wsMgr.createDatasource( getTransaction(), null, "ds" );
+        assertThat( datasource, is( notNullValue() ) );
+        assertThat( _repo.getFromWorkspace( getTransaction(), datasource.getAbsolutePath() ), is( ( KomodoObject )datasource ) );
+    }
+
+    @Test
+    public void shouldCreateDataservice() throws Exception {
+        final Dataservice dataservice = this.wsMgr.createDataservice( getTransaction(), null, "service" );
+        assertThat( dataservice, is( notNullValue() ) );
+        assertThat( _repo.getFromWorkspace( getTransaction(), dataservice.getAbsolutePath() ), is( ( KomodoObject )dataservice ) );
+    }
+
+    @Test
+    public void shouldCreateFolder() throws Exception {
+        final Folder folder = this.wsMgr.createFolder( getTransaction(), null, "model" );
+        assertThat( folder, is( notNullValue() ) );
+        assertThat( _repo.getFromWorkspace( getTransaction(), folder.getAbsolutePath() ), is( ( KomodoObject )folder ) );
     }
 
     @Test
@@ -255,8 +278,8 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
 
     @Test
     public void shouldHaveCorrectChildTypes() {
-        assertThat( Arrays.asList( this.wsMgr.getChildTypes() ), hasItems( Datasource.IDENTIFIER, Vdb.IDENTIFIER, Schema.IDENTIFIER, Teiid.IDENTIFIER ) );
-        assertThat( this.wsMgr.getChildTypes().length, is( 4 ) );
+        assertThat( Arrays.asList( this.wsMgr.getChildTypes() ), hasItems( Folder.IDENTIFIER, Datasource.IDENTIFIER, Dataservice.IDENTIFIER, Vdb.IDENTIFIER, Schema.IDENTIFIER, Teiid.IDENTIFIER ) );
+        assertThat( this.wsMgr.getChildTypes().length, is( 6 ) );
     }
 
     @Test( expected = Exception.class )
@@ -365,6 +388,13 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
     }
 
     @Test
+    public void shouldResolveDataservice() throws Exception {
+        final Dataservice service = this.wsMgr.createDataservice(getTransaction(), null, "service");
+        final KomodoObject kobject = new ObjectImpl(_repo, service.getAbsolutePath(), service.getIndex());
+        assertThat(this.wsMgr.resolve(getTransaction(), kobject, Dataservice.class), is(instanceOf(Dataservice.class)));
+    }
+
+    @Test
     public void shouldResolveDataTypeResultSet() throws Exception {
         final Model model = createModel();
         final StoredProcedure procedure = model.addStoredProcedure(getTransaction(), "procedure");
@@ -379,6 +409,13 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
         final Entry entry = vdb.addEntry(getTransaction(), "entry", "path");
         final KomodoObject kobject = new ObjectImpl(_repo, entry.getAbsolutePath(), entry.getIndex());
         assertThat(this.wsMgr.resolve(getTransaction(), kobject, Entry.class), is(instanceOf(Entry.class)));
+    }
+
+    @Test
+    public void shouldResolveFolder() throws Exception {
+        final Folder folder = this.wsMgr.createFolder(getTransaction(), null, "folder");
+        final KomodoObject kobject = new ObjectImpl(_repo, folder.getAbsolutePath(), folder.getIndex());
+        assertThat(this.wsMgr.resolve(getTransaction(), kobject, Folder.class), is(instanceOf(Folder.class)));
     }
 
     @Test
@@ -455,6 +492,13 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
         final Function function = model.addPushdownFunction(getTransaction(), "function");
         final KomodoObject kobject = new ObjectImpl(_repo, function.getAbsolutePath(), function.getIndex());
         assertThat(this.wsMgr.resolve(getTransaction(), kobject, PushdownFunction.class), is(instanceOf(PushdownFunction.class)));
+    }
+
+    @Test
+    public void shouldResolveSchema() throws Exception {
+        final Schema schema = createSchema();
+        final KomodoObject kobject = new ObjectImpl(_repo, schema.getAbsolutePath(), schema.getIndex());
+        assertThat(this.wsMgr.resolve(getTransaction(), kobject, Schema.class), is(instanceOf(Schema.class)));
     }
 
     @Test
@@ -709,6 +753,21 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
                 }
                 case RESULT_SET_COLUMN: {
                     // see separate test
+                    break;
+                }
+                case FOLDER: {
+                    KomodoObject result = wsMgr.create(getTransaction(), workspace, "test" + id, type);
+                    assertNotNull(result);
+                    break;
+                }
+                case DATASOURCE: {
+                    KomodoObject result = wsMgr.create(getTransaction(), workspace, "test" + id, type);
+                    assertNotNull(result);
+                    break;
+                }
+                case DATASERVICE: {
+                    KomodoObject result = wsMgr.create(getTransaction(), workspace, "test" + id, type);
+                    assertNotNull(result);
                     break;
                 }
                 case SCHEMA: {

--- a/komodo-spi/src/main/java/org/komodo/spi/repository/KomodoType.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/repository/KomodoType.java
@@ -33,9 +33,19 @@ import org.komodo.spi.constants.StringConstants;
 public enum KomodoType {
 
     /**
+     * Dataservice
+     */
+    DATASERVICE("dataservice"), //$NON-NLS-1$
+
+    /**
      * Datasource
      */
-    DATASOURCE("datasource"),
+    DATASOURCE("datasource"), //$NON-NLS-1$
+
+    /**
+     * Folder
+     */
+    FOLDER,
 
     /**
      * Schema


### PR DESCRIPTION
Adds Dataservice and Folder repo objects
- Folders can contain other folders, datasources, dataservices, vdbs and schema
- Dataservice extends a VDB.  Currently it can only contain other VDB children, but child types may be added or removed as we define dataservices in future sprints