### PR TITLE
Rolls back the version of resteasy to match jboss installation

### DIFF
--- a/komodo-integration-utils/pom.xml
+++ b/komodo-integration-utils/pom.xml
@@ -21,49 +21,51 @@
 
 		<plugins>
 			<!-- Downloads resteasy jaxrs from resteasy for use in integration tests -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>download-resteasy</id>
-						<phase>process-sources</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<!-- Not required if skipping integration tests -->
-							<skip>${integration.skipTests}</skip>
-							<target>
-								<property name="version.resteasy" value="${version.resteasy}" />
-								<property name="destination.resteasy" value="${project.build.directory}/resteasy" />
-								<property name="resteasy.final.module.name.zip" value="${resteasy.module.zip}" />
-								<ant antfile="${project.basedir}/download-resteasy.xml"
-									target="download" />
-							</target>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<!-- Not required if skipping integration tests -->
-					<skipAssembly>${integration.skipTests}</skipAssembly>
-					<descriptors>
-						<descriptor>assembly/assemble.xml</descriptor>
-					</descriptors>
-				</configuration>
-				<executions>
-					<execution>
-						<id>make-assembly-zip</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+			<!-- NOT CURRENTLY REQUIRED SINCE THE REVERSION TO THE RESTEASY VERSION
+			       THAT IS SHIPPED WITH JBOSS AS -->
+<!-- 			<plugin> -->
+<!-- 				<groupId>org.apache.maven.plugins</groupId> -->
+<!-- 				<artifactId>maven-antrun-plugin</artifactId> -->
+<!-- 				<executions> -->
+<!-- 					<execution> -->
+<!-- 						<id>download-resteasy</id> -->
+<!-- 						<phase>process-sources</phase> -->
+<!-- 						<goals> -->
+<!-- 							<goal>run</goal> -->
+<!-- 						</goals> -->
+<!-- 						<configuration> -->
+<!-- 							Not required if skipping integration tests -->
+<!-- 							<skip>${integration.skipTests}</skip> -->
+<!-- 							<target> -->
+<!-- 								<property name="version.resteasy" value="${version.resteasy}" /> -->
+<!-- 								<property name="destination.resteasy" value="${project.build.directory}/resteasy" /> -->
+<!-- 								<property name="resteasy.final.module.name.zip" value="${resteasy.module.zip}" /> -->
+<!-- 								<ant antfile="${project.basedir}/download-resteasy.xml" -->
+<!-- 									target="download" /> -->
+<!-- 							</target> -->
+<!-- 						</configuration> -->
+<!-- 					</execution> -->
+<!-- 				</executions> -->
+<!-- 			</plugin> -->
+<!-- 			<plugin> -->
+<!-- 				<artifactId>maven-assembly-plugin</artifactId> -->
+<!-- 				<configuration> -->
+<!-- 					Not required if skipping integration tests -->
+<!-- 					 <skipAssembly>${integration.skipTests}</skipAssembly> -->
+<!-- 					<descriptors> -->
+<!-- 						<descriptor>assembly/assemble.xml</descriptor> -->
+<!-- 					</descriptors> -->
+<!-- 				</configuration> -->
+<!-- 				<executions> -->
+<!-- 					<execution> -->
+<!-- 						<id>make-assembly-zip</id> -->
+<!-- 						<phase>package</phase> -->
+<!-- 						<goals> -->
+<!-- 							<goal>single</goal> -->
+<!-- 						</goals> -->
+<!-- 					</execution> -->
+<!-- 				</executions> -->
+<!-- 			</plugin> -->
 		</plugins>
 
 		<pluginManagement>

--- a/komodo-integration-utils/pom.xml
+++ b/komodo-integration-utils/pom.xml
@@ -6,6 +6,7 @@
 		<groupId>org.komodo</groupId>
 		<artifactId>komodo-parent</artifactId>
 		<version>0.0.4-SNAPSHOT</version>
+		<relativePath>../komodo-parent/pom.xml</relativePath>
 	</parent>
 
 	<artifactId>komodo-integration-utils</artifactId>

--- a/komodo-parent/pom.xml
+++ b/komodo-parent/pom.xml
@@ -128,9 +128,6 @@
 		<version.arquillian>1.1.9.Final</version.arquillian>
 		<version.arquillian-container>7.5.5.Final-redhat-3</version.arquillian-container>
 
-		<!-- The test version of resteasy when its unpacked -->
-		<version.resteasy>3.0.11.Final</version.resteasy>
-		<resteasy.module.zip>resteasy-module.zip</resteasy.module.zip>
 	</properties>
 
 	<profiles>

--- a/server/komodo-rest/pom.xml
+++ b/server/komodo-rest/pom.xml
@@ -52,13 +52,6 @@
 				<version>${version.guava}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.jboss.resteasy</groupId>
-				<artifactId>resteasy-bom</artifactId>
-				<version>${version.resteasy}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
 				<groupId>io.swagger</groupId>
 				<artifactId>swagger-annotations</artifactId>
 				<version>${version.swagger}</version>
@@ -154,11 +147,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-json-p-provider</artifactId>
+			<artifactId>jaxrs-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.resteasy</groupId>
@@ -182,15 +171,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.undertow</groupId>
-			<artifactId>undertow-servlet</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-undertow</artifactId>
-			<scope>test</scope>
+  			<groupId>org.jboss.resteasy</groupId>
+  			<artifactId>resteasy-test-tjws</artifactId>
+  			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -376,53 +359,6 @@
 							</artifactItems>
 						</configuration>
 					</execution>
-					<execution>
-						<!-- Fetch the integration utils zip so that the resteasy module can be included in the jboss instance -->
-						<id>unpack-resteasy-stage-1</id>
-						<phase>process-sources</phase>
-						<goals>
-							<goal>unpack</goal>
-						</goals>
-						<configuration>
-							<!-- Not required if skipping integration tests -->
-							<skip>${integration.skipTests}</skip>
-							<artifactItems>
-								<artifactItem>
-									<groupId>org.komodo</groupId>
-									<artifactId>komodo-integration-utils</artifactId>
-									<version>${project.version}</version>
-									<classifier>components</classifier>
-									<type>zip</type>
-									<overWrite>true</overWrite>
-									<outputDirectory>${project.build.directory}</outputDirectory>
-									<includes>/${resteasy.module.zip}</includes>
-								</artifactItem>
-							</artifactItems>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<!-- The resteasy-module.zip should be in build directory so unpack it to the jboss instance -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>unpack-resteasy-stage-2</id>
-						<phase>process-sources</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							Not required if skipping integration tests
-							<skip>${integration.skipTests}</skip>
-							<target>
-								<unzip src="${project.build.directory}/${resteasy.module.zip}"
-											dest="${project.basedir}/lib/jbossas/${version.jbossas.test}/modules/system/layers/base" />
-							</target>
-						</configuration>
-					</execution>
 				</executions>
 			</plugin>
 
