### PR TITLE
Rework Dataservice to container

### DIFF
--- a/komodo-core/src/main/resources/config/komodo.cnd
+++ b/komodo-core/src/main/resources/config/komodo.cnd
@@ -193,7 +193,7 @@
 /*
  * A data service known by the workspace.
  */
-[tko:dataService] > tko:vdb
+[tko:dataService] > nt:unstructured, tko:libraryComponent
   + * (tko:vdb) copy
  
 /*

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
@@ -21,7 +21,9 @@
  */
 package org.komodo.relational.dataservice;
 
+import java.util.Properties;
 import org.komodo.core.KomodoLexicon;
+import org.komodo.relational.RelationalObject;
 import org.komodo.relational.RelationalProperties;
 import org.komodo.relational.TypeResolver;
 import org.komodo.relational.dataservice.internal.DataserviceImpl;
@@ -29,15 +31,17 @@ import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.Exportable;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Repository;
 import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.spi.repository.Repository.UnitOfWork.State;
 
 /**
  * A model of a dataservice instance
  */
-public interface Dataservice extends Vdb {
+public interface Dataservice extends Exportable, RelationalObject {
 
     /**
      * The type identifier.
@@ -126,6 +130,16 @@ public interface Dataservice extends Vdb {
     };
 
     /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param properties (can be <code>null</code> or empty)
+     * @return the VDB XML manifest representing the current state of the VDB (never null)
+     * @throws KException
+     *         if an error occurs
+     */
+    DataserviceManifest createManifest( final UnitOfWork transaction, Properties properties ) throws KException;
+
+    /**
      * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
@@ -145,6 +159,16 @@ public interface Dataservice extends Vdb {
      * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @return the service VDB (may be <code>null</code> if not defined)
+     * @throws KException
+     *         if an error occurs
+     */
+    Vdb getServiceVdb( final UnitOfWork uow ) throws KException;
+
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @param namePatterns
      *        optional name patterns (can be <code>null</code> or empty but cannot have <code>null</code> or empty elements)
      * @return the VDBs (never <code>null</code> but can be empty)
@@ -153,5 +177,25 @@ public interface Dataservice extends Vdb {
      */
     Vdb[] getVdbs( final UnitOfWork uow,
                    final String... namePatterns ) throws KException;
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @return the value of the <code>description</code> property (can be empty)
+     * @throws KException
+     *         if an error occurs
+     */
+    String getDescription( final UnitOfWork transaction ) throws KException;
+
+    /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
+     * @param newDescription
+     *        the new value of the <code>description</code> property
+     * @throws KException
+     *         if an error occurs
+     */
+    void setDescription( final UnitOfWork transaction,
+                         final String newDescription ) throws KException;
+
     
 }

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/DataserviceManifest.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/DataserviceManifest.java
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
  * 02110-1301 USA.
  */
-package org.komodo.relational.dataservice.internal;
+package org.komodo.relational.dataservice;
 
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -30,7 +30,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 import org.komodo.core.KomodoLexicon;
-import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.dataservice.internal.DataserviceImpl;
 import org.komodo.relational.vdb.Vdb.VdbManifest;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.DocumentType;
@@ -41,7 +41,7 @@ import org.komodo.utils.KLog;
 import org.modeshape.jcr.api.JcrConstants;
 import org.w3c.dom.Document;
 
-class DataserviceManifest implements VdbManifest {
+public class DataserviceManifest implements VdbManifest {
 
     public static final String MANIFEST = "META-INF/dataservice.xml";
 
@@ -70,7 +70,7 @@ class DataserviceManifest implements VdbManifest {
     }
 
     @Override
-    public DocumentType getDocumentType() throws KException {
+    public DocumentType getDocumentType(UnitOfWork uow) throws KException {
         return DocumentType.XML;
     }
 

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceConveyor.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceConveyor.java
@@ -37,6 +37,7 @@ import org.komodo.importer.ImportOptions.ExistingNodeOptions;
 import org.komodo.importer.ImportOptions.OptionKeys;
 import org.komodo.importer.Messages;
 import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.dataservice.DataserviceManifest;
 import org.komodo.relational.importer.ddl.DdlImporter;
 import org.komodo.relational.importer.vdb.VdbImporter;
 import org.komodo.relational.workspace.WorkspaceManager;

--- a/komodo-relational/src/test/java/org/komodo/relational/AllTests.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/AllTests.java
@@ -2,6 +2,7 @@ package org.komodo.relational;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
+import org.komodo.relational.dataservice.internal.DataserviceImplTest;
 import org.komodo.relational.datasource.internal.DatasourceImplTest;
 import org.komodo.relational.datasource.internal.DatasourceParserTest;
 import org.komodo.relational.importer.ddl.TestTeiidDdlImporter;
@@ -49,6 +50,9 @@ import org.komodo.relational.workspace.WorkspaceManagerTest;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     RelationalObjectImplTest.class,
+
+    // Dataservice
+    DataserviceImplTest.class,
 
     // DataSource
     DatasourceImplTest.class,

--- a/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
@@ -46,6 +46,7 @@ import org.komodo.importer.ImportOptions;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.RelationalObject.Filter;
 import org.komodo.relational.dataservice.Dataservice;
+import org.komodo.relational.dataservice.DataserviceManifest;
 import org.komodo.relational.importer.vdb.VdbImporter;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.spi.repository.KomodoObject;
@@ -103,6 +104,14 @@ public final class DataserviceImplTest extends RelationalModelTest {
     }
     
     @Test
+    public void shouldSetDescription() throws Exception {
+        final String descr = "This is a description";
+        this.dataservice.setDescription(getTransaction(), descr);
+        
+        assertThat( this.dataservice.getDescription( getTransaction() ), is( descr ) );
+    }
+
+    @Test
     public void shouldAddVdb() throws Exception {
         final String name = "childVdb";
         final Vdb vdb = this.dataservice.addVdb(getTransaction(), name, "externalPath");
@@ -131,6 +140,7 @@ public final class DataserviceImplTest extends RelationalModelTest {
         assertThat( vdb1.getName( getTransaction() ), is( name1 ) );
         assertThat( vdb2.getName( getTransaction() ), is( name2 ) );
         assertThat( this.dataservice.getVdbs( getTransaction() ).length, is( 2 ) );
+        assertThat( this.dataservice.getServiceVdb( getTransaction() )==null, is( true ) );
         assertThat( this.dataservice.getChildren( getTransaction() )[1], is( instanceOf( Vdb.class ) ) );
 
         assertThat( this.dataservice.hasChild( getTransaction(), name1 ), is( true ) );
@@ -145,11 +155,68 @@ public final class DataserviceImplTest extends RelationalModelTest {
     }
 
     @Test
+    public void shouldTestGetChildren() throws Exception {
+        final String unkName = "unknown";
+        final String name1 = "childVdb1";
+        final Vdb vdb1 = this.dataservice.addVdb(getTransaction(), name1, "externalPath1");
+        
+        assertThat( vdb1, is( notNullValue() ) );
+        assertThat( vdb1.getName( getTransaction() ), is( name1 ) );
+        assertThat( this.dataservice.getChildren( getTransaction() ).length, is( 1 ) );
+        assertThat( this.dataservice.getChildren( getTransaction() )[0], is( instanceOf( Vdb.class ) ) );
+        assertThat( this.dataservice.getChildren( getTransaction(), name1 ).length, is( 1 ) );
+        assertThat( this.dataservice.getChildren( getTransaction(), unkName ).length, is( 0 ) );
+        assertThat( this.dataservice.getChildrenOfType( getTransaction(), VdbLexicon.Vdb.VIRTUAL_DATABASE ).length, is( 1 ) );
+        assertThat( this.dataservice.getChildrenOfType( getTransaction(), VdbLexicon.DataRole.DATA_ROLE ).length, is( 0 ) );
+        assertThat( this.dataservice.getChildrenOfType( getTransaction(), VdbLexicon.Vdb.VIRTUAL_DATABASE, name1 ).length, is( 1 ) );
+        assertThat( this.dataservice.getChildrenOfType( getTransaction(), VdbLexicon.Vdb.VIRTUAL_DATABASE, unkName ).length, is( 0 ) );
+        assertThat( this.dataservice.getChild( getTransaction(), name1)!=null, is( true ) );
+        assertThat( this.dataservice.getChild( getTransaction(), name1, VdbLexicon.Vdb.VIRTUAL_DATABASE)!=null, is( true ) );
+
+        assertThat( this.dataservice.hasChild( getTransaction(), name1 ), is( true ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), unkName ), is( false ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), name1, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( true ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), unkName, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( false ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), name1, VdbLexicon.DataRole.DATA_ROLE ), is( false ) );
+        
+        assertThat( this.dataservice.hasChildren( getTransaction() ), is( true ) );
+    }
+
+    @Test
+    public void shouldAddServiceVdb() throws Exception {
+        // Add child VDB
+        final String name = "childVdb";
+        final Vdb vdb = this.dataservice.addVdb(getTransaction(), name, "externalPath");
+        
+        // Add service VDB (same name as dataservice node)
+        final Vdb serviceVDB = this.dataservice.addVdb(getTransaction(), SERVICE_NAME, "externalPath");
+        
+        assertThat( vdb, is( notNullValue() ) );
+        assertThat( vdb.getName( getTransaction() ), is( name ) );
+        assertThat( serviceVDB, is( notNullValue() ) );
+        assertThat( serviceVDB.getName( getTransaction() ), is( SERVICE_NAME ) );
+        assertThat( this.dataservice.getVdbs( getTransaction() ).length, is( 2 ) );
+        assertThat( this.dataservice.getServiceVdb( getTransaction() )==null, is( false ) );
+        assertThat( this.dataservice.getChildren( getTransaction() )[0], is( instanceOf( Vdb.class ) ) );
+
+        assertThat( this.dataservice.hasChildren( getTransaction() ), is( true ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), name ), is( true ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), name, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( true ) );
+        assertThat( this.dataservice.getChild( getTransaction(), name ), is( vdb ) );
+        assertThat( this.dataservice.getChild( getTransaction(), name, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( vdb ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), SERVICE_NAME ), is( true ) );
+        assertThat( this.dataservice.hasChild( getTransaction(), SERVICE_NAME, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( true ) );
+        assertThat( this.dataservice.getChild( getTransaction(), SERVICE_NAME ), is( serviceVDB ) );
+        assertThat( this.dataservice.getChild( getTransaction(), SERVICE_NAME, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( serviceVDB ) );
+    }
+
+    @Test
     public void shouldExport() throws Exception {
         final String name1 = "childVdb1";
         final String name2 = "childVdb2";
         this.dataservice.addVdb(getTransaction(), name1, "externalPath1");
         this.dataservice.addVdb(getTransaction(), name2, "externalPath1");
+        this.dataservice.addVdb(getTransaction(), SERVICE_NAME, "externalSvcPath");
 
         byte[] dsBytes = this.dataservice.export(getTransaction(), new Properties());
         assertNotNull(dsBytes);
@@ -231,8 +298,13 @@ public final class DataserviceImplTest extends RelationalModelTest {
         assertFalse(importMessages.hasError());
 
         importer.importVdb(getTransaction(),
-                                               TestUtilities.tweetExample(), dataservice,
-                                               importOptions, importMessages);
+                           TestUtilities.tweetExample(), dataservice,
+                           importOptions, importMessages);
+        assertFalse(importMessages.hasError());
+
+        importer.importVdb(getTransaction(),
+                           TestUtilities.dataserviceVdbExample(), dataservice,
+                           importOptions, importMessages);
         assertFalse(importMessages.hasError());
 
         commit(State.COMMITTED);

--- a/komodo-spi/src/main/java/org/komodo/spi/repository/DocumentType.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/repository/DocumentType.java
@@ -59,4 +59,29 @@ public class DocumentType {
     public static DocumentType documentType(String docTypeValue) {
         return new DocumentType(docTypeValue);
     }
+    
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((this.type == null) ? 0 : this.type.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        DocumentType other = (DocumentType)obj;
+        if (this.type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!this.type.equals(other.type))
+            return false;
+        return true;
+    }
 }

--- a/komodo-utils/src/test/java/org/komodo/test/utils/TestUtilities.java
+++ b/komodo-utils/src/test/java/org/komodo/test/utils/TestUtilities.java
@@ -123,6 +123,11 @@ public class TestUtilities implements StringConstants {
                             "CREATE VIEW Tweet AS select * FROM twitterview.getTweets;";
 
     /**
+     * Dataservice vdb
+     */
+    public static final String DATASERVICE_VDB_FILE = "myService-vdb.xml";
+
+    /**
      * Portfolio vdb
      */
     public static final String PORTFOLIO_VDB_FILE = "portfolio-vdb.xml";
@@ -1044,6 +1049,16 @@ public class TestUtilities implements StringConstants {
         return myVdbExample;
     }
 
+    /**
+     * @return input stream of portfolio example xml
+     * @throws Exception if error occurs
+     */
+    public static InputStream dataserviceVdbExample() throws Exception {
+        return getResourceAsStream(TestUtilities.class,
+                                   RESOURCES_DIRECTORY,
+                                   DATASERVICE_VDB_FILE);
+    }
+    
     /**
      * @return input stream of portfolio example xml
      * @throws Exception if error occurs

--- a/komodo-utils/src/test/resources/org/komodo/test/utils/myService-vdb.xml
+++ b/komodo-utils/src/test/resources/org/komodo/test/utils/myService-vdb.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<vdb name="MyService" version="1">
+ 
+    <description>The Dataservice Dynamic VDB</description>
+ 
+    <!--
+      Setting to use connector supplied metadata. Can be "true" or "cached".
+      "true" will obtain metadata once for every launch of Teiid.
+      "cached" will save a file containing the metadata into
+      the deploy/<vdb name>/<vdb version/META-INF directory
+    -->
+    <property name="UseConnectorMetadata" value="true" />
+ 
+</vdb>

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/DataServiceSchema.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/DataServiceSchema.java
@@ -24,7 +24,9 @@ package org.komodo.rest.relational.dataservice;
 import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.core.MediaType;
+import org.komodo.core.KomodoLexicon;
 import org.komodo.rest.KRestEntity;
+import org.komodo.rest.KomodoService;
 import org.komodo.spi.repository.KomodoType;
 
 public class DataServiceSchema implements KRestEntity {
@@ -47,7 +49,7 @@ public class DataServiceSchema implements KRestEntity {
     /**
      * Label for the description
      */
-    public static final String DESCRIPTION_LABEL = "keng__description";
+    public static final String DESCRIPTION_LABEL = KomodoService.encode(KomodoLexicon.LibraryComponent.DESCRIPTION);
 
     /**
      * Label for the properties
@@ -58,7 +60,7 @@ public class DataServiceSchema implements KRestEntity {
 
     private String kType = KomodoType.DATASERVICE.getType();
 
-    private String description = "Describes the configuration for a dataservice";
+    private String description = "A description for the dataservice";
 
     private List<DataServiceSchemaProperty> properties = new ArrayList<DataServiceSchemaProperty>(4);
 

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
@@ -23,6 +23,7 @@ package org.komodo.rest.relational.dataservice;
 
 import java.net.URI;
 import java.util.Properties;
+import org.komodo.core.KomodoLexicon;
 import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.rest.KomodoService;
 import org.komodo.rest.RestBasicEntity;
@@ -31,7 +32,6 @@ import org.komodo.rest.RestLink.LinkType;
 import org.komodo.rest.relational.KomodoRestUriBuilder.SettingNames;
 import org.komodo.spi.KException;
 import org.komodo.spi.repository.Repository.UnitOfWork;
-import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
 
 /**
  * A Dataservice that can be used by GSON to build a JSON document representation.
@@ -39,37 +39,9 @@ import org.teiid.modeshape.sequencer.vdb.lexicon.VdbLexicon;
 public final class RestDataservice extends RestBasicEntity {
 
     /**
-     * Label used to describe name
-     */
-    public static final String NAME_LABEL = KomodoService.encode(VdbLexicon.Vdb.NAME);
-
-    /**
      * Label used to describe description
      */
-    public static final String DESCRIPTION_LABEL = KomodoService.encode(VdbLexicon.Vdb.DESCRIPTION);
-
-    /**
-     * Label used to describe original file path
-     */
-    public static final String FILE_PATH_LABEL = KomodoService.encode(VdbLexicon.Vdb.ORIGINAL_FILE);
-
-    /**
-     * Label used to describe original file path
-     */
-    public static final String PREVIEW_LABEL = KomodoService.encode(VdbLexicon.Vdb.PREVIEW);
-
-    /**
-     * Label used to describe original file path
-     */
-    public static final String CONNECTION_TYPE_LABEL = KomodoService.encode(VdbLexicon.Vdb.CONNECTION_TYPE);
-
-    /**
-     * Label used to describe original file path
-     */
-    public static final String VERSION_LABEL = KomodoService.encode(VdbLexicon.Vdb.VERSION);
-    
-    private static final int VERSION_DEFAULT = 1;
-    private static final boolean PREVIEW_DEFAULT = false;
+    public static final String DESCRIPTION_LABEL = KomodoService.encode(KomodoLexicon.LibraryComponent.DESCRIPTION);
 
     /**
      * Constructor for use when deserializing
@@ -90,13 +62,7 @@ public final class RestDataservice extends RestBasicEntity {
     public RestDataservice(URI baseUri, Dataservice dataService, boolean exportXml, UnitOfWork uow) throws KException {
         super(baseUri, dataService, uow, false);
 
-        setName(dataService.getName(uow));
         setDescription(dataService.getDescription(uow));
-        setOriginalFilePath(dataService.getOriginalFilePath(uow));
-
-        setPreview(dataService.isPreview(uow));
-        setConnectionType(dataService.getConnectionType(uow));
-        setVersion(dataService.getVersion(uow));
 
         addExecutionProperties(uow, dataService);
 
@@ -107,28 +73,9 @@ public final class RestDataservice extends RestBasicEntity {
         addLink(new RestLink(LinkType.SELF, getUriBuilder().dataserviceUri(LinkType.SELF, settings)));
         addLink(new RestLink(LinkType.PARENT, getUriBuilder().dataserviceUri(LinkType.PARENT, settings)));
         createChildLink();
-        addLink(new RestLink(LinkType.IMPORTS, getUriBuilder().dataserviceUri(LinkType.IMPORTS, settings)));
-        addLink(new RestLink(LinkType.MODELS, getUriBuilder().dataserviceUri(LinkType.MODELS, settings)));
-        addLink(new RestLink(LinkType.TRANSLATORS, getUriBuilder().dataserviceUri(LinkType.TRANSLATORS, settings)));
-        addLink(new RestLink(LinkType.DATA_ROLES, getUriBuilder().dataserviceUri(LinkType.DATA_ROLES, settings)));
         addLink(new RestLink(LinkType.VDBS, getUriBuilder().dataserviceUri(LinkType.VDBS, settings)));
     }
-
-    /**
-     * @return the name
-     */
-    public String getName() {
-        Object name = tuples.get(NAME_LABEL);
-        return name != null ? name.toString() : null;
-    }
-
-    /**
-     * @param name the name to set
-     */
-    public void setName(String name) {
-        tuples.put(NAME_LABEL, name);
-    }
-
+    
     /**
      * @return the VDB description (can be empty)
      */
@@ -144,63 +91,5 @@ public final class RestDataservice extends RestBasicEntity {
         tuples.put(DESCRIPTION_LABEL, description);
     }
 
-    /**
-     * @return the originalFilePath
-     */
-    public String getOriginalFilePath() {
-        Object path = tuples.get(FILE_PATH_LABEL);
-        return path != null ? path.toString() : null;
-    }
 
-    /**
-     * @param originalFilePath the originalFilePath to set
-     */
-    public void setOriginalFilePath(String originalFilePath) {
-        tuples.put(FILE_PATH_LABEL, originalFilePath);
-    }
-
-    /**
-     * @return the preview
-     */
-    public boolean isPreview() {
-        Object preview = tuples.get(PREVIEW_LABEL);
-        return preview != null ? Boolean.parseBoolean(preview.toString()) : PREVIEW_DEFAULT;
-    }
-
-    /**
-     * @param preview the preview to set
-     */
-    public void setPreview(boolean preview) {
-        tuples.put(PREVIEW_LABEL, preview);
-    }
-
-    /**
-     * @return the connectionType
-     */
-    public String getConnectionType() {
-        Object connectionType = tuples.get(CONNECTION_TYPE_LABEL);
-        return connectionType != null ? connectionType.toString() : null;
-    }
-
-    /**
-     * @param connectionType the connectionType to set
-     */
-    public void setConnectionType(String connectionType) {
-        tuples.put(CONNECTION_TYPE_LABEL, connectionType);
-    }
-
-    /**
-     * @return the version
-     */
-    public int getVersion() {
-        Object version = tuples.get(VERSION_LABEL);
-        return version != null ? Integer.parseInt(version.toString()) : VERSION_DEFAULT;
-    }
-
-    /**
-     * @param version the version to set
-     */
-    public void setVersion(int version) {
-        tuples.put(VERSION_LABEL, version);
-    }
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceSerializer.java
@@ -31,7 +31,7 @@ public final class DataserviceSerializer extends BasicEntitySerializer<RestDatas
 
     @Override
     protected boolean isComplete(final RestDataservice dataService) {
-        return super.isComplete(dataService) && !StringUtils.isBlank(dataService.getName());
+        return super.isComplete(dataService) && !StringUtils.isBlank(dataService.getId());
     }
 
     @Override

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -437,8 +437,6 @@ public final class KomodoDataserviceService extends KomodoService {
 
             setProperties( uow, dataservice, oldEntity );
 
-            // TODO copy the properties
-
             final RestDataservice entity = entityFactory.create(dataservice, uriInfo.getBaseUri(), uow );
             final Response response = commit( uow, mediaTypes, entity );
             return response;
@@ -583,39 +581,16 @@ public final class KomodoDataserviceService extends KomodoService {
     
     // Sets Dataservice properties using the supplied RestDataservice object
     private void setProperties(final UnitOfWork uow, Dataservice dataService, RestDataservice restDataService) throws KException {
-        //TODO: Complete to include all properties
-        
         // 'New' = requested RestDataservice properties
         String newDescription = restDataService.getDescription();
-        String newConnType = restDataService.getConnectionType();
-        String newFilePath = restDataService.getOriginalFilePath();
-        int newVersion = restDataService.getVersion();
         
         // 'Old' = current Dataservice properties
         String oldDescription = dataService.getDescription(uow);
-        String oldConnType = dataService.getConnectionType(uow);
-        String oldFilePath = dataService.getOriginalFilePath(uow);
-        int oldVersion = dataService.getVersion(uow);
         
         // Description
         if ( !StringUtils.equals(newDescription, oldDescription) ) {
             dataService.setDescription( uow, newDescription );
         } 
-        
-        // ConnectionType
-        if( !StringUtils.isBlank(newConnType) && !StringUtils.equals(newConnType, oldConnType) ) {
-            dataService.setConnectionType(uow, newConnType);
-        }
-        
-        // OriginalFilePath
-        if( !StringUtils.equals(newFilePath,oldFilePath) ) {
-            dataService.setOriginalFilePath(uow, newFilePath);
-        }
-        
-        // Version
-        if( newVersion != oldVersion ) {
-            dataService.setVersion(uow, newVersion);
-        }
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/swagger/RestDataserviceConverter.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/swagger/RestDataserviceConverter.java
@@ -44,12 +44,7 @@ public class RestDataserviceConverter extends RestEntityConverter<RestDataservic
 
     @Override
     protected void addProperties(ModelImpl model, ModelConverterContext context) throws Exception {
-        model.property(RestDataservice.NAME_LABEL, requiredProperty(String.class));
         model.property(RestDataservice.DESCRIPTION_LABEL, property(String.class));
-        model.property(RestDataservice.FILE_PATH_LABEL, requiredProperty(String.class));
-        model.property(RestDataservice.PREVIEW_LABEL, property(Boolean.class));
-        model.property(RestDataservice.CONNECTION_TYPE_LABEL, requiredProperty(String.class));
-        model.property(RestDataservice.VERSION_LABEL, property(String.class));
 
         model.property(PROPERTIES, context.resolveProperty(RestProperty.class, null));
     }

--- a/server/komodo-rest/src/test/java/org/komodo/rest/AllTests.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/AllTests.java
@@ -32,12 +32,14 @@ import org.komodo.rest.relational.RestVdbImportTest;
 import org.komodo.rest.relational.RestVdbPermissionTest;
 import org.komodo.rest.relational.RestVdbTest;
 import org.komodo.rest.relational.RestVdbTranslatorTest;
+import org.komodo.rest.relational.json.DataserviceSerializerTest;
 import org.komodo.rest.relational.json.VdbDataRoleSerializerTest;
 import org.komodo.rest.relational.json.VdbImportSerializerTest;
 import org.komodo.rest.relational.json.VdbPermissionSerializerTest;
 import org.komodo.rest.relational.json.VdbSerializerTest;
 import org.komodo.rest.relational.json.VdbTranslatorSerializerTest;
 import org.komodo.rest.service.KomodoDataserviceServiceTest;
+import org.komodo.rest.service.KomodoImportExportServiceTest;
 import org.komodo.rest.service.KomodoSearchServiceTest;
 import org.komodo.rest.service.KomodoUtilServiceTest;
 import org.komodo.rest.service.KomodoVdbServiceTest;
@@ -56,6 +58,7 @@ import org.komodo.rest.service.KomodoVdbServiceTest;
         RestVdbTest.class,
         RestVdbTranslatorTest.class,
 
+        DataserviceSerializerTest.class,
         VdbDataRoleSerializerTest.class,
         VdbImportSerializerTest.class,
         VdbPermissionSerializerTest.class,
@@ -63,6 +66,7 @@ import org.komodo.rest.service.KomodoVdbServiceTest;
         VdbTranslatorSerializerTest.class,
 
         KomodoDataserviceServiceTest.class,
+        KomodoImportExportServiceTest.class,
         KomodoSearchServiceTest.class,
         KomodoUtilServiceTest.class,
         KomodoVdbServiceTest.class

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
@@ -21,7 +21,6 @@
  */
 package org.komodo.rest.relational;
 
-import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
@@ -49,9 +48,6 @@ public final class RestDataserviceTest {
     private static final String DATASERVICE_DATA_PATH = "/workspace/dataservices/dataservice1";
     private static final KomodoType kType = KomodoType.DATASERVICE;
     private static final String DESCRIPTION = "my description";
-    private static final String ORIGINAL_FILE = "/Users/ElvisIsKing/MyVdb.xml";
-    private static final String CONNECTION_TYPE = "BY_VERSION";
-    private static final int VERSION = 1;
 
     private RestDataservice dataservice;
 
@@ -59,16 +55,11 @@ public final class RestDataserviceTest {
         final RestDataservice copy = new RestDataservice();
 
         copy.setBaseUri(dataservice.getBaseUri());
-        copy.setId(dataservice.getName());
+        copy.setId(dataservice.getId());
+        copy.setDescription(dataservice.getDescription());
         copy.setDataPath(dataservice.getDataPath());
         copy.setkType(dataservice.getkType());
         copy.setHasChildren(dataservice.hasChildren());
-        copy.setName(this.dataservice.getName());
-        copy.setDescription(this.dataservice.getDescription());
-        copy.setOriginalFilePath(this.dataservice.getOriginalFilePath());
-        copy.setConnectionType(this.dataservice.getConnectionType());
-        copy.setPreview(this.dataservice.isPreview());
-        copy.setVersion(this.dataservice.getVersion());
         copy.setLinks(this.dataservice.getLinks());
         copy.setProperties(this.dataservice.getProperties());
 
@@ -96,12 +87,8 @@ public final class RestDataserviceTest {
         Mockito.when(theDataservice.getParent(transaction)).thenReturn(workspace);
 
         this.dataservice = new RestDataservice(BASE_URI, theDataservice, false, transaction);
-        this.dataservice.setName(DATASERVICE_NAME);
+        this.dataservice.setId(DATASERVICE_NAME);
         this.dataservice.setDescription(DESCRIPTION);
-        this.dataservice.setOriginalFilePath(ORIGINAL_FILE);
-        this.dataservice.setConnectionType(CONNECTION_TYPE);
-        this.dataservice.setPreview(false);
-        this.dataservice.setVersion(VERSION);
     }
 
     @Test
@@ -126,9 +113,8 @@ public final class RestDataserviceTest {
     public void shouldConstructEmptyDataservice() {
         final RestDataservice empty = new RestDataservice();
         assertNull(empty.getBaseUri());
-        assertNull(empty.getName());
+        assertNull(empty.getId());
         assertNull(empty.getDescription());
-        assertNull(empty.getOriginalFilePath());
         assertEquals(empty.getProperties().isEmpty(), true);
         assertEquals(empty.getLinks().size(), 0);
     }
@@ -140,26 +126,19 @@ public final class RestDataserviceTest {
     }
 
     @Test
-    public void shouldNotBeEqualWhenDescriptionIsDifferent() {
-        final RestDataservice thatDataservice = copy();
-        thatDataservice.setDescription(this.dataservice.getDescription() + "blah");
-        assertNotEquals(this.dataservice, not(thatDataservice));
-    }
-
-    @Test
     public void shouldNotBeEqualWhenNameIsDifferent() {
         final RestDataservice thatDataservice = copy();
-        thatDataservice.setName(this.dataservice.getName() + "blah");
+        thatDataservice.setId(this.dataservice.getId() + "blah");
         assertNotEquals(this.dataservice, thatDataservice);
     }
 
     @Test
-    public void shouldNotBeEqualWhenOriginalFileIsDifferent() {
-        final RestDataservice thatDataservice = copy();
-        thatDataservice.setOriginalFilePath(this.dataservice.getOriginalFilePath() + "blah");
-        assertNotEquals(this.dataservice, thatDataservice);
+    public void shouldSetName() {
+        final String newName = "blah";
+        this.dataservice.setId(newName);
+        assertEquals(this.dataservice.getId(), newName);
     }
-
+    
     @Test
     public void shouldSetDescription() {
         final String newDescription = "blah";
@@ -167,18 +146,5 @@ public final class RestDataserviceTest {
         assertEquals(this.dataservice.getDescription(), newDescription);
     }
 
-    @Test
-    public void shouldSetName() {
-        final String newName = "blah";
-        this.dataservice.setName(newName);
-        assertEquals(this.dataservice.getName(), newName);
-    }
-
-    @Test
-    public void shouldSetOriginalFilePath() {
-        final String newPath = "blah";
-        this.dataservice.setOriginalFilePath(newPath);
-        assertEquals(this.dataservice.getOriginalFilePath(), newPath);
-    }
 
 }

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/json/DataserviceSerializerTest.java
@@ -36,10 +36,7 @@ import org.mockito.Mockito;
 public final class DataserviceSerializerTest extends AbstractSerializerTest  {
 
     private static final String DESCRIPTION = "my description";
-    private static final String ORIGINAL_FILE = "/Users/originalFile";
     private static final KomodoType kType = KomodoType.DATASERVICE;
-    private static final String CONNECTION_TYPE = "BY_VERSION";
-    private static final int VERSION = 1;
 
     private static final String JSON = OPEN_BRACE + NEW_LINE +
         "  \"" + BASE_URI + "\": \"" + MY_BASE_URI + "\"," + NEW_LINE +
@@ -47,12 +44,7 @@ public final class DataserviceSerializerTest extends AbstractSerializerTest  {
         "  \"keng__dataPath\": \"" + DATASERVICE_DATA_PATH + "\"," + NEW_LINE +
         "  \"keng__kType\": \"Dataservice\"," + NEW_LINE +
         "  \"keng__hasChildren\": true," + NEW_LINE +
-        "  \"vdb__name\": \"" + DATASERVICE_NAME + "\"," + NEW_LINE +
-        "  \"vdb__description\": \"my description\"," + NEW_LINE +
-        "  \"vdb__originalFile\": \"/Users/originalFile\"," + NEW_LINE +
-        "  \"vdb__preview\": false," + NEW_LINE +
-        "  \"vdb__connectionType\": \"BY_VERSION\"," + NEW_LINE +
-        "  \"vdb__version\": 1," + NEW_LINE +
+        "  \"tko__description\": \"my description\"," + NEW_LINE +
         "  \"keng___links\": [" + NEW_LINE +
         "    " + OPEN_BRACE + NEW_LINE +
         "      \"rel\": \"self\"," + NEW_LINE +
@@ -65,22 +57,6 @@ public final class DataserviceSerializerTest extends AbstractSerializerTest  {
         "    " + OPEN_BRACE + NEW_LINE +
         "      \"rel\": \"children\"," + NEW_LINE +
         "      \"href\": \"" + BASE_URI_PREFIX + SEARCH + "parent\\u003d" + Encode.encodeQueryParam(DATASERVICE_DATA_PATH) + "\"" + NEW_LINE +
-        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
-        "    " + OPEN_BRACE + NEW_LINE +
-        "      \"rel\": \"imports\"," + NEW_LINE +
-        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "/VdbImports\"" + NEW_LINE +
-        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
-        "    " + OPEN_BRACE + NEW_LINE +
-        "      \"rel\": \"models\"," + NEW_LINE +
-        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "/Models\"" + NEW_LINE +
-        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
-        "    " + OPEN_BRACE + NEW_LINE +
-        "      \"rel\": \"translators\"," + NEW_LINE +
-        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "/VdbTranslators\"" + NEW_LINE +
-        "    " + CLOSE_BRACE + COMMA + NEW_LINE +
-        "    " + OPEN_BRACE + NEW_LINE +
-        "      \"rel\": \"dataRoles\"," + NEW_LINE +
-        "      \"href\": \"" + BASE_URI_PREFIX + DATASERVICE_DATA_PATH + "/VdbDataRoles\"" + NEW_LINE +
         "    " + CLOSE_BRACE + COMMA + NEW_LINE +
         "    " + OPEN_BRACE + NEW_LINE +
         "      \"rel\": \"vdbs\"," + NEW_LINE +
@@ -103,12 +79,7 @@ public final class DataserviceSerializerTest extends AbstractSerializerTest  {
         Mockito.when(theService.getParent(transaction)).thenReturn(workspace);
 
         this.dataservice = new RestDataservice(MY_BASE_URI, theService, false, transaction);
-        this.dataservice.setName(DATASERVICE_NAME);
         this.dataservice.setDescription(DESCRIPTION);
-        this.dataservice.setOriginalFilePath(ORIGINAL_FILE);
-        this.dataservice.setConnectionType(CONNECTION_TYPE);
-        this.dataservice.setPreview(false);
-        this.dataservice.setVersion(VERSION);
     }
 
     @Test
@@ -120,10 +91,9 @@ public final class DataserviceSerializerTest extends AbstractSerializerTest  {
     @Test
     public void shouldImportJson() {
         final RestDataservice descriptor = KomodoJsonMarshaller.unmarshall( JSON, RestDataservice.class );
-        assertEquals(DATASERVICE_NAME, descriptor.getName());
+        assertEquals(DATASERVICE_NAME, descriptor.getId());
         assertEquals(DESCRIPTION, descriptor.getDescription());
-        assertEquals(ORIGINAL_FILE, descriptor.getOriginalFilePath());
-        assertEquals(8, descriptor.getLinks().size());
+        assertEquals(4, descriptor.getLinks().size());
         assertEquals(true, descriptor.getProperties().isEmpty());
     }
 


### PR DESCRIPTION
This PR changes the Dataservice to a 'container' node, rather than extending a Vdb.  This should simplify future development.  There will be a corresponding PR for vdb-bench.
- Dataservice no longer extends Vdb.  Currently it can contain VDB children - will continue to build out in subsequent PRs.
- override equals in DocumentType class for equals checks
- changed related rest classes per the changes to Dataservice