### PR TITLE
Introduces Data Source Importer

### DIFF
--- a/komodo-importer/src/main/java/org/komodo/importer/AbstractImporter.java
+++ b/komodo-importer/src/main/java/org/komodo/importer/AbstractImporter.java
@@ -118,14 +118,16 @@ public abstract class AbstractImporter implements StringConstants {
      * Determines how to handle node creation if child to be created already exists.  The ExistingNodeOptions specify the behavior.
      * If no Option is set, then the default behavior is to overwrite any existing nodes.
      * @param transaction the transaction
+     * @param parentObject the parent object
      * @param importOptions the import options
      * @param importMessages the import messages
      * @return 'true' to continue, 'false' to bail
      * @throws KException the exception
      */
     protected abstract boolean handleExistingNode(UnitOfWork transaction,
-    		ImportOptions importOptions,
-    		ImportMessages importMessages) throws KException;
+                                                                                              KomodoObject parentObject,
+                                                                                              ImportOptions importOptions,
+                                                                                              ImportMessages importMessages) throws KException;
 
 
     protected abstract void executeImport(UnitOfWork transaction,
@@ -146,7 +148,7 @@ public abstract class AbstractImporter implements StringConstants {
         // --------------------------------------------------------------
         // Determine whether to continue, based on ImportOptions...
         // --------------------------------------------------------------
-        boolean doImport = handleExistingNode(transaction, importOptions, importMessages);
+        boolean doImport = handleExistingNode(transaction, parentObject, importOptions, importMessages);
         if (! doImport) {
             // Handling existing node advises not to continue
             return;

--- a/komodo-importer/src/main/java/org/komodo/importer/ImportType.java
+++ b/komodo-importer/src/main/java/org/komodo/importer/ImportType.java
@@ -38,5 +38,10 @@ public enum ImportType {
     /**
      * Import vdb
      */
-    VDB;
+    VDB,
+
+    /**
+     * Import data source
+     */
+    DS;
 }

--- a/komodo-importer/src/main/java/org/komodo/importer/Messages.java
+++ b/komodo-importer/src/main/java/org/komodo/importer/Messages.java
@@ -49,7 +49,8 @@ public class Messages implements StringConstants {
         newNameFailure,
         nodeCreated,
         nodeCreationFailed,
-        teiidParserException;
+        teiidParserException,
+        dataSourceImported;
 
         @Override
         public String toString() {

--- a/komodo-importer/src/main/resources/org/komodo/importer/messages.properties
+++ b/komodo-importer/src/main/resources/org/komodo/importer/messages.properties
@@ -12,3 +12,4 @@ IMPORTER.newNameFailure = The importer failed to determine a new name from the o
 IMPORTER.nodeCreated = The node has been created
 IMPORTER.nodeCreationFailed = The node failed to be created
 IMPORTER.teiidParserException = Parse Exception (Line={1}, Column={2}) - {0}
+IMPORTER.dataSourceImported = Data source successfully imported

--- a/komodo-relational-commands/src/main/java/org/komodo/relational/commands/workspace/UploadDatasourceCommand.java
+++ b/komodo-relational-commands/src/main/java/org/komodo/relational/commands/workspace/UploadDatasourceCommand.java
@@ -25,10 +25,12 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import org.komodo.core.KomodoLexicon;
 import org.komodo.relational.datasource.Datasource;
 import org.komodo.relational.datasource.internal.DatasourceParser;
+import org.komodo.relational.datasource.internal.DatasourceParser.ParserOption;
 import org.komodo.shell.CommandResultImpl;
 import org.komodo.shell.CompletionConstants;
 import org.komodo.shell.api.CommandResult;
@@ -87,11 +89,11 @@ public final class UploadDatasourceCommand extends WorkspaceShellCommand {
             }
 
             // Parser validates xml file and obtains dsNames
-            DatasourceParser datasourceParser = new DatasourceParser( getRepository(), overwrite );
+            DatasourceParser datasourceParser = new DatasourceParser();
             
             File dsXmlFile = new File(fileName);
             // Validate the data source XML file and get names
-            String[] dsNames = datasourceParser.validate(getTransaction(), dsXmlFile);
+            String[] dsNames = datasourceParser.validate(dsXmlFile);
             // Collect fatalErrors and Errors
             List<String> parseErrors = datasourceParser.getFatalErrors();
             if(parseErrors.isEmpty()) {
@@ -111,9 +113,15 @@ public final class UploadDatasourceCommand extends WorkspaceShellCommand {
                 }
             }
 
+            EnumSet<ParserOption> options = EnumSet.of(ParserOption.CREATE_REPO_SOURCES);
+            if (overwrite)
+                options.add(ParserOption.REPLACE_REPO_SOURCE);
+
             // Parse creates the sources in the repo.
-            datasourceParser.parse(getTransaction(), dsXmlFile);
-            
+            datasourceParser.parse(getTransaction(),
+                                                       getRepository().komodoWorkspace(getTransaction()),
+                                                       dsXmlFile, options);
+
             // Check again for parse errors
             parseErrors = datasourceParser.getFatalErrors();
             if(parseErrors.isEmpty()) {

--- a/komodo-relational/src/main/java/org/komodo/relational/RelationalModelFactory.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/RelationalModelFactory.java
@@ -145,6 +145,22 @@ public final class RelationalModelFactory {
     }
 
     /**
+     * Wraps the given exception in a {@link KException}
+     *
+     * @param e the exception
+     * @return return a {@link KException} from the given {@link Exception}
+     */
+    public static KException handleError( final Exception e ) {
+        assert ( e != null );
+
+        if ( e instanceof KException ) {
+            return ( KException )e;
+        }
+
+        return new KException( e );
+    }
+
+    /**
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
      * @param repository
@@ -1286,16 +1302,6 @@ public final class RelationalModelFactory {
 
         final VirtualProcedure result = new VirtualProcedureImpl( transaction, repository, kobject.getAbsolutePath() );
         return result;
-    }
-
-    private static KException handleError( final Exception e ) {
-        assert ( e != null );
-
-        if ( e instanceof KException ) {
-            return ( KException )e;
-        }
-
-        return new KException( e );
     }
 
     private static void setCreateStatementProperties( final UnitOfWork transaction,

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/DataserviceManifest.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/DataserviceManifest.java
@@ -71,7 +71,7 @@ public class DataserviceManifest implements VdbManifest {
 
     @Override
     public DocumentType getDocumentType(UnitOfWork transaction) throws KException {
-        return DocumentType.XML;
+        return DocumentType.VDB_XML;
     }
 
     private static XMLStreamReader createReader(InputStream srcStream) throws Exception {

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceConveyor.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceConveyor.java
@@ -39,12 +39,14 @@ import org.komodo.importer.ImportMessages;
 import org.komodo.importer.ImportOptions;
 import org.komodo.importer.ImportOptions.ExistingNodeOptions;
 import org.komodo.importer.ImportOptions.OptionKeys;
+import org.komodo.relational.DeployStatus;
 import org.komodo.relational.Messages;
 import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.dataservice.DataserviceManifest;
 import org.komodo.relational.datasource.Datasource;
 import org.komodo.relational.driver.Driver;
 import org.komodo.relational.importer.ddl.DdlImporter;
+import org.komodo.relational.importer.dsource.DatasourceImporter;
 import org.komodo.relational.importer.vdb.VdbImporter;
 import org.komodo.relational.teiid.Teiid;
 import org.komodo.relational.vdb.Vdb;
@@ -259,10 +261,14 @@ public class DataserviceConveyor implements StringConstants {
                     if (DataserviceManifest.MANIFEST.equals(name)) {
                         DataserviceManifest manifest = new DataserviceManifest(transaction, dataservice);
                         manifest.read(transaction, entryStream);
-                    } else if (name.endsWith(DocumentType.XML.toString())) {
+                    } else if (name.endsWith(DocumentType.VDB_XML.toString())) {
                         VdbImporter importer = new VdbImporter(repository);
                         ImportOptions options = new ImportOptions();
                         importer.importVdb(transaction, entryStream, dataservice, options, importMessages);
+                    } else if (name.endsWith(DocumentType.TDS.toString())) {
+                        DatasourceImporter importer = new DatasourceImporter(repository);
+                        ImportOptions options = new ImportOptions();
+                        importer.importDS(transaction, entryStream, dataservice, options, importMessages);
                     } else if (name.endsWith(DocumentType.DDL.toString())) {
                         DdlImporter importer = new DdlImporter(repository);
                         ImportOptions options = new ImportOptions();
@@ -336,10 +342,9 @@ public class DataserviceConveyor implements StringConstants {
                     continue;
 
                 String name = exportable.getName(transaction);
-                String ext = exportable.getDocumentType(transaction).toString();
                 byte[] content = exportable.export(transaction, new Properties());
 
-                String entryName = name + DOT + ext;
+                String entryName = exportable.getDocumentType(transaction).fileName(name);
                 ZipEntry zipEntry = new ZipEntry(entryName);
 
                 zipStream.putNextEntry(zipEntry);

--- a/komodo-relational/src/main/java/org/komodo/relational/datasource/internal/DatasourceImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/datasource/internal/DatasourceImpl.java
@@ -334,7 +334,7 @@ public class DatasourceImpl extends RelationalChildRestrictedObject implements D
 
     @Override
     public DocumentType getDocumentType(UnitOfWork transaction) throws KException {
-        return DocumentType.XML;
+        return DocumentType.TDS;
     }
 
     /**

--- a/komodo-relational/src/main/java/org/komodo/relational/driver/internal/DriverImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/driver/internal/DriverImpl.java
@@ -139,12 +139,6 @@ public class DriverImpl extends RelationalObjectImpl implements Driver {
     @Override
     public DocumentType getDocumentType(UnitOfWork transaction) throws KException {
         String name = getName(transaction);
-        int dotIndex = name.lastIndexOf(DOT);
-
-        if (dotIndex == -1)
-            return DocumentType.UNKNOWN;
-
-        String suffix = name.substring(dotIndex + 1);
-        return new DocumentType(suffix);
+        return DocumentType.createDocumentType(name);
     }
 }

--- a/komodo-relational/src/main/java/org/komodo/relational/importer/ddl/DdlImporter.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/importer/ddl/DdlImporter.java
@@ -91,8 +91,9 @@ public class DdlImporter extends AbstractImporter {
 	 */
     @Override
     protected boolean handleExistingNode(UnitOfWork transaction,
-    		ImportOptions importOptions,
-    		ImportMessages importMessages) throws KException {
+                                                                             KomodoObject parentObject,
+                                                                             ImportOptions importOptions,
+                                                                             ImportMessages importMessages) throws KException {
 
     	return true;
     }

--- a/komodo-relational/src/main/java/org/komodo/relational/importer/dsource/DatasourceImporter.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/importer/dsource/DatasourceImporter.java
@@ -1,0 +1,194 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.importer.dsource;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.EnumSet;
+import org.komodo.importer.AbstractImporter;
+import org.komodo.importer.ImportMessages;
+import org.komodo.importer.ImportOptions;
+import org.komodo.importer.ImportOptions.ExistingNodeOptions;
+import org.komodo.importer.ImportOptions.OptionKeys;
+import org.komodo.importer.ImportType;
+import org.komodo.importer.Messages;
+import org.komodo.relational.datasource.Datasource;
+import org.komodo.relational.datasource.internal.DatasourceParser;
+import org.komodo.relational.datasource.internal.DatasourceParser.ParserOption;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork;
+import org.komodo.utils.ArgCheck;
+
+public class DatasourceImporter extends AbstractImporter {
+
+    public DatasourceImporter(Repository repository) {
+        super(repository, ImportType.DS);
+    }
+
+    @Override
+    protected boolean handleExistingNode(UnitOfWork transaction,
+                                                                             KomodoObject parentObject,
+                                                                              ImportOptions importOptions,
+                                                                              ImportMessages importMessages) throws KException {
+     // VDB name to create
+        String dsrcName = importOptions.getOption(OptionKeys.NAME).toString();
+
+        // No node with the requested name - ok to create
+        if (! parentObject.hasChild(transaction, dsrcName))
+            return true;
+
+        // Option specifying how to handle when node exists with requested name
+        ExistingNodeOptions exNodeOption = (ExistingNodeOptions)importOptions.getOption(OptionKeys.HANDLE_EXISTING);
+
+        switch (exNodeOption) {
+        // RETURN - Return 'false' - do not create a node.  Log an error message
+        case RETURN:
+            importMessages.addErrorMessage(Messages.getString(Messages.IMPORTER.nodeExistsReturn));
+            return false;
+        // CREATE_NEW - Return 'true' - will create a new VDB with new unique name.  Log a progress message.
+        case CREATE_NEW:
+            String newName = determineNewName(transaction, dsrcName);
+            importMessages.addProgressMessage(Messages.getString(Messages.IMPORTER.nodeExistCreateNew, dsrcName, newName));
+            importOptions.setOption(OptionKeys.NAME, newName);
+            break;
+        // OVERWRITE - Return 'true' - deletes the existing VDB so that new one can replace existing.
+        case OVERWRITE:
+            KomodoObject oldNode = parentObject.getChild(transaction, dsrcName);
+            oldNode.remove(transaction);
+        }
+
+        return true;
+    }
+
+    @Override
+    protected void executeImport(UnitOfWork transaction,
+                                                             String content,
+                                                             KomodoObject parentObject,
+                                                             ImportOptions importOptions,
+                                                             ImportMessages importMessages) throws KException {
+
+        DatasourceParser parser = new DatasourceParser();
+        EnumSet<ParserOption> options = EnumSet.allOf(ParserOption.class);
+
+        ByteArrayInputStream contentStream = new ByteArrayInputStream(content.getBytes());
+
+        Datasource[] dataSources = parser.parse(transaction, parentObject, contentStream, options);
+        if (dataSources != null && dataSources.length > 0) {
+            importMessages.addProgressMessage(org.komodo.importer.Messages.getString(
+                                                                                     org.komodo.importer.Messages.IMPORTER.dataSourceImported));
+        }
+    }
+
+    /**
+     * @param dsStream the ds input stream
+     * @return the name of the data source specified in the xml
+     */
+    public static String extractDsName(InputStream dsStream) {
+        if (dsStream == null)
+            return null;
+
+        try {
+            DatasourceParser parser = new DatasourceParser();
+            String[] dsNames = parser.validate(dsStream);
+            if (dsNames.length == 0)
+                return null;
+
+            return dsNames[0];
+
+        } catch (Exception ex) {
+            // Don't need to worry about the exception
+            return null;
+        }
+    }
+
+    /**
+     * Extracts the name attribute from the ds xml file and sets it into
+     * the import options to synchronise the imported node name with
+     * the vdb:name property.
+     *
+     * @param dsStream
+     * @param importOptions
+     * @throws Exception
+     */
+    private void overrideName(InputStream dsStream, ImportOptions importOptions) throws Exception {
+        String dsName = extractDsName(dsStream);
+        if (dsName == null)
+            return;
+
+        importOptions.setOption(OptionKeys.NAME, dsName);
+    }
+
+    /**
+     * Perform the data source import using the specified xml Stream.
+     *
+     * @param uow the transaction
+     * @param stream the data source xml input stream
+     * @param parentObject the parent object in which to place the vdb
+     * @param importOptions the options for the import
+     * @param importMessages the messages recorded during the import
+     */
+    public void importDS(UnitOfWork transaction,
+                                             InputStream stream,
+                                             KomodoObject parentObject,
+                                             ImportOptions importOptions,
+                                             ImportMessages importMessages) {
+        ArgCheck.isNotNull(stream);
+
+        try {
+            String dsXml = toString(stream);
+            ByteArrayInputStream vdbNameStream = new ByteArrayInputStream(dsXml.getBytes("UTF-8")); //$NON-NLS-1$
+            overrideName(vdbNameStream, importOptions);
+
+            doImport(transaction, dsXml, parentObject, importOptions, importMessages);
+        } catch (Exception ex) {
+            importMessages.addErrorMessage(ex.getLocalizedMessage());
+        }
+    }
+
+    /**
+     * Perform the data source import using the specified ds xml File.
+     *
+     * @param uow the transaction
+     * @param dsXmlFile the ds xml file
+     * @param parentObject the parent object in which to place the ds
+     * @param importOptions the options for the import
+     * @param importMessages the messages recorded during the import
+     */
+    public void importDS(UnitOfWork uow, File dsXmlFile,
+                                              KomodoObject parentObject, ImportOptions importOptions,
+                                              ImportMessages importMessages) {
+        if (!validFile(dsXmlFile, importMessages))
+            return;
+
+        try {
+            overrideName(new FileInputStream(dsXmlFile), importOptions);
+
+            doImport(uow, toString(dsXmlFile), parentObject, importOptions, importMessages);
+        } catch (Exception ex) {
+            importMessages.addErrorMessage(ex.getLocalizedMessage());
+        }
+    }
+}

--- a/komodo-relational/src/main/java/org/komodo/relational/importer/vdb/VdbImporter.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/importer/vdb/VdbImporter.java
@@ -82,35 +82,36 @@ public class VdbImporter extends AbstractImporter {
 
     @Override
     protected boolean handleExistingNode(UnitOfWork transaction,
-    		ImportOptions importOptions,
-    		ImportMessages importMessages) throws KException {
+                                                                             KomodoObject parentObject,
+                                                                             ImportOptions importOptions,
+                                                                             ImportMessages importMessages) throws KException {
 
-    	// VDB name to create
-    	String vdbName = importOptions.getOption(OptionKeys.NAME).toString();
+        // VDB name to create
+        String vdbName = importOptions.getOption(OptionKeys.NAME).toString();
 
-    	// No node with the requested name - ok to create
-    	if (! getWorkspace(transaction).hasChild(transaction, vdbName))
-    		return true;
+        // No node with the requested name - ok to create
+        if (!parentObject.hasChild(transaction, vdbName))
+            return true;
 
-    	// Option specifying how to handle when node exists with requested name
-    	ExistingNodeOptions exNodeOption = (ExistingNodeOptions)importOptions.getOption(OptionKeys.HANDLE_EXISTING);
+        // Option specifying how to handle when node exists with requested name
+        ExistingNodeOptions exNodeOption = (ExistingNodeOptions)importOptions.getOption(OptionKeys.HANDLE_EXISTING);
 
-    	switch (exNodeOption) {
-    	// RETURN - Return 'false' - do not create a node.  Log an error message
-    	case RETURN:
-    		importMessages.addErrorMessage(Messages.getString(Messages.IMPORTER.nodeExistsReturn));
-    		return false;
-    	// CREATE_NEW - Return 'true' - will create a new VDB with new unique name.  Log a progress message.
-    	case CREATE_NEW:
-    		String newName = determineNewName(transaction, vdbName);
-    		importMessages.addProgressMessage(Messages.getString(Messages.IMPORTER.nodeExistCreateNew, vdbName, newName));
-    		importOptions.setOption(OptionKeys.NAME, newName);
-    		break;
-    	// OVERWRITE - Return 'true' - deletes the existing VDB so that new one can replace existing.
-    	case OVERWRITE:
-    		KomodoObject oldNode = getWorkspace(transaction).getChild(transaction, vdbName);
-    		oldNode.remove(transaction);
-    	}
+        switch (exNodeOption) {
+            // RETURN - Return 'false' - do not create a node.  Log an error message
+            case RETURN:
+                importMessages.addErrorMessage(Messages.getString(Messages.IMPORTER.nodeExistsReturn));
+                return false;
+            // CREATE_NEW - Return 'true' - will create a new VDB with new unique name.  Log a progress message.
+            case CREATE_NEW:
+                String newName = determineNewName(transaction, vdbName);
+                importMessages.addProgressMessage(Messages.getString(Messages.IMPORTER.nodeExistCreateNew, vdbName, newName));
+                importOptions.setOption(OptionKeys.NAME, newName);
+                break;
+            // OVERWRITE - Return 'true' - deletes the existing VDB so that new one can replace existing.
+            case OVERWRITE:
+                KomodoObject oldNode = parentObject.getChild(transaction, vdbName);
+                oldNode.remove(transaction);
+        }
 
     	return true;
     }

--- a/komodo-relational/src/main/java/org/komodo/relational/vdb/internal/VdbImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/vdb/internal/VdbImpl.java
@@ -222,7 +222,7 @@ public class VdbImpl extends RelationalObjectImpl implements Vdb {
 
         @Override
         public DocumentType getDocumentType(UnitOfWork transaction) throws KException {
-            return DocumentType.XML;
+            return DocumentType.VDB_XML;
         }
     }
 
@@ -1235,6 +1235,6 @@ public class VdbImpl extends RelationalObjectImpl implements Vdb {
 
     @Override
     public DocumentType getDocumentType(UnitOfWork transaction) throws KException {
-        return DocumentType.XML;
+        return DocumentType.VDB_XML;
     }
 }

--- a/komodo-relational/src/main/java/org/komodo/relational/workspace/WorkspaceManager.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/workspace/WorkspaceManager.java
@@ -21,8 +21,8 @@
  */
 package org.komodo.relational.workspace;
 
-import java.util.ArrayList;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import org.komodo.core.KomodoLexicon;
@@ -44,6 +44,7 @@ import org.komodo.relational.datasource.internal.DatasourceImpl;
 import org.komodo.relational.driver.Driver;
 import org.komodo.relational.folder.Folder;
 import org.komodo.relational.importer.ddl.DdlImporter;
+import org.komodo.relational.importer.dsource.DatasourceImporter;
 import org.komodo.relational.importer.vdb.VdbImporter;
 import org.komodo.relational.internal.AdapterFactory;
 import org.komodo.relational.internal.TypeResolverRegistry;
@@ -829,9 +830,13 @@ public class WorkspaceManager extends ObjectImpl implements RelationalObject {
             ImportOptions importOptions = new ImportOptions();
             ImportMessages importMessages = new ImportMessages();
 
-            if (DocumentType.XML.equals(storageRef.getDocumentType())) {
+            if (DocumentType.VDB_XML.equals(storageRef.getDocumentType())) {
                 VdbImporter importer = new VdbImporter(getRepository());
                 importer.importVdb(transaction, stream, parent, importOptions, importMessages);
+            }
+            else if (DocumentType.TDS.equals(storageRef.getDocumentType())) {
+                DatasourceImporter importer = new DatasourceImporter(getRepository());
+                importer.importDS(transaction, stream, parent, importOptions, importMessages);
             }
             else if (DocumentType.DDL.equals(storageRef.getDocumentType())) {
                 DdlImporter importer = new DdlImporter(getRepository());

--- a/komodo-relational/src/test/java/org/komodo/relational/AbstractImporterTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/AbstractImporterTest.java
@@ -54,6 +54,8 @@ public abstract class AbstractImporterTest extends AbstractLocalRepositoryTest {
 
     protected static final String DDL_DIRECTORY = "ddl";
 
+    protected static final String TDS_DIRECTORY = "tds";
+
     protected abstract void runImporter(Repository repository,
                                                 InputStream inputStream,
                                                 KomodoObject parentObject,

--- a/komodo-relational/src/test/java/org/komodo/relational/datasource/internal/DatasourceParserTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/datasource/internal/DatasourceParserTest.java
@@ -29,6 +29,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
 import org.komodo.relational.datasource.Datasource;
+import org.komodo.spi.KException;
+import org.komodo.spi.repository.KomodoObject;
 
 @SuppressWarnings( { "javadoc", "nls" } )
 public final class DatasourceParserTest extends RelationalModelTest {
@@ -36,13 +38,17 @@ public final class DatasourceParserTest extends RelationalModelTest {
     private static DatasourceParser datasourceParser;
 
     @BeforeClass
-    public static void oneTimeSetup() throws Exception {
-        datasourceParser = new DatasourceParser( _repo, true );
+    public static void setup() throws Exception {
+        datasourceParser = new DatasourceParser();
     }
-    
+
+    private KomodoObject getWorkspace() throws KException {
+        return _repo.komodoWorkspace(getTransaction());
+    }
+
     @Test( expected = IllegalArgumentException.class )
     public void shouldFailWhenNullRulesFile() throws Exception {
-        datasourceParser.parse(getTransaction(), null);
+        datasourceParser.parse(getTransaction(), getWorkspace(), null);
     }
 
     @Test
@@ -52,7 +58,7 @@ public final class DatasourceParserTest extends RelationalModelTest {
 
         final int numErrors = 6;
         final int numSources = 4;
-        final Datasource[] dataSources = datasourceParser.parse(getTransaction(), testFile);
+        final Datasource[] dataSources = datasourceParser.parse(getTransaction(), getWorkspace(), testFile);
         final List<String> errors = datasourceParser.getErrors();
         
         assertThat( errors.size(), is( numErrors ) );
@@ -73,7 +79,7 @@ public final class DatasourceParserTest extends RelationalModelTest {
         String testFilePath = getClass().getClassLoader().getResource("datasource-valid.xml").getFile();
         final File testFile = new File(testFilePath);
 
-        final String[] dataSourceNames = datasourceParser.validate(getTransaction(), testFile);
+        final String[] dataSourceNames = datasourceParser.validate(testFile);
         final List<String> errors = datasourceParser.getErrors();
         assertThat( errors.size(), is( 0 ) );
         assertThat( dataSourceNames.length, is( 1 ) );
@@ -85,7 +91,7 @@ public final class DatasourceParserTest extends RelationalModelTest {
         String testFilePath = getClass().getClassLoader().getResource("datasource-multipleValid.xml").getFile();
         final File testFile = new File(testFilePath);
 
-        final String[] dataSourceNames = datasourceParser.validate(getTransaction(), testFile);
+        final String[] dataSourceNames = datasourceParser.validate(testFile);
         final List<String> errors = datasourceParser.getErrors();
         assertThat( errors.size(), is( 0 ) );
         assertThat( dataSourceNames.length, is( 3 ) );
@@ -100,7 +106,7 @@ public final class DatasourceParserTest extends RelationalModelTest {
         String testFilePath = getClass().getClassLoader().getResource("datasource-validDashboardDS.xml").getFile();
         final File testFile = new File(testFilePath);
 
-        final String[] dataSourceNames = datasourceParser.validate(getTransaction(), testFile);
+        final String[] dataSourceNames = datasourceParser.validate(testFile);
         final List<String> errors = datasourceParser.getErrors();
         assertThat( errors.size(), is( 0 ) );
         assertThat( dataSourceNames.length, is( 1 ) );
@@ -113,7 +119,7 @@ public final class DatasourceParserTest extends RelationalModelTest {
         String testFilePath = getClass().getClassLoader().getResource("datasource-valid.xml").getFile();
         final File testFile = new File(testFilePath);
 
-        final Datasource[] dataSources = datasourceParser.parse(getTransaction(), testFile);
+        final Datasource[] dataSources = datasourceParser.parse(getTransaction(), getWorkspace(), testFile);
         final List<String> errors = datasourceParser.getErrors();
         assertThat( errors.size(), is( 0 ) );
         assertThat( dataSources.length, is( 1 ) );
@@ -133,7 +139,7 @@ public final class DatasourceParserTest extends RelationalModelTest {
         String testFilePath = getClass().getClassLoader().getResource("datasource-multipleValid.xml").getFile();
         final File testFile = new File(testFilePath);
 
-        final Datasource[] dataSources = datasourceParser.parse(getTransaction(), testFile);
+        final Datasource[] dataSources = datasourceParser.parse(getTransaction(), getWorkspace(), testFile);
         final List<String> errors = datasourceParser.getErrors();
         assertThat( errors.size(), is( 0 ) );
         assertThat( dataSources.length, is( 3 ) );
@@ -177,7 +183,7 @@ public final class DatasourceParserTest extends RelationalModelTest {
         String testFilePath = getClass().getClassLoader().getResource("datasource-validDashboardDS.xml").getFile();
         final File testFile = new File(testFilePath);
 
-        final Datasource[] dataSources = datasourceParser.parse(getTransaction(), testFile);
+        final Datasource[] dataSources = datasourceParser.parse(getTransaction(), getWorkspace(), testFile);
         final List<String> errors = datasourceParser.getErrors();
         assertThat( errors.size(), is( 0 ) );
         assertThat( dataSources.length, is( 1 ) );

--- a/komodo-relational/src/test/java/org/komodo/relational/importer/dsource/TestTeiidDatasourceImporter.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/importer/dsource/TestTeiidDatasourceImporter.java
@@ -1,0 +1,238 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.relational.importer.dsource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import org.junit.Test;
+import org.komodo.core.KomodoLexicon;
+import org.komodo.importer.ImportMessages;
+import org.komodo.importer.ImportOptions;
+import org.komodo.relational.AbstractImporterTest;
+import org.komodo.relational.datasource.Datasource;
+import org.komodo.relational.workspace.WorkspaceManager;
+import org.komodo.repository.SynchronousCallback;
+import org.komodo.spi.repository.KomodoObject;
+import org.komodo.spi.repository.Repository;
+import org.komodo.spi.repository.Repository.UnitOfWork.State;
+import org.komodo.test.utils.TestUtilities;
+
+public class TestTeiidDatasourceImporter  extends AbstractImporterTest {
+
+    private static final String MYSQL_USSTATES_TDS = "mysql-usstates.tds";
+
+    private static final String TDS_NAME = "MySqlPool";
+
+    @Override
+    protected void runImporter(Repository repository,
+                                                                 File file, KomodoObject parentObject, ImportOptions importOptions,
+                                                                 ImportMessages importMessages) throws Exception {
+        DatasourceImporter importer = new DatasourceImporter(_repo);
+        importer.importDS(getTransaction(), file, parentObject, importOptions, importMessages);
+    }
+
+    @Override
+    protected void runImporter(Repository repository,
+                                                                 InputStream inputStream, KomodoObject parentObject,
+                                                                 ImportOptions importOptions,
+                                                                 ImportMessages importMessages) throws Exception {
+        DatasourceImporter importer = new DatasourceImporter(_repo);
+        importer.importDS(getTransaction(), inputStream, parentObject, importOptions, importMessages);
+    }
+
+    // Commit Transaction and handle Importer errors, adding to import messages.  Then start a new transaction.
+    private void commitHandleErrors(ImportMessages importMessages, State expectedState) throws Exception {
+        // cache current callback as a new one will be created when the commit occurs
+        final SynchronousCallback testCallback = this.callback;
+
+        // Commit the transaction and handle any import exceptions
+        commit(expectedState);
+
+        if ( testCallback.hasError() ) {
+            importMessages.addErrorMessage( testCallback.error() );
+        }
+    }
+
+    // Commit Transaction and handle Importer errors, adding to import messages.  Then start a new transaction.
+    private void commitHandleErrors(ImportMessages importMessages) throws Exception {
+        commitHandleErrors(importMessages, State.COMMITTED);
+    }
+
+    /**
+     * Test Error condition - bad TDS file name supplied
+     * Expected Outcome - Error message saying that the supplied file is not found
+     */
+    @Test
+    public void testBadTdsFile() throws Exception {
+        ImportMessages importMessages = new ImportMessages();
+        KomodoObject workspace = _repo.komodoWorkspace(getTransaction());
+        executeImporter(new File("unknown.tds"), workspace, new ImportOptions(), importMessages);
+
+        // Verify no children created
+        KomodoObject[] children = workspace.getChildren(getTransaction());
+        assertEquals(0,children.length);
+
+        // Should have 1 error message
+        assertEquals(1, importMessages.getErrorMessages().size());
+
+        String msg = importMessages.getErrorMessages().get(0);
+        assertEquals("The specified File \"unknown.tds\" was not found",msg);
+    }
+
+    /**
+     * Test Error condition - unreadable TDS file supplied.
+     * Expected Outcome - Error Message saying that the supplied file is not readable
+     */
+    @Test
+    public void testUnreadableTDSFile() throws Exception {
+        InputStream tdsStream = TestUtilities.getResourceAsStream(getClass(),
+                                                                  TDS_DIRECTORY, MYSQL_USSTATES_TDS);
+
+        File tmpFile = File.createTempFile("unreadableFile", ".tds");
+        Files.copy(tdsStream, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        tmpFile.deleteOnExit();
+
+        assertTrue(tmpFile.exists());
+        assertTrue(tmpFile.length() > 0);
+
+        // Make file unreadable
+        tmpFile.setReadable(false);
+
+        // Saves Messages during import
+        ImportMessages importMessages = new ImportMessages();
+
+        KomodoObject workspace = _repo.komodoWorkspace(getTransaction());
+        executeImporter(tmpFile, workspace, new ImportOptions(), importMessages);
+
+        // Set back to readable
+        tmpFile.setReadable(true);
+
+        // Verify no children created
+        KomodoObject[] children = workspace.getChildren(getTransaction());
+        assertEquals(0,children.length);
+
+        // Should have 1 error message
+        assertEquals(1, importMessages.getErrorMessages().size());
+
+        String msg = importMessages.getErrorMessages().get(0);
+        assertEquals("The specified File \"" + tmpFile.getName() + "\" is not readable", msg);
+    }
+
+    /**
+     * Test Error condition - empty TDS string supplied
+     * Expected Outcome - Error Message saying that the supplied TDS string is empty
+     */
+    @Test
+    public void testEmptyTDSString() throws Exception {
+        File tmpFile = File.createTempFile("emptyFile", ".tds");
+        tmpFile.deleteOnExit();
+
+        assertTrue(tmpFile.exists());
+        assertEquals(0, tmpFile.length());
+
+        // Saves Messages during import
+        ImportMessages importMessages = new ImportMessages();
+
+        KomodoObject workspace = _repo.komodoWorkspace(getTransaction());
+        executeImporter(tmpFile, workspace, new ImportOptions(), importMessages);
+
+        // Verify no children created
+        KomodoObject[] children = workspace.getChildren(getTransaction());
+        assertEquals(0,children.length);
+
+        // Should have 1 error message
+        assertEquals(1, importMessages.getErrorMessages().size());
+
+        String msg = importMessages.getErrorMessages().get(0);
+        assertEquals("The supplied content string is empty", msg);
+    }
+
+    // Verifies a MySQL data source node
+    private void verifyMySQLUSStatesTDS(KomodoObject dsNode) throws Exception {
+        verifyProperty(dsNode, KomodoLexicon.DataSource.DRIVER_NAME, "mysql");
+        verifyProperty(dsNode, KomodoLexicon.DataSource.JNDI_NAME, "java:/MySqlDS");
+        verifyProperty(dsNode, "connection-url", "jdbc:mysql://db4free.net:3306/usstates");
+        verifyProperty(dsNode, "username", "komodo");
+        verifyProperty(dsNode, "password", "XUMz4vBKuA2v");
+        verifyProperty(dsNode, KomodoLexicon.DataSource.JDBC, "true");
+    }
+
+    /**
+     * Test import of mysql-usstates.tds
+     * Expected outcome - successful creation
+     */
+    @Test
+    public void testTdsImport_MySQLUSStates() throws Exception {
+        InputStream tdsStream = TestUtilities.getResourceAsStream(getClass(),
+                                                                  TDS_DIRECTORY, MYSQL_USSTATES_TDS);
+
+        ImportOptions importOptions = new ImportOptions();
+        ImportMessages importMessages = new ImportMessages();
+        KomodoObject workspace = _repo.komodoWorkspace(getTransaction());
+        executeImporter(tdsStream, workspace, importOptions, importMessages);
+
+        // Commit the transaction and handle any import exceptions
+        commitHandleErrors(importMessages);
+
+        // Retrieve data source after import
+        WorkspaceManager mgr = WorkspaceManager.getInstance(_repo);
+        Datasource[] datasources = mgr.findDatasources(getTransaction());
+        assertEquals(1, datasources.length);
+
+        Datasource dataSrc = datasources[0];
+        // Test Data source name
+        String dataSrcName = dataSrc.getName(getTransaction());
+        assertEquals(TDS_NAME, dataSrcName);
+
+        verifyMySQLUSStatesTDS(dataSrc);
+    }
+
+    /**
+     * Imports MySQL USStates TDS, then re-imports.  import of TDS into a parent
+     * does a full replace of the existing content...
+     * Expected outcome - successful creation with replacement of first import content
+     */
+    @Test
+    public void testTdsImportModelThenReimport() throws Exception {
+        // Import the original datasource from tds
+        testTdsImport_MySQLUSStates();
+        commit();
+
+        testTdsImport_MySQLUSStates();
+        commit();
+
+        WorkspaceManager mgr = WorkspaceManager.getInstance(_repo);
+        Datasource[] datasources = mgr.findDatasources(getTransaction());
+        assertEquals(1, datasources.length);
+
+        Datasource dataSrc = datasources[0];
+        // Test Data source name
+        String dataSrcName = dataSrc.getName(getTransaction());
+        assertEquals(TDS_NAME, dataSrcName);
+
+        verifyMySQLUSStatesTDS(dataSrc);
+    }
+}

--- a/komodo-relational/src/test/java/org/komodo/relational/workspace/WorkspaceManagerTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/workspace/WorkspaceManagerTest.java
@@ -922,7 +922,7 @@ public final class WorkspaceManagerTest extends RelationalModelTest {
         parameters.setProperty(StorageConnector.FILE_PATH_PROPERTY, vdbSrcFile.getName());
 
         KomodoObject parent = _repo.komodoWorkspace(getTransaction());
-        StorageReference reference = new StorageReference("file", parameters, DocumentType.XML);
+        StorageReference reference = new StorageReference("file", parameters, DocumentType.VDB_XML);
         wsMgr.importArtifact(getTransaction(), parent, reference);
 
         assertTrue(parent.hasChild(getTransaction(), TestUtilities.SAMPLE_VDB_NAME));

--- a/komodo-relational/src/test/resources/tds/mysql-usstates.tds
+++ b/komodo-relational/src/test/resources/tds/mysql-usstates.tds
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataSourceSet>
+    <dataSource name="MySqlPool" jdbc="true">
+        <property name="jndiName">java:/MySqlDS</property>
+        <property name="driverName">mysql</property>
+        <property name="username">komodo</property>
+        <property name="password">XUMz4vBKuA2v</property>
+        <property name="allow-multiple-users">false</property>
+        <property name="connection-url">jdbc:mysql://db4free.net:3306/usstates</property>
+        <property name="set-tx-query-timeout">false</property>
+        <property name="share-prepared-statements">false</property>
+        <property name="spy">false</property>
+        <property name="statistics-enabled">false</property>
+        <property name="track-statements">NOWARN</property>
+        <property name="use-fast-fail">false</property>
+        <property name="validate-on-match">false</property>
+    </dataSource>
+</dataSourceSet>

--- a/komodo-spi/src/main/java/org/komodo/spi/constants/StringConstants.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/constants/StringConstants.java
@@ -375,6 +375,11 @@ public interface StringConstants {
   String VDB_DEPLOYMENT_SUFFIX = "-vdb" + XML_SUFFIX; //$NON-NLS-1$
 
   /**
+   * Datasource Suffix
+   */
+  String DS_SUFFIX = ".tds"; //$NON-NLS-1$
+
+  /**
    * jboss temp directory
    */
   String JBOSS_SERVER_TMP_DIR = "jboss.server.temp.dir";

--- a/komodo-spi/src/main/java/org/komodo/spi/repository/DocumentType.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/repository/DocumentType.java
@@ -23,12 +23,17 @@ package org.komodo.spi.repository;
 
 import org.komodo.spi.constants.StringConstants;
 
-public class DocumentType {
+public class DocumentType implements StringConstants {
 
     /**
-     * XML
+     * VDB-XML
      */
-    public static final DocumentType XML = new DocumentType(StringConstants.XML);
+    public static final DocumentType VDB_XML = new DocumentType(StringConstants.VDB_DEPLOYMENT_SUFFIX);
+
+    /**
+     * TDS
+     */
+    public static final DocumentType TDS = new DocumentType(StringConstants.DS_SUFFIX);
 
     /**
      * ZIP
@@ -56,10 +61,39 @@ public class DocumentType {
         return this.type;
     }
 
+    /**
+     * @param name
+     * @return a file name from the given name and the document type
+     */
+    public String fileName(String name) {
+        if (type.contains(DOT))
+            return name + type;
+
+        return name + DOT + type;
+    }
+
+    public static DocumentType createDocumentType(String name) {
+        if (name == null)
+            return DocumentType.UNKNOWN;
+
+        if (name.endsWith(VDB_DEPLOYMENT_SUFFIX))
+            return DocumentType.VDB_XML;
+
+        if (name.endsWith(DS_SUFFIX))
+            return DocumentType.TDS;
+
+        int dotIndex = name.lastIndexOf(DOT);
+        if (dotIndex == -1)
+            return DocumentType.UNKNOWN;
+
+        String suffix = name.substring(dotIndex + 1);
+        return new DocumentType(suffix);
+    }
+
     public static DocumentType documentType(String docTypeValue) {
         return new DocumentType(docTypeValue);
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoImportExportServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoImportExportServiceTest.java
@@ -82,7 +82,7 @@ public class KomodoImportExportServiceTest extends AbstractKomodoServiceTest {
 
         KomodoStorageAttributes storageAttr = new KomodoStorageAttributes();
         storageAttr.setStorageType("file");
-        storageAttr.setDocumentType(DocumentType.XML);
+        storageAttr.setDocumentType(DocumentType.VDB_XML);
 
         String portfolioCnt = FileUtils.streamToString(TestUtilities.portfolioExample());
         String content = Base64.getEncoder().encodeToString(portfolioCnt.getBytes());


### PR DESCRIPTION
* DocumentType
 * Modifies XML type to VDB-XML (-vdb.xml) since this is the expected
   suffix of dynamic vdb files
 * Adds DS-XML suffix which denotes the extension used for data sources
 * createDocumentType for constructing a new instance from a file name

* DatasourceParser
 * Constructor parameters moved to the parse and validate methods
 * Uses enum for parsing options
 * Allows a parent to be specified rather than assuming the workspace

* DatasourceImporter
 * Importer mirroring structure of DDL and VDB importers
 * Delegates to the DatasourceParser for doing the actual import