@@ -538,17 +474,6 @@
 					<artifactId>resteasy-jaxrs</artifactId>
 					<scope>provided</scope>
 				</dependency>
-				<dependency>
-					<groupId>org.jboss.resteasy</groupId>
-					<artifactId>resteasy-client</artifactId>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.jboss.resteasy</groupId>
-					<artifactId>resteasy-json-p-provider</artifactId>
-					<scope>provided</scope>
-				</dependency>
-
 			</dependencies>
 		</profile>
 

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
@@ -28,7 +28,7 @@ import java.io.StringWriter;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
@@ -129,7 +129,7 @@ public abstract class KomodoService implements V1Constants {
         try {
             this.wsMgr = WorkspaceManager.getInstance(this.repo);
         } catch (final Exception e) {
-            throw new ServerErrorException(Messages.getString(Messages.Error.KOMODO_ENGINE_WORKSPACE_MGR_ERROR), Status.INTERNAL_SERVER_ERROR);
+            throw new WebApplicationException(new Exception(Messages.getString(Messages.Error.KOMODO_ENGINE_WORKSPACE_MGR_ERROR)), Status.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -267,7 +267,7 @@ public abstract class KomodoService implements V1Constants {
             // callback timeout occurred
             String errorMessage = Messages.getString( COMMIT_TIMEOUT, transaction.getName(), timeout, unit );
             Object responseEntity = createErrorResponseEntity(acceptableMediaTypes, errorMessage);
-            return Response.status( Status.GATEWAY_TIMEOUT )
+            return Response.status( Status.INTERNAL_SERVER_ERROR )
                            .entity(responseEntity)
                            .build();
         }
@@ -297,7 +297,6 @@ public abstract class KomodoService implements V1Constants {
                                                      resourceNotFound.getOperationName() );
             Object responseEntity = createErrorResponseEntity(acceptableMediaTypes, notFoundMsg);
             builder = Response.status( Status.NOT_FOUND ).entity(responseEntity);
-
         } else {
 
             //
@@ -327,7 +326,7 @@ public abstract class KomodoService implements V1Constants {
             // callback timeout occurred
             String errorMessage = Messages.getString( COMMIT_TIMEOUT, transaction.getName(), timeout, unit );
             Object responseEntity = createErrorResponseEntity(acceptableMediaTypes, errorMessage);
-            return Response.status( Status.GATEWAY_TIMEOUT )
+            return Response.status( Status.INTERNAL_SERVER_ERROR )
                            .type( MediaType.TEXT_PLAIN )
                            .entity(responseEntity)
                            .build();

--- a/server/komodo-rest/src/main/java/org/komodo/rest/cors/CorsHeaders.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/cors/CorsHeaders.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.cors;
+
+public interface CorsHeaders {
+
+    String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
+    String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";
+    String ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods";
+    String ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers";
+    String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";
+    String ORIGIN = "Origin";
+    String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
+    String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
+    String ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers";
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/cors/CorsInterceptor.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/cors/CorsInterceptor.java
@@ -1,0 +1,238 @@
+package org.komodo.rest.cors;
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+import org.jboss.resteasy.annotations.interception.ServerInterceptor;
+import org.jboss.resteasy.core.ResourceMethod;
+import org.jboss.resteasy.core.ServerResponse;
+import org.jboss.resteasy.spi.Failure;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.interception.PostProcessInterceptor;
+import org.jboss.resteasy.spi.interception.PreProcessInterceptor;
+import org.komodo.spi.constants.StringConstants;
+
+@Provider
+@ServerInterceptor
+public class CorsInterceptor implements PreProcessInterceptor, PostProcessInterceptor, StringConstants {
+
+    public static final String ALLOW_HEADERS = "Content-Type, X-Requested-With, accept, Origin," + //$NON-NLS-1$
+                                                                                        "Access-Control-Request-Method," + //$NON-NLS-1$
+                                                                                        "Access-Control-Request-Headers, Authorization"; //$NON-NLS-1$
+
+    public static final String ALLOW_METHODS = "GET, POST, PUT, DELETE, OPTIONS, HEAD"; //$NON-NLS-1$
+
+    private boolean allowCredentials = true;
+
+    private String allowedMethods;
+
+    private String allowedHeaders;
+
+    private String exposedHeaders;
+
+    private int corsMaxAge = -1;
+
+    private Set<String> allowedOrigins = new HashSet<String>();
+
+    private static final ThreadLocal<String> REQUEST_ORIGIN = new ThreadLocal<String>();
+
+    /**
+     * Put "*" if you want to accept all origins
+     *
+     * @return
+     */
+    public Set<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    /**
+     * Defaults to true
+     *
+     * @return
+     */
+    public boolean isAllowCredentials() {
+        return allowCredentials;
+    }
+
+    public void setAllowCredentials(boolean allowCredentials) {
+        this.allowCredentials = allowCredentials;
+    }
+
+    /**
+     * Will allow all by default
+     *
+     * @return
+     */
+    public String getAllowedMethods() {
+        return allowedMethods;
+    }
+
+    /**
+     * Will allow all by default
+     * comma delimited string for Access-Control-Allow-Methods
+     *
+     * @param allowedMethods
+     */
+    public void setAllowedMethods(String allowedMethods) {
+        this.allowedMethods = allowedMethods;
+    }
+
+    public String getAllowedHeaders() {
+        return allowedHeaders;
+    }
+
+    /**
+     * Will allow all by default
+     * comma delimited string for Access-Control-Allow-Headers
+     *
+     * @param allowedHeaders
+     */
+    public void setAllowedHeaders(String allowedHeaders) {
+        this.allowedHeaders = allowedHeaders;
+    }
+
+    public int getCorsMaxAge() {
+        return corsMaxAge;
+    }
+
+    public void setCorsMaxAge(int corsMaxAge) {
+        this.corsMaxAge = corsMaxAge;
+    }
+
+    public String getExposedHeaders() {
+        return exposedHeaders;
+    }
+
+    /**
+     * comma delimited list
+     *
+     * @param exposedHeaders
+     */
+    public void setExposedHeaders(String exposedHeaders) {
+        this.exposedHeaders = exposedHeaders;
+    }
+
+    @Override
+    public ServerResponse preProcess(HttpRequest request, ResourceMethod method) throws Failure, WebApplicationException {
+        HttpHeaders httpHeaders = request.getHttpHeaders();
+        MultivaluedMap<String, String> headers = httpHeaders.getRequestHeaders();
+        String origin = headers.getFirst(CorsHeaders.ORIGIN);
+
+        //
+        // Need to stash this for the post process
+        //
+        REQUEST_ORIGIN.set(origin);
+
+        if (origin == null)
+            return null;
+
+        if (isOption(method.getMethod())) {
+            return preflight(origin, request);
+
+        } else {
+            checkOrigin(request, origin);
+        }
+
+        return null;
+    }
+
+    private boolean isOption(Method method) {
+        if (method == null)
+            return false;
+
+        return method.getName().equalsIgnoreCase("OPTIONS");
+    }
+
+    @Override
+    public void postProcess(ServerResponse response) {
+        MultivaluedMap<String, Object> headers = response.getMetadata();
+        String origin = REQUEST_ORIGIN.get();
+
+        if (origin == null || isOption(response.getResourceMethod())) {
+            // don't do anything if origin is null, its an OPTIONS request, or cors.failure is set
+            return;
+        }
+
+        headers.putSingle(CorsHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+
+        if (allowCredentials)
+            headers.putSingle(CorsHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+
+        if (exposedHeaders != null)
+            headers.putSingle(CorsHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, exposedHeaders);
+    }
+
+    protected ServerResponse preflight(String origin, HttpRequest requestContext) {
+        checkOrigin(requestContext, origin);
+
+        Response.ResponseBuilder builder = Response.ok();
+        builder.header(CorsHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+        if (allowCredentials)
+            builder.header(CorsHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+
+        HttpHeaders httpHeaders = requestContext.getHttpHeaders();
+        MultivaluedMap<String, String> headers = httpHeaders.getRequestHeaders();
+
+        String requestMethods = headers.getFirst(CorsHeaders.ACCESS_CONTROL_REQUEST_METHOD);
+        if (requestMethods != null) {
+            if (allowedMethods != null) {
+                requestMethods = this.allowedMethods;
+            }
+            builder.header(CorsHeaders.ACCESS_CONTROL_ALLOW_METHODS, requestMethods);
+        }
+
+        String allowHeaders = headers.getFirst(CorsHeaders.ACCESS_CONTROL_REQUEST_HEADERS);
+        if (allowHeaders != null) {
+            if (allowedHeaders != null) {
+                allowHeaders = this.allowedHeaders;
+            }
+            builder.header(CorsHeaders.ACCESS_CONTROL_ALLOW_HEADERS, allowHeaders);
+        }
+
+        if (corsMaxAge > -1) {
+            builder.header(CorsHeaders.ACCESS_CONTROL_MAX_AGE, corsMaxAge);
+        }
+
+        Response response = builder.build();
+        return ServerResponse.copyIfNotServerResponse(response);
+    }
+
+    protected void checkOrigin(HttpRequest requestContext, String origin) {
+        if (allowedOrigins.contains(STAR))
+            return; // Nothing to check all good
+
+        if (origin == null)
+            return;
+
+        if (!allowedOrigins.contains(origin)) {
+            requestContext.setAttribute("cors.failure", true);
+            throw new ForbiddenException("Origin not allowed: " + origin);
+        }
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/cors/ForbiddenException.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/cors/ForbiddenException.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.cors;
+
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.spi.LoggableFailure;
+
+public class ForbiddenException extends LoggableFailure {
+
+    private static final long serialVersionUID = -7370671758722865878L;
+
+    public ForbiddenException() {
+        super(403);
+    }
+
+    public ForbiddenException(String s) {
+        super(s, 403);
+    }
+
+    public ForbiddenException(String s, Response response) {
+        super(s, response);
+    }
+
+    public ForbiddenException(String s, Throwable throwable, Response response) {
+        super(s, throwable, response);
+    }
+
+    public ForbiddenException(String s, Throwable throwable) {
+        super(s, throwable, 403);
+    }
+
+    public ForbiddenException(Throwable throwable) {
+        super(throwable, 403);
+    }
+
+    public ForbiddenException(Throwable throwable, Response response) {
+        super(throwable, response);
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/cors/OptionsExceptionMapper.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/cors/OptionsExceptionMapper.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.cors;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.jboss.resteasy.spi.DefaultOptionsMethodException;
+import org.komodo.spi.constants.StringConstants;
+
+@Provider
+public class OptionsExceptionMapper implements ExceptionMapper<DefaultOptionsMethodException>, StringConstants {
+
+    @Override
+    public Response toResponse(DefaultOptionsMethodException exception) {
+        //
+        // Exception provides its own OK response to avoid this exception causing failures
+        //
+        Response response = exception.getResponse();
+
+        MultivaluedMap<String, Object> headers = response.getMetadata();
+        headers.add(CorsHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, STAR);
+        headers.add(CorsHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        headers.add(CorsHeaders.ACCESS_CONTROL_ALLOW_METHODS, CorsInterceptor.ALLOW_METHODS);
+        headers.add(CorsHeaders.ACCESS_CONTROL_ALLOW_HEADERS, CorsInterceptor.ALLOW_HEADERS);
+        headers.add(CorsHeaders.ACCESS_CONTROL_MAX_AGE, 1209600);
+
+        return response;
+    }
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -32,7 +32,6 @@ import static org.komodo.rest.relational.RelationalMessages.Error.DATASERVICE_SE
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -40,7 +39,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -85,10 +84,10 @@ public final class KomodoDataserviceService extends KomodoService {
     /**
      * @param engine
      *        the Komodo Engine (cannot be <code>null</code> and must be started)
-     * @throws ServerErrorException
+     * @throws WebApplicationException
      *         if there is a problem obtaining the {@link WorkspaceManager workspace manager}
      */
-    public KomodoDataserviceService( final KEngine engine ) throws ServerErrorException {
+    public KomodoDataserviceService( final KEngine engine ) throws WebApplicationException {
         super( engine );
     }
 
@@ -104,7 +103,6 @@ public final class KomodoDataserviceService extends KomodoService {
      */
     @GET
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Display the collection of data services",
                             response = RestDataservice[].class)
     @ApiResponses(value = {
@@ -229,7 +227,6 @@ public final class KomodoDataserviceService extends KomodoService {
     @GET
     @Path( V1Constants.DATA_SERVICE_PLACEHOLDER )
     @Produces( { MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML } )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find dataservice by name", response = RestDataservice.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No Dataservice could be found with name"),
@@ -286,7 +283,6 @@ public final class KomodoDataserviceService extends KomodoService {
     @POST
     @Path( StringConstants.FORWARD_SLASH + V1Constants.DATA_SERVICE_PLACEHOLDER )
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Create a dataservice in the workspace")
     @ApiResponses(value = {
         @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
@@ -374,7 +370,6 @@ public final class KomodoDataserviceService extends KomodoService {
     @POST
     @Path( StringConstants.FORWARD_SLASH + V1Constants.CLONE_DATA_SERVICE_SEGMENT + StringConstants.FORWARD_SLASH + V1Constants.DATA_SERVICE_PLACEHOLDER )
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Clone a dataservice in the workspace")
     @ApiResponses(value = {
         @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
@@ -470,7 +465,6 @@ public final class KomodoDataserviceService extends KomodoService {
     @PUT
     @Path( StringConstants.FORWARD_SLASH + V1Constants.DATA_SERVICE_PLACEHOLDER )
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Update a dataservice in the workspace")
     @ApiResponses(value = {
         @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoImportExportService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoImportExportService.java
@@ -32,7 +32,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -73,7 +73,7 @@ import io.swagger.annotations.ApiResponses;
 @Api( tags = {V1Constants.IMPORT_EXPORT_SEGMENT} )
 public class KomodoImportExportService extends KomodoService {
 
-    public KomodoImportExportService(KEngine engine) throws ServerErrorException {
+    public KomodoImportExportService(KEngine engine) throws WebApplicationException {
         super(engine);
     }
 
@@ -354,7 +354,6 @@ public class KomodoImportExportService extends KomodoService {
     @GET
     @Path(V1Constants.STORAGE_TYPES)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Returns the collection of available storage types used for import/export",
                              response = RestStorageType[].class)
     @ApiResponses(value = {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoSearchService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoSearchService.java
@@ -36,7 +36,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -86,10 +86,10 @@ public final class KomodoSearchService extends KomodoService {
     /**
      * @param engine
      *        the Komodo Engine (cannot be <code>null</code> and must be started)
-     * @throws ServerErrorException
+     * @throws WebApplicationException
      *         if there is a problem obtaining the {@link WorkspaceManager workspace manager}
      */
-    public KomodoSearchService( final KEngine engine ) throws ServerErrorException {
+    public KomodoSearchService( final KEngine engine ) throws WebApplicationException {
         super( engine );
     }
 
@@ -219,7 +219,6 @@ public final class KomodoSearchService extends KomodoService {
      */
     @GET
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Search the workspace using criteria",
                              response = RestBasicEntity[].class)
     @ApiResponses(value = {
@@ -414,7 +413,6 @@ public final class KomodoSearchService extends KomodoService {
     @GET
     @Path(V1Constants.SAVED_SEARCHES_SEGMENT)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Fetch saved searches from the workspace",
                              response = RestBasicEntity[].class)
     @ApiResponses(value = {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
@@ -34,7 +34,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -99,10 +99,10 @@ public class KomodoTeiidService extends KomodoService {
     /**
      * @param engine
      *        the Komodo Engine (cannot be <code>null</code> and must be started)
-     * @throws ServerErrorException
+     * @throws WebApplicationException
      *         if there is a problem obtaining the {@link WorkspaceManager workspace manager}
      */
-    public KomodoTeiidService(final KEngine engine) throws ServerErrorException {
+    public KomodoTeiidService(final KEngine engine) throws WebApplicationException {
         super(engine);
     }
 
@@ -359,7 +359,6 @@ public class KomodoTeiidService extends KomodoService {
     @GET
     @Path(V1Constants.VDBS_SEGMENT)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Display the collection of vdbs",
                             response = RestVdb[].class)
     @ApiResponses(value = {
@@ -422,7 +421,6 @@ public class KomodoTeiidService extends KomodoService {
     @Path( V1Constants.VDBS_SEGMENT + StringConstants.FORWARD_SLASH +
                   V1Constants.VDB_PLACEHOLDER )
     @Produces( { MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML } )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find vdb by name", response = RestVdb.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -479,7 +477,6 @@ public class KomodoTeiidService extends KomodoService {
     @GET
     @Path(V1Constants.TRANSLATORS_SEGMENT)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Display the collection of translators",
                             response = RestVdbTranslator[].class)
     @ApiResponses(value = {
@@ -538,7 +535,6 @@ public class KomodoTeiidService extends KomodoService {
     @GET
     @Path(V1Constants.DATA_SOURCES_SEGMENT)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Display the collection of data sources",
                             response = RestDataSource[].class)
     @ApiResponses(value = {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -27,13 +27,12 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -94,10 +93,10 @@ public final class KomodoUtilService extends KomodoService {
     /**
      * @param engine
      *        the Komodo Engine (cannot be <code>null</code> and must be started)
-     * @throws ServerErrorException
+     * @throws WebApplicationException
      *         if there is a problem obtaining the {@link WorkspaceManager workspace manager}
      */
-    public KomodoUtilService(final KEngine engine) throws ServerErrorException {
+    public KomodoUtilService(final KEngine engine) throws WebApplicationException {
         super(engine);
     }
 
@@ -270,7 +269,6 @@ public final class KomodoUtilService extends KomodoService {
     @GET
     @Path(V1Constants.SCHEMA_SEGMENT)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Display the schema structure of the teiid vdb",
                             response = String.class)
     @ApiResponses(value = {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoVdbService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoVdbService.java
@@ -42,12 +42,11 @@ import static org.komodo.rest.relational.RelationalMessages.Error.VDB_SERVICE_GE
 import static org.komodo.rest.relational.RelationalMessages.Error.VDB_SERVICE_GET_VDB_ERROR;
 import java.util.ArrayList;
 import java.util.List;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -107,10 +106,10 @@ public final class KomodoVdbService extends KomodoService {
     /**
      * @param engine
      *        the Komodo Engine (cannot be <code>null</code> and must be started)
-     * @throws ServerErrorException
+     * @throws WebApplicationException
      *         if there is a problem obtaining the {@link WorkspaceManager workspace manager}
      */
-    public KomodoVdbService( final KEngine engine ) throws ServerErrorException {
+    public KomodoVdbService( final KEngine engine ) throws WebApplicationException {
         super( engine );
     }
 
@@ -129,7 +128,6 @@ public final class KomodoVdbService extends KomodoService {
 //     */
 //    @PUT
 //    @Path( "{vdbName}" )
-//    @Consumes( MediaType.APPLICATION_JSON )
 //    @Produces( MediaType.APPLICATION_JSON )
 //    public Response addOrUpdateVdb( final @Context HttpHeaders headers,
 //                                    final @Context UriInfo uriInfo,
@@ -396,7 +394,6 @@ public final class KomodoVdbService extends KomodoService {
      */
     @GET
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Display the collection of vdbs",
                             response = RestVdb[].class)
     @ApiResponses(value = {
@@ -522,7 +519,6 @@ public final class KomodoVdbService extends KomodoService {
     @GET
     @Path( V1Constants.VDB_PLACEHOLDER )
     @Produces( { MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML } )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find vdb by name", response = RestVdb.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -578,7 +574,6 @@ public final class KomodoVdbService extends KomodoService {
     @Path( V1Constants.VDB_PLACEHOLDER + StringConstants.FORWARD_SLASH +
                 V1Constants.MODELS_SEGMENT )
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find all models belonging to the vdb", response = RestVdb.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -645,7 +640,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.MODELS_SEGMENT + StringConstants.FORWARD_SLASH +
                 V1Constants.MODEL_PLACEHOLDER)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the named model belonging to the vdb", response = RestVdbModel.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -708,7 +702,6 @@ public final class KomodoVdbService extends KomodoService {
     @Path( V1Constants.VDB_PLACEHOLDER + StringConstants.FORWARD_SLASH +
                 V1Constants.TRANSLATORS_SEGMENT )
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find all translators belonging to the vdb", response = RestVdbTranslator[].class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -775,7 +768,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.TRANSLATORS_SEGMENT + StringConstants.FORWARD_SLASH +
                 V1Constants.TRANSLATOR_PLACEHOLDER)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the named translator belonging to the vdb", response = RestVdbTranslator.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -855,7 +847,6 @@ public final class KomodoVdbService extends KomodoService {
     @Path( V1Constants.VDB_PLACEHOLDER + StringConstants.FORWARD_SLASH +
                 V1Constants.IMPORTS_SEGMENT )
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find all imports belonging to the vdb", response = RestVdbImport[].class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -922,7 +913,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.IMPORTS_SEGMENT + StringConstants.FORWARD_SLASH +
                 V1Constants.IMPORT_PLACEHOLDER)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the named vdb import belonging to the vdb", response = RestVdbImport.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -1002,7 +992,6 @@ public final class KomodoVdbService extends KomodoService {
     @Path( V1Constants.VDB_PLACEHOLDER + StringConstants.FORWARD_SLASH +
                 V1Constants.DATA_ROLES_SEGMENT )
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON} )
     @ApiOperation(value = "Find all data roles belonging to the vdb", response = RestBasicEntity[].class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -1069,7 +1058,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.DATA_ROLES_SEGMENT + StringConstants.FORWARD_SLASH +
                 V1Constants.DATA_ROLE_PLACEHOLDER)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the named data role belonging to the vdb", response = RestVdbDataRole.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -1136,7 +1124,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.MODEL_PLACEHOLDER + StringConstants.FORWARD_SLASH +
                 V1Constants.SOURCES_SEGMENT)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find all sources of the model belonging to the vdb", response = RestVdbModelSource[].class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -1214,7 +1201,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.SOURCES_SEGMENT + StringConstants.FORWARD_SLASH +
                 V1Constants.SOURCE_PLACEHOLDER)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the named source belonging to the model of the vdb", response = RestVdbModelSource.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb could be found with name"),
@@ -1313,7 +1299,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.DATA_ROLE_PLACEHOLDER + StringConstants.FORWARD_SLASH +
                 V1Constants.PERMISSIONS_SEGMENT)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON} )
     @ApiOperation(value = "Find all permissions belonging to the vdb data role", response = RestVdbPermission[].class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb or data role could be found with given names"),
@@ -1391,7 +1376,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.PERMISSIONS_SEGMENT + StringConstants.FORWARD_SLASH +
                 V1Constants.PERMISSION_PLACEHOLDER)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the named permission belonging to the data role of the vdb", response = RestVdbPermission.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb, data role or permission could be found with name"),
@@ -1466,7 +1450,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.PERMISSION_PLACEHOLDER + StringConstants.FORWARD_SLASH +
                 V1Constants.CONDITIONS_SEGMENT)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the conditions belonging to the permission of the data role of the vdb", response = RestVdbPermission.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb, data role or permission could be found with given names"),
@@ -1550,7 +1533,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.CONDITIONS_SEGMENT + StringConstants.FORWARD_SLASH +
                 V1Constants.CONDITION_PLACEHOLDER)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the condition belonging to the permission of the data role of the vdb", response = RestVdbPermission.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb, data role, permission or condition could be found with name"),
@@ -1656,7 +1638,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.PERMISSION_PLACEHOLDER + StringConstants.FORWARD_SLASH +
                 V1Constants.MASKS_SEGMENT)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the masks belonging to the permission of the data role of the vdb", response = RestVdbPermission.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb, data role or permission could be found with given names"),
@@ -1740,7 +1721,6 @@ public final class KomodoVdbService extends KomodoService {
                 V1Constants.MASKS_SEGMENT + StringConstants.FORWARD_SLASH +
                 V1Constants.MASK_PLACEHOLDER)
     @Produces( MediaType.APPLICATION_JSON )
-    @Consumes ( { MediaType.APPLICATION_JSON } )
     @ApiOperation(value = "Find the mask belonging to the permission of the data role of the vdb", response = RestVdbPermission.class)
     @ApiResponses(value = {
         @ApiResponse(code = 404, message = "No vdb, data role, permission or mask could be found with name"),

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
@@ -29,6 +29,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import java.net.URI;
 import java.util.Properties;
+import javax.ws.rs.core.MediaType;
+import org.jboss.resteasy.client.ClientRequest;
+import org.jboss.resteasy.client.ClientResponse;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -52,10 +55,12 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
 
         // get
         URI uri = _uriBuilder.workspaceDataservicesUri();
-        this.response = request(uri).get();
-        assertTrue(response.hasEntity());
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
 
-        final String entities = response.readEntity(String.class);
+        assertNotNull(response.getEntity());
+
+        final String entities = response.getEntity();
         assertThat(entities, is(notNullValue()));
 
         // System.out.println("Response:\n" + entities);
@@ -71,9 +76,12 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
     }
     
     @Test
-    public void shouldReturnEmptyListWhenNoDataservicesInWorkspace() {
-        this.response = request(_uriBuilder.workspaceDataservicesUri()).get();
-        final String entity = this.response.readEntity(String.class);
+    public void shouldReturnEmptyListWhenNoDataservicesInWorkspace() throws Exception {
+        URI uri = _uriBuilder.workspaceDataservicesUri();
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+
+        final String entity = response.getEntity();
         assertThat(entity, is(notNullValue()));
 
         //System.out.println("Response:\n" + entity);
@@ -90,8 +98,12 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
         // get
         Properties settings = _uriBuilder.createSettings(SettingNames.DATA_SERVICE_NAME, DATASERVICE_NAME);
         _uriBuilder.addSetting(settings, SettingNames.DATA_SERVICE_PARENT_PATH, _uriBuilder.workspaceDataservicesUri());
-        this.response = request(_uriBuilder.dataserviceUri(LinkType.SELF, settings)).get();
-        final String entity = this.response.readEntity(String.class);
+
+        URI uri = _uriBuilder.dataserviceUri(LinkType.SELF, settings);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+
+        final String entity = response.getEntity();
         assertThat(entity, is(notNullValue()));
 
         //System.out.println("Response:\n" + entity);

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoImportExportServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoImportExportServiceTest.java
@@ -31,11 +31,12 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Base64;
 import java.util.List;
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import org.apache.tika.io.IOUtils;
+import org.jboss.resteasy.client.ClientRequest;
+import org.jboss.resteasy.client.ClientResponse;
 import org.junit.Test;
 import org.komodo.relational.dataservice.Dataservice;
 import org.komodo.relational.workspace.WorkspaceManager;
@@ -63,8 +64,11 @@ public class KomodoImportExportServiceTest extends AbstractKomodoServiceTest {
 
         KomodoStorageAttributes storageAttr = new KomodoStorageAttributes();
 
-        this.response = request(uri, MediaType.APPLICATION_JSON_TYPE).post(Entity.json(storageAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, storageAttr);
+        ClientResponse<String> response = request.post(String.class);
+        final String entity = response.getEntity();
 
         assertTrue(entity.contains("The storage type requested from the import export service is unsupported"));
     }
@@ -92,10 +96,14 @@ public class KomodoImportExportServiceTest extends AbstractKomodoServiceTest {
 
         assertFalse(workspace.hasChild(uow, TestUtilities.PORTFOLIO_VDB_NAME));
 
-        this.response = request(uri, MediaType.APPLICATION_JSON_TYPE).post(Entity.json(storageAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, storageAttr);
+        ClientResponse<String> response = request.post(String.class);
 
-        assertEquals(Response.Status.OK.getStatusCode(), this.response.getStatus());
+        final String entity = response.getEntity();
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         ImportExportStatus status = KomodoJsonMarshaller.unmarshall(entity, ImportExportStatus.class);
         assertNotNull(status);
 
@@ -122,8 +130,12 @@ public class KomodoImportExportServiceTest extends AbstractKomodoServiceTest {
         String tmpDirPath = System.getProperty("java.io.tmpdir");
         storageAttr.setParameter("files-home-path-property", tmpDirPath);
 
-        this.response = request(uri, MediaType.APPLICATION_JSON_TYPE).post(Entity.json(storageAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, storageAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
 
         assertTrue(entity.contains("No artifact could be found to export at path"));
     }
@@ -143,8 +155,12 @@ public class KomodoImportExportServiceTest extends AbstractKomodoServiceTest {
         String tmpDirPath = System.getProperty("java.io.tmpdir");
         storageAttr.setParameter("files-home-path-property", tmpDirPath);
 
-        this.response = request(uri).post(Entity.json(storageAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, storageAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         assertNotNull(entity);
 
         //
@@ -203,10 +219,14 @@ public class KomodoImportExportServiceTest extends AbstractKomodoServiceTest {
 
         assertFalse(workspace.hasChild(uow, dsName));
 
-        this.response = request(uri, MediaType.APPLICATION_JSON_TYPE).post(Entity.json(storageAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, storageAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         System.out.println(entity);
-        assertEquals(Response.Status.OK.getStatusCode(), this.response.getStatus());
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
         ImportExportStatus status = KomodoJsonMarshaller.unmarshall(entity, ImportExportStatus.class);
         assertNotNull(status);
@@ -245,10 +265,14 @@ public class KomodoImportExportServiceTest extends AbstractKomodoServiceTest {
         String tmpDirPath = System.getProperty("java.io.tmpdir");
         storageAttr.setParameter("files-home-path-property", tmpDirPath);
 
-        this.response = request(uri).post(Entity.json(storageAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, storageAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         assertNotNull(entity);
-        assertEquals(Response.Status.OK.getStatusCode(), this.response.getStatus());
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
         //
         // Test that the file storage connector really did export the data service
@@ -281,11 +305,12 @@ public class KomodoImportExportServiceTest extends AbstractKomodoServiceTest {
                                         .path(V1Constants.IMPORT_EXPORT_SEGMENT)
                                         .path(V1Constants.STORAGE_TYPES).build();
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         assertNotNull(entity);
         System.out.println(entity);
-        assertEquals(Response.Status.OK.getStatusCode(), this.response.getStatus());
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
         RestStorageType[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestStorageType[].class);
         assertNotNull(entities);

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoSearchServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoSearchServiceTest.java
@@ -27,10 +27,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import java.net.URI;
 import java.util.List;
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+import org.jboss.resteasy.client.ClientRequest;
+import org.jboss.resteasy.client.ClientResponse;
 import org.junit.Test;
 import org.komodo.rest.RestBasicEntity;
 import org.komodo.rest.relational.AbstractKomodoServiceTest;
@@ -62,8 +63,10 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoProperties properties = new KomodoProperties();
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).accept(MediaType.APPLICATION_JSON).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+
+        final String entity = response.getEntity();
         System.out.println("Response:\n" + entity);
 
         JsonElement jelement = new JsonParser().parse(entity);
@@ -81,8 +84,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_CONTAINS_PARAMETER, "view");
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
 
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
@@ -108,8 +112,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_CONTAINS_PARAMETER, "view");
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
 
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
@@ -136,8 +141,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_CONTAINS_PARAMETER, "view");
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
 
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
@@ -163,8 +169,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_PATH_PARAMETER, PORTFOLIO_DATA_PATH);
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(1, entities.length);
@@ -185,8 +192,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_PARENT_PARAMETER, PORTFOLIO_DATA_PATH);
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(5, entities.length);
@@ -206,8 +214,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_ANCESTOR_PARAMETER, PORTFOLIO_DATA_PATH);
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(110, entities.length);
@@ -222,8 +231,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_TYPE_PARAMETER, TeiidDdlLexicon.CreateTable.TABLE_ELEMENT);
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(38, entities.length);
@@ -243,8 +253,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_TYPE_PARAMETER, KomodoType.COLUMN.getType());
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(38, entities.length);
@@ -265,8 +276,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_OBJECT_NAME_PARAMETER, "%ID%");
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(12, entities.length);
@@ -289,8 +301,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         properties.addProperty(SEARCH_SAVED_NAME_PARAMETER, searchNames.get(0));
         URI uri = _uriBuilder.searchUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(4, entities.length);
@@ -311,8 +324,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoProperties properties = new KomodoProperties();
         URI uri = _uriBuilder.savedSearchCollectionUri(properties);
 
-        this.response = request(uri).get();
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         KomodoSavedSearcher[] entities = KomodoJsonMarshaller.unmarshallArray(entity, KomodoSavedSearcher[].class);
         assertEquals(searchNames.size(), entities.length);
@@ -334,7 +348,10 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         searchAttr.setSearchName(searchName);
         searchAttr.setType(VdbLexicon.Vdb.VIRTUAL_DATABASE);
 
-        this.response = request(uri).post(Entity.json(searchAttr));
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        request.post(String.class);
 
         Repository repository = getRestApp().getDefaultRepository();
         UnitOfWork uow = repository.createTransaction(
@@ -359,7 +376,10 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         searchAttr.setSearchName(searchName);
         searchAttr.setType("{fromTypeParam}");
 
-        this.response = request(uri).post(Entity.json(searchAttr));
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        request.post(String.class);
 
         Repository repository = getRestApp().getDefaultRepository();
         UnitOfWork uow = repository.createTransaction(
@@ -382,7 +402,9 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         String searchName = searchNames.get(0);
         uri = UriBuilder.fromUri(uri).path(searchName).build();
 
-        this.response = request(uri).delete();
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        request.delete(String.class);
 
         Repository repository = getRestApp().getDefaultRepository();
         UnitOfWork uow = repository.createTransaction(
@@ -408,8 +430,12 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
         searchAttr.setContains("view");
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
 
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
@@ -437,8 +463,12 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         searchAttr.setType(VdbLexicon.Vdb.DECLARATIVE_MODEL);
         searchAttr.setContains("view");
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
 
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
@@ -467,8 +497,12 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         searchAttr.setParent(PORTFOLIO_DATA_PATH);
         searchAttr.setContains("view");
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
 
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
@@ -496,10 +530,14 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
         searchAttr.setPath(PORTFOLIO_DATA_PATH);
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         System.out.println("Response:\n" + entity);
-        assertEquals(Response.Status.OK.getStatusCode(), this.response.getStatus());
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
 
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(1, entities.length);
@@ -522,8 +560,12 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
         searchAttr.setParent(PORTFOLIO_DATA_PATH);
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(5, entities.length);
@@ -545,8 +587,12 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
         searchAttr.setAncestor(PORTFOLIO_DATA_PATH);
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(110, entities.length);
@@ -563,9 +609,13 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
         searchAttr.setType(TeiidDdlLexicon.CreateTable.TABLE_ELEMENT);
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
-        // System.out.println("Response:\n" + entity);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
+        System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(38, entities.length);
 
@@ -586,8 +636,12 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
         searchAttr.setType(KomodoType.COLUMN.getType());
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(38, entities.length);
@@ -610,8 +664,12 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         searchAttr.setType(KomodoType.COLUMN.getType());
         searchAttr.setObjectName("%ID%");
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(12, entities.length);
@@ -636,8 +694,12 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
         searchAttr.setSearchName(searchNames.get(0));
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(4, entities.length);
@@ -662,10 +724,14 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         searchAttr.setSearchName(searchNames.get(2));
         searchAttr.setParameter("valueParam", "%_ID");
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        assertEquals(Response.Status.OK.getStatusCode(), this.response.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_TYPE, this.response.getMediaType());
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(12, entities.length);
@@ -689,12 +755,15 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         KomodoSearcherAttributes searchAttr = new KomodoSearcherAttributes();
         searchAttr.setSearchName(searchNames.get(2));
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), this.response.getStatus());
-        assertEquals(MediaType.APPLICATION_JSON_TYPE, this.response.getMediaType());
-        final String entity = this.response.readEntity(String.class);
-        // System.out.println("Response:\n" + entity);
-        assertTrue(entity.startsWith("An error occurred whilst searching the workspace: " +
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+        final String entity = response.getEntity();
+        System.out.println("Response:\n" + entity);
+        assertTrue(entity.contains("An error occurred whilst searching the workspace: " +
                             "Search requires the parameter valueParam but has not been provided a value"));
     }
 
@@ -711,8 +780,12 @@ public final class KomodoSearchServiceTest extends AbstractKomodoServiceTest {
         searchAttr.setSearchName(searchNames.get(3));
         searchAttr.setParameter("fromTypeParam", "Vdb");
 
-        this.response = request(uri).post(Entity.json(searchAttr));
-        final String entity = this.response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, searchAttr);
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
         // System.out.println("Response:\n" + entity);
         RestBasicEntity[] entities = KomodoJsonMarshaller.unmarshallArray(entity, RestBasicEntity[].class);
         assertEquals(4, entities.length);

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoUtilServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoUtilServiceTest.java
@@ -21,18 +21,19 @@
  */
 package org.komodo.rest.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
+import org.jboss.resteasy.client.ClientRequest;
+import org.jboss.resteasy.client.ClientResponse;
 import org.junit.Assert;
 import org.junit.Test;
 import org.komodo.rest.KomodoRestV1Application.V1Constants;
 import org.komodo.rest.KomodoService;
+import org.komodo.rest.cors.CorsHeaders;
 import org.komodo.rest.relational.AbstractKomodoServiceTest;
 import org.komodo.rest.relational.RelationalMessages;
 import org.komodo.rest.relational.json.KomodoJsonMarshaller;
@@ -67,11 +68,17 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
         URI uri = UriBuilder.fromUri(_uriBuilder.baseUri())
                                                     .path(V1Constants.SERVICE_SEGMENT)
                                                     .path(V1Constants.ABOUT).build();
-        this.response = request(uri).get();
-        assertTrue(response.hasEntity());
 
-        final String entity = response.readEntity(String.class);
-        //System.out.println("Response from uri " + uri + ":\n" + entity);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addHeader(request, CorsHeaders.ORIGIN, "http://localhost:2772");
+
+        ClientResponse<String> response = request.get(String.class);
+        
+
+        assertNotNull(response.getEntity());
+
+        final String entity = response.getEntity();
+        System.out.println("Response from uri " + uri + ":\n" + entity);
         for (String expected : EXPECTED) {
             assertTrue(entity.contains(expected));
         }
@@ -83,10 +90,12 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
         // get
         URI uri = UriBuilder.fromUri(_uriBuilder.baseUri())
                                                     .path("swagger.json").build();
-        this.response = request(uri).get();
-        assertTrue(response.hasEntity());
 
-        final String entity = response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        assertNotNull(response.getEntity());
+
+        final String entity = response.getEntity();
         //System.out.println("Response from uri " + uri + ":\n" + entity);
 
         assertTrue(entity.contains("\"swagger\" : \"2.0\""));
@@ -106,9 +115,12 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
         URI uri = UriBuilder.fromUri(_uriBuilder.baseUri())
                                                     .path(V1Constants.SERVICE_SEGMENT)
                                                     .path(V1Constants.SAMPLE_DATA).build();
-        this.response = request(uri).post(null);
 
-        final String entity = response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.post(String.class);
+        assertNotNull(response.getEntity());
+
+        final String entity = response.getEntity();
         // System.out.println("Response from uri " + uri + ":\n" + entity);
 
         KomodoStatusObject status = KomodoJsonMarshaller.unmarshall(entity, KomodoStatusObject.class);
@@ -134,9 +146,12 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
         URI uri = UriBuilder.fromUri(_uriBuilder.baseUri())
                                                     .path(V1Constants.SERVICE_SEGMENT)
                                                     .path(V1Constants.SAMPLE_DATA).build();
-        this.response = request(uri).post(null);
 
-        final String entity = response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.post(String.class);
+        assertNotNull(response.getEntity());
+
+        final String entity = response.getEntity();
         // System.out.println("Response from uri " + uri + ":\n" + entity);
 
         KomodoStatusObject status = KomodoJsonMarshaller.unmarshall(entity, KomodoStatusObject.class);
@@ -164,10 +179,12 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
                                                     .path(V1Constants.SERVICE_SEGMENT)
                                                     .path(V1Constants.SCHEMA_SEGMENT)
                                                     .build();
-        this.response = request(uri).get();
-        assertTrue(response.hasEntity());
 
-        final String entity = response.readEntity(String.class);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        assertNotNull(response.getEntity());
+
+        final String entity = response.getEntity();
         System.out.println("Response from uri " + uri + ":\n" + entity);
 
         InputStream schemaStream = getClass().getResourceAsStream("teiid-schema.json");
@@ -188,11 +205,13 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
         URI uri = baseBuilder.clone()
                                          .queryParam(KomodoService.QueryParamKeys.KTYPE, KomodoType.MODEL)
                                          .build();
-        this.response = request(uri).get();
-        assertTrue(response.hasEntity());
 
-        String entity = response.readEntity(String.class);
-        //System.out.println("Response from uri " + uri + ":\n" + entity);
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        ClientResponse<String> response = request.get(String.class);
+        assertNotNull(response.getEntity());
+
+        String entity = response.getEntity();
+        System.out.println("Response from uri " + uri + ":\n" + entity);
 
         assertFalse(entity.contains("\"schema-1\" : {"));
         assertFalse(entity.contains("\"keng__id\" : \"vdb\""));
@@ -213,10 +232,13 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
         uri = baseBuilder.clone()
                                   .queryParam(KomodoService.QueryParamKeys.KTYPE, KomodoType.VDB_DATA_ROLE)
                                   .build();
-        this.response = request(uri).get();
-        assertTrue(response.hasEntity());
 
-        entity = response.readEntity(String.class);
+        request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        response = request.get(String.class);
+        assertNotNull(response.getEntity());
+
+        entity = response.getEntity();
+
         //System.out.println("Response from uri " + uri + ":\n" + entity);
 
         assertFalse(entity.contains("\"schema-1\" : {"));
@@ -238,10 +260,12 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
         uri = baseBuilder.clone().
                                    queryParam(KomodoService.QueryParamKeys.KTYPE, KomodoType.VDB_MASK)
                                    .build();
-        this.response = request(uri).get();
-        assertTrue(response.hasEntity());
 
-        entity = response.readEntity(String.class);
+        request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        response = request.get(String.class);
+        assertNotNull(response.getEntity());
+
+        entity = response.getEntity();
         //System.out.println("Response from uri " + uri + ":\n" + entity);
 
         assertFalse(entity.contains("\"schema-1\" : {"));
@@ -263,10 +287,13 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
         uri = baseBuilder.clone().
                                    queryParam(KomodoService.QueryParamKeys.KTYPE, KomodoType.DATASOURCE)
                                    .build();
-        this.response = request(uri).get();
-        assertTrue(response.hasEntity());
 
-        entity = response.readEntity(String.class);
+        request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        response = request.get(String.class);
+        assertNotNull(response.getEntity());
+
+        entity = response.getEntity();
 //        System.out.println("Response from uri " + uri + ":\n" + entity);
 
         assertFalse(entity.contains("\"schema-1\" : {"));


### PR DESCRIPTION
* To avoid having to upgrade the jboss server's resteasy version and to
  stay compatible with teiid-odata, this rolls back the client/jaxrs
  version of resteasy to 2.3.10.Final

* This version is imported directly from the integration-platform-parent
  so compatible with DV6.3

* ServerErrorException replaced with WebApplicationException

* CorsFilter replaced with custom CorsInterceptor (filters not provided in
  RestEasy 2.x)

* Due to now filters, there is no pre-processing so CorsInterceptor does
  not step in and rectify preflight OPTIONS requests as the CorsFilter
  would in 3.0.11

* So OPTIONS requests get thrown as DefaultOptionsMethodException and by
  default return a 500 response. To workaround OptionsExceptionMapper
  steps in and maps the exception, fixing the response to ensure the
  response is ok. Without this Angular cannot do any POST/... requests

* GET @Consumes annotations removed since GET requests have no body so
  do not need to consume anyway but requests seem to fail without the
  Content-Type header set.

* Undertow migrated to TJWSEmbeddedJaxrsServer

* Testing Client class migrated to ClientRequest