### PR TITLE
Adds dataservice rest methods

### DIFF
--- a/komodo-relational-commands/src/main/java/org/komodo/relational/commands/FindCommand.java
+++ b/komodo-relational-commands/src/main/java/org/komodo/relational/commands/FindCommand.java
@@ -164,7 +164,7 @@ public final class FindCommand extends RelationalShellCommand {
                                   final String pattern ) throws Exception {
         final String lexiconType = KomodoTypeRegistry.getInstance().getIdentifier( queryType ).getLexiconType();
         final WorkspaceManager wsMgr = WorkspaceManager.getInstance( wsStatus.getCurrentContext().getRepository() );
-        final String[] searchResults = wsMgr.findByType( wsStatus.getTransaction(), lexiconType, parentPath, pattern );
+        final String[] searchResults = wsMgr.findByType( wsStatus.getTransaction(), lexiconType, parentPath, pattern, false );
 
         if ( searchResults.length == 0 ) {
             return searchResults;

--- a/server/komodo-rest/src/main/java/org/komodo/rest/RestLink.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/RestLink.java
@@ -65,6 +65,11 @@ public final class RestLink {
         SEARCH,
 
         /**
+         * A link to a VDB resource
+         */
+        VDBS(KomodoType.VDB),
+
+        /**
          * A link to a vdb imports resource
          */
         IMPORTS(KomodoType.VDB_IMPORT),

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -41,6 +41,26 @@ public final class RelationalMessages {
     public enum Error {
 
         /**
+         * An error indicating a JSON document representing the Dataservices in the workspace could not be retrieved.
+         */
+        DATASERVICE_SERVICE_GET_DATASERVICES_ERROR,
+
+        /**
+         * An error indicating an error occurred trying to obtain the specified Dataservice.
+         */
+        DATASERVICE_SERVICE_GET_DATASERVICE_ERROR,
+
+        /**
+         * An error indicating a request to create a dataservice failed
+         */
+        DATASERVICE_SERVICE_CREATE_DATASERVICE_ERROR,
+
+        /**
+         * An error indicating a request to delete a dataservice failed
+         */
+        DATASERVICE_SERVICE_DELETE_DATASERVICE_ERROR,
+
+        /**
          * An error indicating the VDB descriptor JSON representation could not be created.
          */
         VDB_DESCRIPTOR_BUILDER_ERROR,

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestEntityFactory.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RestEntityFactory.java
@@ -22,6 +22,7 @@
 package org.komodo.rest.relational;
 
 import java.net.URI;
+import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.datasource.Datasource;
 import org.komodo.relational.model.Model;
 import org.komodo.relational.teiid.Teiid;
@@ -35,8 +36,9 @@ import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.vdb.VdbImport;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.rest.KomodoRestV1Application.V1Constants;
-import org.komodo.rest.relational.datasource.RestDataSource;
 import org.komodo.rest.RestBasicEntity;
+import org.komodo.rest.relational.dataservice.RestDataservice;
+import org.komodo.rest.relational.datasource.RestDataSource;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
@@ -99,6 +101,9 @@ public class RestEntityFactory implements V1Constants {
             case DATASOURCE:
                 Datasource dataSource = wsMgr.resolve(uow, kObject, Datasource.class);
                 return (T) new RestDataSource(baseUri, dataSource, uow);
+            case DATASERVICE:
+                Dataservice dataService = wsMgr.resolve(uow, kObject, Dataservice.class);
+                return (T) new RestDataservice(baseUri, dataService, false, uow);
             case UNKNOWN:
                 return null;
             default:

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/DataServiceSchema.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/DataServiceSchema.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.dataservice;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.core.MediaType;
+import org.komodo.rest.KRestEntity;
+import org.komodo.spi.repository.KomodoType;
+
+public class DataServiceSchema implements KRestEntity {
+
+    /**
+     * Label for the whole data source schema
+     */
+    public static final String NAME_LABEL = KomodoType.DATASERVICE.name().toLowerCase();
+
+    /**
+     * Label for the id
+     */
+    public static final String ID_LABEL = "keng__id";
+
+    /**
+     * Label for the ktype
+     */
+    public static final String KTYPE_LABEL = "keng__kType";
+
+    /**
+     * Label for the description
+     */
+    public static final String DESCRIPTION_LABEL = "keng__description";
+
+    /**
+     * Label for the properties
+     */
+    public static final String PROPERTIES_LABEL = "keng__properties";
+
+    private String id = KomodoType.DATASERVICE.name().toLowerCase();
+
+    private String kType = KomodoType.DATASERVICE.getType();
+
+    private String description = "Describes the configuration for a dataservice";
+
+    private List<DataServiceSchemaProperty> properties = new ArrayList<DataServiceSchemaProperty>(4);
+
+    public DataServiceSchema() {
+    }
+
+    @Override
+    public Object getXml() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean supports(MediaType mediaType) {
+        return MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getkType() {
+        return kType;
+    }
+
+    public void setkType(String kType) {
+        this.kType = kType;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<DataServiceSchemaProperty> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<DataServiceSchemaProperty> properties) {
+        this.properties = properties;
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/DataServiceSchemaProperty.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/DataServiceSchemaProperty.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.dataservice;
+
+public class DataServiceSchemaProperty {
+
+    public static final String TYPE_LABEL = "keng__type";
+
+    public static final String REQUIRED_LABEL = "keng__required";
+
+    public static final String REPEATABLE_LABEL = "keng__repeatable";
+
+    public static final String LIMIT_LABEL = "keng__limit";
+
+    public static final String PROPERTIES_NAME_LABEL = "property";
+
+    private String name;
+
+    private String type = "string";
+
+    private boolean required = true;
+
+    private boolean repeatable = false;
+
+    private int limit = 1;
+
+    public DataServiceSchemaProperty(String name, String type, boolean required, boolean repeatable, int limit) {
+        setName(name);
+        setType(type);
+        setRequired(required);
+        setRepeatable(repeatable);
+        setLimit(limit);
+    }
+
+    public DataServiceSchemaProperty(String name) {
+        setName(name);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    public boolean isRepeatable() {
+        return repeatable;
+    }
+
+    public void setRepeatable(boolean repeatable) {
+        this.repeatable = repeatable;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
@@ -1,0 +1,208 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.dataservice;
+
+import java.net.URI;
+import java.util.Properties;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.rest.KomodoService;
+import org.komodo.rest.RestBasicEntity;
+import org.komodo.rest.RestLink;
+import org.komodo.rest.RestLink.LinkType;
+import org.komodo.rest.relational.KomodoRestUriBuilder.SettingNames;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
+
+/**
+ * A Dataservice that can be used by GSON to build a JSON document representation.
+ */
+public final class RestDataservice extends RestBasicEntity {
+
+    /**
+     * Label used to describe name
+     */
+    public static final String NAME_LABEL = KomodoService.encode(VdbLexicon.Vdb.NAME);
+
+    /**
+     * Label used to describe description
+     */
+    public static final String DESCRIPTION_LABEL = KomodoService.encode(VdbLexicon.Vdb.DESCRIPTION);
+
+    /**
+     * Label used to describe original file path
+     */
+    public static final String FILE_PATH_LABEL = KomodoService.encode(VdbLexicon.Vdb.ORIGINAL_FILE);
+
+    /**
+     * Label used to describe original file path
+     */
+    public static final String PREVIEW_LABEL = KomodoService.encode(VdbLexicon.Vdb.PREVIEW);
+
+    /**
+     * Label used to describe original file path
+     */
+    public static final String CONNECTION_TYPE_LABEL = KomodoService.encode(VdbLexicon.Vdb.CONNECTION_TYPE);
+
+    /**
+     * Label used to describe original file path
+     */
+    public static final String VERSION_LABEL = KomodoService.encode(VdbLexicon.Vdb.VERSION);
+
+    /**
+     * Constructor for use when deserializing
+     */
+    public RestDataservice() {
+        super();
+    }
+
+    /**
+     * Constructor for use when serializing.
+     * @param baseUri the base uri of the vdb
+     * @param dataService the dataService
+     * @param exportXml whether xml should be exported
+     * @param uow the transaction
+     *
+     * @throws KException if error occurs
+     */
+    public RestDataservice(URI baseUri, Dataservice dataService, boolean exportXml, UnitOfWork uow) throws KException {
+        super(baseUri, dataService, uow, false);
+
+        setName(dataService.getName(uow));
+        setDescription(dataService.getDescription(uow));
+        setOriginalFilePath(dataService.getOriginalFilePath(uow));
+
+        setPreview(dataService.isPreview(uow));
+        setConnectionType(dataService.getConnectionType(uow));
+        setVersion(dataService.getVersion(uow));
+
+        addExecutionProperties(uow, dataService);
+
+        if (exportXml) {
+            String xml = dataService.export(uow, new Properties());
+            setXml(xml);
+        }
+
+        Properties settings = getUriBuilder().createSettings(SettingNames.DATA_SERVICE_NAME, getId());
+        URI parentUri = getUriBuilder().dataserviceParentUri(dataService, uow);
+        getUriBuilder().addSetting(settings, SettingNames.DATA_SERVICE_PARENT_PATH, parentUri);
+
+        addLink(new RestLink(LinkType.SELF, getUriBuilder().dataserviceUri(LinkType.SELF, settings)));
+        addLink(new RestLink(LinkType.PARENT, getUriBuilder().dataserviceUri(LinkType.PARENT, settings)));
+        createChildLink();
+        addLink(new RestLink(LinkType.IMPORTS, getUriBuilder().dataserviceUri(LinkType.IMPORTS, settings)));
+        addLink(new RestLink(LinkType.MODELS, getUriBuilder().dataserviceUri(LinkType.MODELS, settings)));
+        addLink(new RestLink(LinkType.TRANSLATORS, getUriBuilder().dataserviceUri(LinkType.TRANSLATORS, settings)));
+        addLink(new RestLink(LinkType.DATA_ROLES, getUriBuilder().dataserviceUri(LinkType.DATA_ROLES, settings)));
+        addLink(new RestLink(LinkType.VDBS, getUriBuilder().dataserviceUri(LinkType.VDBS, settings)));
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        Object name = tuples.get(NAME_LABEL);
+        return name != null ? name.toString() : null;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        tuples.put(NAME_LABEL, name);
+    }
+
+    /**
+     * @return the VDB description (can be empty)
+     */
+    public String getDescription() {
+        Object description = tuples.get(DESCRIPTION_LABEL);
+        return description != null ? description.toString() : null;
+    }
+
+    /**
+     * @param description the description to set
+     */
+    public void setDescription(String description) {
+        tuples.put(DESCRIPTION_LABEL, description);
+    }
+
+    /**
+     * @return the originalFilePath
+     */
+    public String getOriginalFilePath() {
+        Object path = tuples.get(FILE_PATH_LABEL);
+        return path != null ? path.toString() : null;
+    }
+
+    /**
+     * @param originalFilePath the originalFilePath to set
+     */
+    public void setOriginalFilePath(String originalFilePath) {
+        tuples.put(FILE_PATH_LABEL, originalFilePath);
+    }
+
+    /**
+     * @return the preview
+     */
+    public boolean isPreview() {
+        Object preview = tuples.get(PREVIEW_LABEL);
+        return preview != null ? Boolean.parseBoolean(preview.toString()) : null;
+    }
+
+    /**
+     * @param preview the preview to set
+     */
+    public void setPreview(boolean preview) {
+        tuples.put(PREVIEW_LABEL, preview);
+    }
+
+    /**
+     * @return the connectionType
+     */
+    public String getConnectionType() {
+        Object connectionType = tuples.get(CONNECTION_TYPE_LABEL);
+        return connectionType != null ? connectionType.toString() : null;
+    }
+
+    /**
+     * @param connectionType the connectionType to set
+     */
+    public void setConnectionType(String connectionType) {
+        tuples.put(CONNECTION_TYPE_LABEL, connectionType);
+    }
+
+    /**
+     * @return the version
+     */
+    public int getVersion() {
+        Object version = tuples.get(VERSION_LABEL);
+        return version != null ? Integer.parseInt(version.toString()) : null;
+    }
+
+    /**
+     * @param version the version to set
+     */
+    public void setVersion(int version) {
+        tuples.put(VERSION_LABEL, version);
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.json;
+
+import org.komodo.rest.relational.dataservice.RestDataservice;
+import org.komodo.utils.StringUtils;
+
+/**
+ * A GSON serializer/deserializer for {@link RestDataservice}s.
+ */
+public final class DataserviceSerializer extends BasicEntitySerializer<RestDataservice> {
+
+    @Override
+    protected boolean isComplete(final RestDataservice dataService) {
+        return super.isComplete(dataService) && !StringUtils.isBlank(dataService.getName());
+    }
+
+    @Override
+    protected RestDataservice createEntity() {
+        return new RestDataservice();
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
@@ -48,14 +48,16 @@ import org.komodo.rest.relational.RestVdbModel;
 import org.komodo.rest.relational.RestVdbModelSource;
 import org.komodo.rest.relational.RestVdbPermission;
 import org.komodo.rest.relational.RestVdbTranslator;
+import org.komodo.rest.relational.dataservice.DataServiceSchema;
+import org.komodo.rest.relational.dataservice.RestDataservice;
 import org.komodo.rest.relational.datasource.DSSPropertyPairProperty;
 import org.komodo.rest.relational.datasource.DataSourceSchema;
 import org.komodo.rest.relational.datasource.DataSourceSchemaProperty;
 import org.komodo.rest.relational.datasource.RestDataSource;
-import org.komodo.rest.relational.json.datasource.DSSSerializer;
 import org.komodo.rest.relational.json.datasource.DSSPropertyListSerializer;
 import org.komodo.rest.relational.json.datasource.DSSPropertyPairPropertySerializer;
 import org.komodo.rest.relational.json.datasource.DSSPropertySerializer;
+import org.komodo.rest.relational.json.datasource.DSSSerializer;
 import org.komodo.rest.relational.json.datasource.DataSourceSerializer;
 import org.komodo.rest.schema.json.TeiidXsdReader;
 import org.komodo.spi.repository.KomodoType;
@@ -97,6 +99,7 @@ public final class KomodoJsonMarshaller {
                                                   .registerTypeAdapter( RestVdbCondition.class, new VdbConditionSerializer() )
                                                   .registerTypeAdapter( RestVdbMask.class, new VdbMaskSerializer() )
                                                   .registerTypeAdapter( RestVdbTranslator.class, new VdbTranslatorSerializer() )
+                                                  .registerTypeAdapter( RestDataservice.class, new DataserviceSerializer() )
                                                   .registerTypeAdapter( RestDataSource.class, new DataSourceSerializer() )
                                                   .registerTypeAdapter( RestBasicEntity.class, new BasicEntitySerializer<RestBasicEntity>() )
                                                   .registerTypeAdapter( RestTeiid.class, new TeiidSerializer() )
@@ -158,6 +161,10 @@ public final class KomodoJsonMarshaller {
 
             DataSourceSchema dsSchema = new DataSourceSchema();
             schema = marshall(dsSchema);
+
+        } else if (KomodoType.DATASERVICE.equals(kType)) {
+            DataServiceSchema dataserviceSchema = new DataServiceSchema();
+            schema = marshall(dataserviceSchema);
 
         } else {
             schema = reader.schemaByKType(kType);

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -1,0 +1,315 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.service;
+
+import static org.komodo.rest.relational.RelationalMessages.Error.DATASERVICE_SERVICE_CREATE_DATASERVICE_ERROR;
+import static org.komodo.rest.relational.RelationalMessages.Error.DATASERVICE_SERVICE_DELETE_DATASERVICE_ERROR;
+import static org.komodo.rest.relational.RelationalMessages.Error.DATASERVICE_SERVICE_GET_DATASERVICES_ERROR;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.komodo.core.KEngine;
+import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.workspace.WorkspaceManager;
+import org.komodo.repository.ObjectImpl;
+import org.komodo.rest.KomodoRestException;
+import org.komodo.rest.KomodoRestV1Application.V1Constants;
+import org.komodo.rest.KomodoService;
+import org.komodo.rest.relational.KomodoProperties;
+import org.komodo.rest.relational.KomodoStatusObject;
+import org.komodo.rest.relational.dataservice.RestDataservice;
+import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.repository.Repository.UnitOfWork.State;
+import org.komodo.utils.StringUtils;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+/**
+ * A Komodo REST service for obtaining Dataservice information from the workspace.
+ */
+@Path(V1Constants.WORKSPACE_SEGMENT + StringConstants.FORWARD_SLASH +
+           V1Constants.DATA_SERVICES_SEGMENT)
+@Api(tags = {V1Constants.DATA_SERVICES_SEGMENT})
+public final class KomodoDataserviceService extends KomodoService {
+
+    private static final int ALL_AVAILABLE = -1;
+
+    /**
+     * @param engine
+     *        the Komodo Engine (cannot be <code>null</code> and must be started)
+     * @throws ServerErrorException
+     *         if there is a problem obtaining the {@link WorkspaceManager workspace manager}
+     */
+    public KomodoDataserviceService( final KEngine engine ) throws ServerErrorException {
+        super( engine );
+    }
+
+    /**
+     * @param headers
+     *        the request headers (never <code>null</code>)
+     * @param uriInfo
+     *        the request URI information (never <code>null</code>)
+     * @return a JSON document representing all the Dataservices in the Komodo workspace (never <code>null</code>)
+     * @throws KomodoRestException
+     *         if there is a problem constructing the Dataservices JSON document
+     */
+    @GET
+    @Produces( MediaType.APPLICATION_JSON )
+    @Consumes ( { MediaType.APPLICATION_JSON } )
+    @ApiOperation(value = "Display the collection of data services",
+                            response = RestDataservice[].class)
+    @ApiResponses(value = {
+        @ApiResponse(code = 403, message = "An error has occurred.")
+    })
+    public Response getDataservices( final @Context HttpHeaders headers,
+                                     final @Context UriInfo uriInfo ) throws KomodoRestException {
+
+        List<MediaType> mediaTypes = headers.getAcceptableMediaTypes();
+        UnitOfWork uow = null;
+
+        try {
+            final String searchPattern = uriInfo.getQueryParameters().getFirst( QueryParamKeys.PATTERN );
+
+            // find Data services
+            uow = createTransaction( "getDataservices", true ); //$NON-NLS-1$
+            Dataservice[] dataServices = null;
+
+            if ( StringUtils.isBlank( searchPattern ) ) {
+                dataServices = this.wsMgr.findDataservices( uow );
+                LOGGER.debug( "getDataservices:found '{0}' Dataservices", dataServices.length ); //$NON-NLS-1$
+            } else {
+                final String[] dataservicePaths = this.wsMgr.findByType( uow, KomodoLexicon.DataService.NODE_TYPE, null, searchPattern, false );
+
+                if ( dataservicePaths.length == 0 ) {
+                    dataServices = Dataservice.NO_DATASERVICES;
+                } else {
+                    dataServices = new Dataservice[ dataservicePaths.length ];
+                    int i = 0;
+
+                    for ( final String path : dataservicePaths ) {
+                        dataServices[ i++ ] = this.wsMgr.resolve( uow, new ObjectImpl( this.wsMgr.getRepository(), path, 0 ), Dataservice.class );
+                    }
+
+                    LOGGER.debug( "getDataservices:found '{0}' DataServices using pattern '{1}'", dataServices.length, searchPattern ); //$NON-NLS-1$
+                }
+            }
+
+            int start = 0;
+
+            { // start query parameter
+                final String qparam = uriInfo.getQueryParameters().getFirst( QueryParamKeys.START );
+
+                if ( qparam != null ) {
+
+                    try {
+                        start = Integer.parseInt( qparam );
+
+                        if ( start < 0 ) {
+                            start = 0;
+                        }
+                    } catch ( final Exception e ) {
+                        start = 0;
+                    }
+                }
+            }
+
+            int size = ALL_AVAILABLE;
+
+            { // size query parameter
+                final String qparam = uriInfo.getQueryParameters().getFirst( QueryParamKeys.SIZE );
+
+                if ( qparam != null ) {
+
+                    try {
+                        size = Integer.parseInt( qparam );
+
+                        if ( size <= 0 ) {
+                            size = ALL_AVAILABLE;
+                        }
+                    } catch ( final Exception e ) {
+                        size = ALL_AVAILABLE;
+                    }
+                }
+            }
+
+            final List< RestDataservice > entities = new ArrayList< >();
+            int i = 0;
+
+            KomodoProperties properties = new KomodoProperties();
+            //properties.addProperty(VDB_EXPORT_XML_PROPERTY, false);
+            for ( final Dataservice dataService : dataServices ) {
+                if ( ( start == 0 ) || ( i >= start ) ) {
+                    if ( ( size == ALL_AVAILABLE ) || ( entities.size() < size ) ) {
+                        RestDataservice entity = entityFactory.create(dataService, uriInfo.getBaseUri(), uow, properties);
+                        entities.add(entity);
+                        LOGGER.debug("getDataservices:Dataservice '{0}' entity was constructed", dataService.getName(uow)); //$NON-NLS-1$
+                    } else {
+                        break;
+                    }
+                }
+
+                ++i;
+            }
+
+            // create response
+            return commit( uow, mediaTypes, entities );
+
+        } catch ( final Exception e ) {
+            if ( ( uow != null ) && ( uow.getState() != State.ROLLED_BACK ) ) {
+                uow.rollback();
+            }
+
+            if ( e instanceof KomodoRestException ) {
+                throw ( KomodoRestException )e;
+            }
+
+            return createErrorResponse(mediaTypes, e, DATASERVICE_SERVICE_GET_DATASERVICES_ERROR);
+        }
+    }
+    
+    /**
+     * @param headers
+     *        the request headers (never <code>null</code>)
+     * @param uriInfo
+     *        the request URI information (never <code>null</code>)
+     * @param dataserviceName
+     *        the dataservice name (cannot be <code>null</code>)
+     * @return a JSON document representing the search attributes passed from the request
+     *                  (never <code>null</code>)
+     * @throws KomodoRestException
+     *         if there is a problem performing the save
+     */
+    @POST
+    @Path("{dataserviceName}")
+    @Produces( MediaType.APPLICATION_JSON )
+    @Consumes ( { MediaType.APPLICATION_JSON } )
+    @ApiOperation(value = "Create a dataservice in the workspace")
+    @ApiResponses(value = {
+        @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
+        @ApiResponse(code = 403, message = "An error has occurred.")
+    })
+    public Response createDataservice( final @Context HttpHeaders headers,
+                                       final @Context UriInfo uriInfo,
+                                       final @PathParam( "dataserviceName" ) String dataserviceName) throws KomodoRestException {
+
+        List<MediaType> mediaTypes = headers.getAcceptableMediaTypes();
+        if (! isAcceptable(mediaTypes, MediaType.APPLICATION_JSON_TYPE))
+            return notAcceptableMediaTypesBuilder().build();
+
+        UnitOfWork uow = null;
+        try {
+            uow = createTransaction("createDataserviceInWorkspace", false); //$NON-NLS-1$
+
+            KomodoObject dataservice = repo.komodoWorkspace(uow).addChild(uow, dataserviceName, KomodoLexicon.DataService.NODE_TYPE);
+
+            if (dataservice == null)
+                return Response.noContent().build();
+
+            KomodoStatusObject kso = new KomodoStatusObject("Create Status"); //$NON-NLS-1$
+            kso.addAttribute(dataserviceName, "Successfully created"); //$NON-NLS-1$
+
+            return commit(uow, mediaTypes, kso);
+        } catch (final Exception e) {
+            if ((uow != null) && (uow.getState() != State.ROLLED_BACK)) {
+                uow.rollback();
+            }
+
+            if (e instanceof KomodoRestException) {
+                throw (KomodoRestException)e;
+            }
+
+            return createErrorResponse(mediaTypes, e, DATASERVICE_SERVICE_CREATE_DATASERVICE_ERROR);
+        }
+        
+    }
+
+    /**
+     * @param headers
+     *        the request headers (never <code>null</code>)
+     * @param uriInfo
+     *        the request URI information (never <code>null</code>)
+     * @param dataserviceName
+     *        the name of the data service to remove (cannot be <code>null</code>)
+     * @return a JSON document representing the results of the removal
+     * @throws KomodoRestException
+     *         if there is a problem performing the delete
+     */
+    @DELETE
+    @Path("{dataserviceName}")
+    @Produces( MediaType.APPLICATION_JSON )
+    @ApiOperation(value = "Delete a dataservice from the workspace")
+    @ApiResponses(value = {
+        @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
+        @ApiResponse(code = 403, message = "An error has occurred.")
+    })
+    public Response deleteDataservice( final @Context HttpHeaders headers,
+                                       final @Context UriInfo uriInfo,
+                                       final @PathParam( "dataserviceName" ) String dataserviceName) throws KomodoRestException {
+        List<MediaType> mediaTypes = headers.getAcceptableMediaTypes();
+
+        UnitOfWork uow = null;
+        try {
+            uow = createTransaction("removeDataserviceFromWorkspace", false); //$NON-NLS-1$
+
+            final WorkspaceManager mgr = WorkspaceManager.getInstance( repo );
+            KomodoObject dataservice = mgr.getChild(uow, dataserviceName, KomodoLexicon.DataService.NODE_TYPE);
+            
+            if (dataservice == null)
+                return Response.noContent().build();
+
+            mgr.delete(uow, dataservice);
+
+            KomodoStatusObject kso = new KomodoStatusObject("Delete Status"); //$NON-NLS-1$
+            kso.addAttribute(dataserviceName, "Successfully deleted"); //$NON-NLS-1$
+
+            return commit(uow, mediaTypes, kso);
+        } catch (final Exception e) {
+            if ((uow != null) && (uow.getState() != State.ROLLED_BACK)) {
+                uow.rollback();
+            }
+
+            if (e instanceof KomodoRestException) {
+                throw (KomodoRestException)e;
+            }
+
+            return createErrorResponse(mediaTypes, e, DATASERVICE_SERVICE_DELETE_DATASERVICE_ERROR);
+        }
+    }
+    
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoVdbService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoVdbService.java
@@ -419,7 +419,7 @@ public final class KomodoVdbService extends KomodoService {
                 vdbs = this.wsMgr.findVdbs( uow );
                 LOGGER.debug( "getVdbs:found '{0}' VDBs", vdbs.length ); //$NON-NLS-1$
             } else {
-                final String[] vdbPaths = this.wsMgr.findByType( uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, null, searchPattern );
+                final String[] vdbPaths = this.wsMgr.findByType( uow, VdbLexicon.Vdb.VIRTUAL_DATABASE, null, searchPattern, false );
 
                 if ( vdbPaths.length == 0 ) {
                     vdbs = Vdb.NO_VDBS;

--- a/server/komodo-rest/src/main/java/org/komodo/rest/swagger/RestDataserviceConverter.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/swagger/RestDataserviceConverter.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.swagger;
+
+import org.komodo.rest.RestProperty;
+import org.komodo.rest.relational.dataservice.RestDataservice;
+import org.komodo.spi.repository.KomodoType;
+import io.swagger.converter.ModelConverterContext;
+import io.swagger.models.ModelImpl;
+
+/**
+ * Converter to display properties of {@link RestDataservice} class in swagger
+ */
+public class RestDataserviceConverter extends RestEntityConverter<RestDataservice> {
+
+    @Override
+    protected Class<RestDataservice> getEntityClass() {
+        return RestDataservice.class;
+    }
+
+    @Override
+    protected KomodoType getKomodoType() {
+        return KomodoType.DATASERVICE;
+    }
+
+    @Override
+    protected void addProperties(ModelImpl model, ModelConverterContext context) throws Exception {
+        model.property(RestDataservice.NAME_LABEL, requiredProperty(String.class));
+        model.property(RestDataservice.DESCRIPTION_LABEL, property(String.class));
+        model.property(RestDataservice.FILE_PATH_LABEL, requiredProperty(String.class));
+        model.property(RestDataservice.PREVIEW_LABEL, property(Boolean.class));
+        model.property(RestDataservice.CONNECTION_TYPE_LABEL, requiredProperty(String.class));
+        model.property(RestDataservice.VERSION_LABEL, property(String.class));
+
+        model.property(PROPERTIES, context.resolveProperty(RestProperty.class, null));
+    }
+}

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -52,6 +52,11 @@ Error.VDB_SAMPLE_IMPORT_SUCCESS = The sample vdb '%s' was imported successfully
 Error.VDB_SAMPLE_IMPORT_ERRORS = Errors occurred duing the import of vdb sample '%s': '%s'
 Error.VDB_SAMPLE_IMPORT_VDB_EXISTS = The sample vdb '%s' already exists so no need to import it again 
 
+Error.DATASERVICE_SERVICE_GET_DATASERVICES_ERROR = An error occurred constructing the JSON document representing the DataServices in the Komodo workspace: '%s'
+Error.DATASERVICE_SERVICE_GET_DATASERVICE_ERROR = An error occurred constructing the JSON document for DataService '%s': '%s'
+Error.DATASERVICE_SERVICE_CREATE_DATASERVICE_ERROR = An error occurred while creating a data service in the repository: '%s'
+Error.DATASERVICE_SERVICE_DELETE_DATASERVICE_ERROR = An error occurred while deleting a data service from the repository: '%s'
+
 Error.SCHEMA_SERVICE_GET_SCHEMA_ERROR = An error occurred constructing the JSON document representing the teiid schema: '%s'
 Error.SCHEMA_SERVICE_GET_SCHEMA_UNKNOWN_KTYPE = The type '%s' is unknown so no related schema object could be found.
 Error.SCHEMA_SERVICE_GET_SCHEMA_NOT_FOUND = The schema for type '%s' was not found

--- a/server/komodo-rest/src/test/java/org/komodo/rest/AllTests.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/AllTests.java
@@ -25,6 +25,8 @@ package org.komodo.rest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.komodo.rest.json.LinkSerializerTest;
+import org.komodo.rest.relational.RestDataSourceTest;
+import org.komodo.rest.relational.RestDataserviceTest;
 import org.komodo.rest.relational.RestVdbDataRoleTest;
 import org.komodo.rest.relational.RestVdbImportTest;
 import org.komodo.rest.relational.RestVdbPermissionTest;
@@ -35,6 +37,7 @@ import org.komodo.rest.relational.json.VdbImportSerializerTest;
 import org.komodo.rest.relational.json.VdbPermissionSerializerTest;
 import org.komodo.rest.relational.json.VdbSerializerTest;
 import org.komodo.rest.relational.json.VdbTranslatorSerializerTest;
+import org.komodo.rest.service.KomodoDataserviceServiceTest;
 import org.komodo.rest.service.KomodoSearchServiceTest;
 import org.komodo.rest.service.KomodoUtilServiceTest;
 import org.komodo.rest.service.KomodoVdbServiceTest;
@@ -45,6 +48,8 @@ import org.komodo.rest.service.KomodoVdbServiceTest;
         RestLinkTest.class,
         LinkSerializerTest.class,
 
+        RestDataserviceTest.class,
+        RestDataSourceTest.class,
         RestVdbDataRoleTest.class,
         RestVdbImportTest.class,
         RestVdbPermissionTest.class,
@@ -57,9 +62,10 @@ import org.komodo.rest.service.KomodoVdbServiceTest;
         VdbSerializerTest.class,
         VdbTranslatorSerializerTest.class,
 
+        KomodoDataserviceServiceTest.class,
+        KomodoSearchServiceTest.class,
         KomodoUtilServiceTest.class,
-        KomodoVdbServiceTest.class,
-        KomodoSearchServiceTest.class
+        KomodoVdbServiceTest.class
     } )
 public class AllTests {
     // nothing to do

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/AbstractKomodoServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/AbstractKomodoServiceTest.java
@@ -169,6 +169,12 @@ public abstract class AbstractKomodoServiceTest implements V1Constants {
         Assert.assertEquals(4, _restApp.getVdbs().length);
     }
 
+    protected void createDataservice( String serviceName ) throws Exception {
+        _restApp.createDataservice( serviceName );
+
+        Assert.assertEquals(1, _restApp.getDataservices().length);
+    }
+
     protected List<String> loadSampleSearches() throws Exception {
         List<String> searchNames = new ArrayList<>();
         Repository repository = _restApp.getDefaultRepository();

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
@@ -1,0 +1,184 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational;
+
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+import java.net.URI;
+import javax.ws.rs.core.UriBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.rest.relational.dataservice.RestDataservice;
+import org.komodo.spi.repository.Descriptor;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.PropertyDescriptor;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.mockito.Mockito;
+import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
+
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class RestDataserviceTest {
+
+    private static final URI BASE_URI = UriBuilder.fromUri("http://localhost:8081/v1/").build();
+    private static final String WORKSPACE_DATA_PATH = "/workspace";
+    private static final String DATASERVICE_NAME = "MyDataservice";
+    private static final String DATASERVICE_DATA_PATH = "/workspace/dataservices/dataservice1";
+    private static final KomodoType kType = KomodoType.DATASERVICE;
+    private static final String DESCRIPTION = "my description";
+    private static final String ORIGINAL_FILE = "/Users/ElvisIsKing/MyVdb.xml";
+    private static final String CONNECTION_TYPE = "BY_VERSION";
+    private static final int VERSION = 1;
+
+    private RestDataservice dataservice;
+
+    private RestDataservice copy() {
+        final RestDataservice copy = new RestDataservice();
+
+        copy.setBaseUri(dataservice.getBaseUri());
+        copy.setId(dataservice.getName());
+        copy.setDataPath(dataservice.getDataPath());
+        copy.setkType(dataservice.getkType());
+        copy.setHasChildren(dataservice.hasChildren());
+        copy.setName(this.dataservice.getName());
+        copy.setDescription(this.dataservice.getDescription());
+        copy.setOriginalFilePath(this.dataservice.getOriginalFilePath());
+        copy.setConnectionType(this.dataservice.getConnectionType());
+        copy.setPreview(this.dataservice.isPreview());
+        copy.setVersion(this.dataservice.getVersion());
+        copy.setLinks(this.dataservice.getLinks());
+        copy.setProperties(this.dataservice.getProperties());
+
+        return copy;
+    }
+
+    @Before
+    public void init() throws Exception {
+        UnitOfWork transaction = Mockito.mock(UnitOfWork.class);
+
+        KomodoObject workspace = Mockito.mock(KomodoObject.class);
+        Mockito.when(workspace.getAbsolutePath()).thenReturn(WORKSPACE_DATA_PATH);
+
+        Descriptor dataserviceType = Mockito.mock(Descriptor.class);
+        when(dataserviceType.getName()).thenReturn(VdbLexicon.Vdb.VIRTUAL_DATABASE);
+
+        Dataservice theDataservice = Mockito.mock(Dataservice.class);
+        Mockito.when(theDataservice.getPrimaryType(transaction)).thenReturn(dataserviceType);
+        Mockito.when(theDataservice.getName(transaction)).thenReturn(DATASERVICE_NAME);
+        Mockito.when(theDataservice.getAbsolutePath()).thenReturn(DATASERVICE_DATA_PATH);
+        Mockito.when(theDataservice.getTypeIdentifier(transaction)).thenReturn(kType);
+        Mockito.when(theDataservice.hasChildren(transaction)).thenReturn(true);
+        Mockito.when(theDataservice.getPropertyNames(transaction)).thenReturn(new String[0]);
+        Mockito.when(theDataservice.getPropertyDescriptors(transaction)).thenReturn(new PropertyDescriptor[0]);
+        Mockito.when(theDataservice.getParent(transaction)).thenReturn(workspace);
+
+        this.dataservice = new RestDataservice(BASE_URI, theDataservice, false, transaction);
+        this.dataservice.setName(DATASERVICE_NAME);
+        this.dataservice.setDescription(DESCRIPTION);
+        this.dataservice.setOriginalFilePath(ORIGINAL_FILE);
+        this.dataservice.setConnectionType(CONNECTION_TYPE);
+        this.dataservice.setPreview(false);
+        this.dataservice.setVersion(VERSION);
+    }
+
+    @Test
+    public void shouldHaveBaseUri() {
+        assertEquals(BASE_URI, this.dataservice.getBaseUri());
+    }
+
+    @Test
+    public void shouldBeEqual() {
+        final RestDataservice thatDataservice = copy();
+        assertEquals(this.dataservice, thatDataservice);
+    }
+
+    @Test
+    public void shouldBeEqualWhenComparingEmptyDataservices() {
+        final RestDataservice empty1 = new RestDataservice();
+        final RestDataservice empty2 = new RestDataservice();
+        assertEquals(empty1, empty2);
+    }
+
+    @Test
+    public void shouldConstructEmptyDataservice() {
+        final RestDataservice empty = new RestDataservice();
+        assertNull(empty.getBaseUri());
+        assertNull(empty.getName());
+        assertNull(empty.getDescription());
+        assertNull(empty.getOriginalFilePath());
+        assertEquals(empty.getProperties().isEmpty(), true);
+        assertEquals(empty.getLinks().size(), 0);
+    }
+
+    @Test
+    public void shouldHaveSameHashCode() {
+        final RestDataservice thatDataservice = copy();
+        assertEquals(this.dataservice.hashCode(), thatDataservice.hashCode());
+    }
+
+    @Test
+    public void shouldNotBeEqualWhenDescriptionIsDifferent() {
+        final RestDataservice thatDataservice = copy();
+        thatDataservice.setDescription(this.dataservice.getDescription() + "blah");
+        assertNotEquals(this.dataservice, not(thatDataservice));
+    }
+
+    @Test
+    public void shouldNotBeEqualWhenNameIsDifferent() {
+        final RestDataservice thatDataservice = copy();
+        thatDataservice.setName(this.dataservice.getName() + "blah");
+        assertNotEquals(this.dataservice, thatDataservice);
+    }
+
+    @Test
+    public void shouldNotBeEqualWhenOriginalFileIsDifferent() {
+        final RestDataservice thatDataservice = copy();
+        thatDataservice.setOriginalFilePath(this.dataservice.getOriginalFilePath() + "blah");
+        assertNotEquals(this.dataservice, thatDataservice);
+    }
+
+    @Test
+    public void shouldSetDescription() {
+        final String newDescription = "blah";
+        this.dataservice.setDescription(newDescription);
+        assertEquals(this.dataservice.getDescription(), newDescription);
+    }
+
+    @Test
+    public void shouldSetName() {
+        final String newName = "blah";
+        this.dataservice.setName(newName);
+        assertEquals(this.dataservice.getName(), newName);
+    }
+
+    @Test
+    public void shouldSetOriginalFilePath() {
+        final String newPath = "blah";
+        this.dataservice.setOriginalFilePath(newPath);
+        assertEquals(this.dataservice.getOriginalFilePath(), newPath);
+    }
+
+}

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/AbstractSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/AbstractSerializerTest.java
@@ -49,6 +49,8 @@ public abstract class AbstractSerializerTest implements JsonConstants {
     protected static final String WORKSPACE_DATA_PATH = "/workspace";
     protected static final String VDB_NAME = "vdb1";
     protected static final String VDB_DATA_PATH = "/workspace/vdbs/vdb1";
+    protected static final String DATASERVICE_NAME = "dataservice1";
+    protected static final String DATASERVICE_DATA_PATH = "/workspace/dataservices/dataservice1";
     protected static final String SEARCH = "/workspace/search?";
 
     @Mock

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.json;
+
+import static org.junit.Assert.assertEquals;
+import org.jboss.resteasy.util.Encode;
+import org.junit.Before;
+import org.junit.Test;
+import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.rest.relational.dataservice.RestDataservice;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.KomodoType;
+import org.komodo.spi.repository.PropertyDescriptor;
+import org.mockito.Mockito;
+
+@SuppressWarnings( { "javadoc", "nls" } )
+public final class DataserviceSerializerTest extends AbstractSerializerTest  {
+
+    private static final String DESCRIPTION = "my description";
+    private static final String ORIGINAL_FILE = "/Users/originalFile";
+    private static final KomodoType kType = KomodoType.DATASERVICE;
+    private static final String CONNECTION_TYPE = "BY_VERSION";
+    private static final int VERSION = 1;
+
+    private static final String JSON = OPEN_BRACE + NEW_LINE +
+        "  \"" + BASE_URI + "\": \"" + MY_BASE_URI + "\"," + NEW_LINE +
+        "  \"keng__id\": \"" + DATASERVICE_NAME + "\"," + NEW_LINE +
+        "  \"keng__dataPath\": \"" + DATASERVICE_DATA_PATH + "\"," + NEW_LINE +
+        "  \"keng__kType\": \"Dataservice\"," + NEW_LINE +
+        "  \"keng__hasChildren\": true," + NEW_LINE +
+        "  \"vdb__name\": \"" + DATASERVICE_NAME + "\"," + NEW_LINE +
+        "  \"vdb__description\": \"my description\"," + NEW_LINE +
+        "  \"vdb__originalFile\": \"/Users/originalFile\"," + NEW_LINE +
+        "  \"vdb__preview\": false," + NEW_LINE +
+        "  \"vdb__connectionType\": \"BY_VERSION\"," + NEW_LINE +
+        "  \"vdb__version\": 1," + NEW_LINE +
+        "  \"keng___links\": [" + NEW_LINE +
+        "    " + OPEN_BRACE + NEW_LINE +
+        "      \"rel\": \"self\"," + NEW_LINE +
+        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "\"" + NEW_LINE +
+        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
+        "    " + OPEN_BRACE + NEW_LINE +
+        "      \"rel\": \"parent\"," + NEW_LINE +
+        "      \"href\": \"" + BASE_URI_PREFIX + "/workspace/dataservices\"" + NEW_LINE +
+        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
+        "    " + OPEN_BRACE + NEW_LINE +
+        "      \"rel\": \"children\"," + NEW_LINE +
+        "      \"href\": \"" + BASE_URI_PREFIX + SEARCH + "parent\\u003d" + Encode.encodeQueryParam(DATASERVICE_DATA_PATH) + "\"" + NEW_LINE +
+        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
+        "    " + OPEN_BRACE + NEW_LINE +
+        "      \"rel\": \"imports\"," + NEW_LINE +
+        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "/VdbImports\"" + NEW_LINE +
+        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
+        "    " + OPEN_BRACE + NEW_LINE +
+        "      \"rel\": \"models\"," + NEW_LINE +
+        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "/Models\"" + NEW_LINE +
+        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
+        "    " + OPEN_BRACE + NEW_LINE +
+        "      \"rel\": \"translators\"," + NEW_LINE +
+        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "/VdbTranslators\"" + NEW_LINE +
+        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
+        "    " + OPEN_BRACE + NEW_LINE +
+        "      \"rel\": \"dataRoles\"," + NEW_LINE +
+        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "/VdbDataRoles\"" + NEW_LINE +
+        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
+        "    " + OPEN_BRACE + NEW_LINE +
+        "      \"rel\": \"vdbs\"," + NEW_LINE +
+        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "/Vdbs\"" + NEW_LINE +
+        "    " + CLOSE_BRACE + NEW_LINE +
+        "  " + CLOSE_SQUARE_BRACKET + NEW_LINE +
+        CLOSE_BRACE;
+
+
+    private RestDataservice dataservice;
+
+    @Before
+    public void init() throws Exception {
+        KomodoObject workspace = Mockito.mock(KomodoObject.class);
+        Mockito.when(workspace.getAbsolutePath()).thenReturn(WORKSPACE_DATA_PATH);
+
+        Dataservice theService = mockObject(Dataservice.class, DATASERVICE_NAME, DATASERVICE_DATA_PATH, kType, true);
+        Mockito.when(theService.getPropertyNames(transaction)).thenReturn(new String[0]);
+        Mockito.when(theService.getPropertyDescriptors(transaction)).thenReturn(new PropertyDescriptor[0]);
+        Mockito.when(theService.getParent(transaction)).thenReturn(workspace);
+
+        this.dataservice = new RestDataservice(MY_BASE_URI, theService, false, transaction);
+        this.dataservice.setName(DATASERVICE_NAME);
+        this.dataservice.setDescription(DESCRIPTION);
+        this.dataservice.setOriginalFilePath(ORIGINAL_FILE);
+        this.dataservice.setConnectionType(CONNECTION_TYPE);
+        this.dataservice.setPreview(false);
+        this.dataservice.setVersion(VERSION);
+    }
+
+    @Test
+    public void shouldExportJson() {
+        String json = KomodoJsonMarshaller.marshall( this.dataservice );
+        assertEquals(JSON, json);
+    }
+
+    @Test
+    public void shouldImportJson() {
+        final RestDataservice descriptor = KomodoJsonMarshaller.unmarshall( JSON, RestDataservice.class );
+        assertEquals(DATASERVICE_NAME, descriptor.getName());
+        assertEquals(DESCRIPTION, descriptor.getDescription());
+        assertEquals(ORIGINAL_FILE, descriptor.getOriginalFilePath());
+        assertEquals(8, descriptor.getLinks().size());
+        assertEquals(true, descriptor.getProperties().isEmpty());
+    }
+
+    @Test( expected = Exception.class )
+    public void shouldNotExportJsonWhenNameIsMissing() {
+        final RestDataservice descriptor = new RestDataservice();
+        KomodoJsonMarshaller.marshall( descriptor );
+    }
+
+    @Test( expected = Exception.class )
+    public void shouldNotImportJsonWhenIdIsMissing() {
+        final String malformed = "{\"description\":\"my description\",\"links\":[{\"rel\":\"self\",\"href\":\"http://localhost:8080/v1/workspace/vdbs/MyVdb\",\"method\":\"GET\"},{\"rel\":\"parent\",\"href\":\"http://localhost:8080/v1/workspace/vdbs\",\"method\":\"GET\"},{\"rel\":\"manifest\",\"href\":\"http://localhost:8080/v1/workspace/vdbs/MyVdb/manifest\",\"method\":\"GET\"}]}";
+        KomodoJsonMarshaller.unmarshall( malformed, RestDataservice.class );
+    }
+
+}

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.service;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import java.net.URI;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.komodo.rest.relational.AbstractKomodoServiceTest;
+import org.komodo.rest.relational.dataservice.RestDataservice;
+import org.komodo.rest.relational.json.KomodoJsonMarshaller;
+
+@SuppressWarnings( {"javadoc", "nls"} )
+public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTest {
+
+    public static final String DATASERVICE_NAME = "MyDataService"; 
+    
+    @Rule
+    public TestName testName = new TestName();
+
+    @Test
+    public void shouldGetDataservices() throws Exception {
+        createDataservice(DATASERVICE_NAME);
+
+        // get
+        URI uri = _uriBuilder.workspaceDataservicesUri();
+        this.response = request(uri).get();
+        assertTrue(response.hasEntity());
+
+        final String entities = response.readEntity(String.class);
+        assertThat(entities, is(notNullValue()));
+
+        // System.out.println("Response:\n" + entities);
+        // make sure the Dataservice JSON document is returned for each dataservice
+        RestDataservice[] dataservices = KomodoJsonMarshaller.unmarshallArray(entities, RestDataservice[].class);
+
+        assertEquals(1, dataservices.length);
+        RestDataservice myService = dataservices[0];
+        assertNotNull(myService.getId());
+        assertTrue(DATASERVICE_NAME.equals(myService.getId()));
+        assertNotNull(myService.getDataPath());
+        assertNotNull(myService.getkType());
+    }
+    
+    @Test
+    public void shouldReturnEmptyListWhenNoDataservicesInWorkspace() {
+        this.response = request(_uriBuilder.workspaceDataservicesUri()).get();
+        final String entity = this.response.readEntity(String.class);
+        assertThat(entity, is(notNullValue()));
+
+        //System.out.println("Response:\n" + entity);
+
+        RestDataservice[] dataservices = KomodoJsonMarshaller.unmarshallArray(entity, RestDataservice[].class);
+        assertNotNull(dataservices);
+        assertEquals(0, dataservices.length);
+    }
+    
+}


### PR DESCRIPTION
Addition of rest methods for dataservices and associated changes...
- adds rest methods for 'getDataservices', 'createDataservice' and 'deleteDataservice'.
- mods to WorkspaceManager - the findByType method was changed to add a switch for including subTypes in addition to the requested type.