### PR TITLE
Implements ping functionality as a REST operation

### DIFF
--- a/komodo-spi/src/main/java/org/komodo/spi/query/TeiidService.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/query/TeiidService.java
@@ -78,9 +78,12 @@ public interface TeiidService extends BundleService {
     TeiidInstance getTeiidInstance(TeiidParent teiidParent, TeiidJdbcInfo jdbcInfo) throws Exception;
 
     /**
+     * @param host the host
+     * @param port the port
      * @param user jdbc username
      * @param passwd jdbc password
+     * @param isSecure is connection secure
      * @return the query service for the version of teiid
      */
-    QueryService getQueryService(String user, String passwd) throws Exception;
+    QueryService getQueryService(String host, int port, String user, String passwd, boolean isSecure) throws Exception;
 }

--- a/komodo-spi/src/main/java/org/komodo/spi/runtime/ExecutionAdmin.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/runtime/ExecutionAdmin.java
@@ -28,17 +28,23 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.outcome.Outcome;
 
 /**
  *
  */
-public interface ExecutionAdmin {
+public interface ExecutionAdmin extends StringConstants {
 
     /**
      * VDB name for the ping test
      */
-    String PING_VDB = "ping-vdb.xml"; //$NON-NLS-1$
+    String PING_VDB_NAME = "ping"; //$NON-NLS-1$
+
+    /**
+     * VDB file name for the ping test
+     */
+    String PING_VDB = PING_VDB_NAME + VDB_DEPLOYMENT_SUFFIX;
 
     /**
      * Type of connectivity
@@ -53,6 +59,22 @@ public interface ExecutionAdmin {
          * JDBC connection of the teiid instance
          */
         JDBC;
+
+        /**
+         * @param type
+         * @return the {@link ConnectivityType} for the given type
+         */
+        public static ConnectivityType findType(String type) {
+            if (type == null)
+                return null;
+
+            for (ConnectivityType cType : ConnectivityType.values()) {
+                if (type.equalsIgnoreCase(cType.name()))
+                    return cType;
+            }
+
+            return null;
+        }
     }
     
     /**

--- a/komodo-spi/src/main/resources/org/komodo/spi/messages.properties
+++ b/komodo-spi/src/main/resources/org/komodo/spi/messages.properties
@@ -7,4 +7,4 @@ SPI.invalidTargetTypeForGetTranslatorMethod = Invalid target type {0} for execut
 SPI.invalidTargetTypeForGetUpdatedTeiidMethod = Invalid target type {0} for execution event. Method getUpdatedServer() expected type {1}.
 
 
-OutcomeFactory.OK = OK;
+OutcomeFactory.OK = OK

--- a/plugins/komodo-plugin-framework/src/main/java/org/komodo/plugin/framework/teiid/AbstractConnectionManager.java
+++ b/plugins/komodo-plugin-framework/src/main/java/org/komodo/plugin/framework/teiid/AbstractConnectionManager.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.plugin.framework.teiid;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import org.komodo.spi.KException;
+import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.runtime.TeiidConnectionInfo;
+
+public abstract class AbstractConnectionManager implements StringConstants {
+
+    /**
+     * @return the implementation of the TeiidDriver
+     */
+    protected abstract Driver getTeiidDriver();
+
+    /**
+     * @param vdb the target vdb
+     * @param user the user
+     * @param password the password
+     * @param host the host
+     * @param port the port
+     * @param secure should connection be secure
+     *
+     * @return a new connection to the vdb
+     * @throws Exception if error occurs
+     */
+    public abstract Connection getConnection(String vdb, String host, int port,
+                                                                                     String user, String password,
+                                                                                     boolean secure) throws Exception;
+
+    /**
+     * @param vdb
+     * @param host
+     * @param port
+     * @param user
+     * @param password
+     * @param secure
+     * @return an SQL connection using the TeiidDriver
+     * @throws Exception
+     */
+    public Connection getTeiidDriverConnection(String vdb, String host, int port,
+                                                                                       String user, String password, boolean secure) throws Exception {
+            String protocol = TeiidConnectionInfo.MM;
+            if (secure)
+                protocol = TeiidConnectionInfo.MMS;
+        
+            String url = "jdbc:teiid:" + vdb + AMPERSAND + protocol + host + COLON + port; //$NONNLS1$
+        
+            try {
+                String urlAndCredentials = url + ";user=" + user + ";password=" + password + SEMI_COLON; //$NONNLS1$ //$NONNLS2$
+                return getTeiidDriver().connect(urlAndCredentials, null);
+        
+            } catch (Exception ex) {
+                throw new KException(ex);
+            }
+        }
+
+    public AbstractConnectionManager() {
+        super();
+    }
+
+}

--- a/plugins/komodo-plugin-framework/src/main/java/org/komodo/plugin/framework/teiid/AbstractQueryService.java
+++ b/plugins/komodo-plugin-framework/src/main/java/org/komodo/plugin/framework/teiid/AbstractQueryService.java
@@ -42,10 +42,20 @@ public abstract class AbstractQueryService implements QueryService {
 
     private final String password;
 
-    public AbstractQueryService(DataTypeManager dataTypeManager, String user, String password) {
+    private final String host;
+
+    private final int port;
+
+    private final boolean secure;
+
+    public AbstractQueryService(DataTypeManager dataTypeManager,
+                                                            String host, int port, String user, String password, boolean isSecure) {
         this.dataTypeManager = dataTypeManager;
+        this.host = host;
+        this.port = port;
         this.user = user;
         this.password = password;
+        this.secure = isSecure;
     }
 
     @Override
@@ -60,7 +70,7 @@ public abstract class AbstractQueryService implements QueryService {
 
         try {
             KLog.getLogger().debug("Initialising SQL connection for vdb {0}", vdb);
-            connection = getConnection(vdb, user, password);
+            connection = getConnection(vdb, host, port, user, password, secure);
             if (connection == null)
                 throw new Exception("Failed to make a connection to '" + vdb + "' as user '" + user + "'");
 
@@ -125,5 +135,6 @@ public abstract class AbstractQueryService implements QueryService {
         }
     }
 
-    protected abstract Connection getConnection(String vdb, String user, String password) throws Exception;
+    protected abstract Connection getConnection(String vdb, String host, int port, String user,
+                                                                                            String password, boolean secure) throws Exception;
 }

--- a/plugins/komodo-plugin-service/src/main/java/org/komodo/osgi/teiid/TeiidProxyService.java
+++ b/plugins/komodo-plugin-service/src/main/java/org/komodo/osgi/teiid/TeiidProxyService.java
@@ -108,7 +108,7 @@ public class TeiidProxyService extends AbstractProxyService<TeiidService, TeiidI
     }
 
     @Override
-    public QueryService getQueryService(String user, String passwd) throws Exception {
-        return getDelegate().getQueryService(user, passwd);
+    public QueryService getQueryService(String host, int port, String user, String passwd, boolean isSecure) throws Exception {
+        return getDelegate().getQueryService(host, port, user, passwd, isSecure);
     }
 }

--- a/plugins/teiid-8.11/pom.xml
+++ b/plugins/teiid-8.11/pom.xml
@@ -16,7 +16,6 @@
 		<version.teiid>8.11.5</version.teiid>
 		<version.aesh>0.33.12.redhat-1</version.aesh>
 
-		<!-- The actual maven version of jboss to be downloaded -->
 		<version.org.jboss.dmr>1.2.1.Final-redhat-1</version.org.jboss.dmr>
 	</properties>
 
@@ -66,6 +65,13 @@
 				<groupId>org.jboss.as</groupId>
 				<artifactId>jboss-as-controller-client</artifactId>
 				<version>${version.org.jboss.as}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>org.osgi.core</artifactId>
+				<version>${version.apache.felix}</version>
+				<scope>provided</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/plugins/teiid-8.11/src/main/java/org/komodo/teiid/ConnectionManager.java
+++ b/plugins/teiid-8.11/src/main/java/org/komodo/teiid/ConnectionManager.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.teiid;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import org.komodo.plugin.framework.teiid.AbstractConnectionManager;
+import org.komodo.spi.KException;
+import org.komodo.spi.constants.StringConstants;
+import org.teiid.jdbc.TeiidDataSource;
+import org.teiid.jdbc.TeiidDriver;
+
+public class ConnectionManager extends AbstractConnectionManager implements StringConstants {
+
+    private static ConnectionManager instance;
+
+    public static ConnectionManager getInstance() {
+        if (instance == null)
+            instance = new ConnectionManager();
+
+        return instance;
+    }
+
+    @Override
+    public Connection getConnection(String vdb, String host, int port,
+                                                                    String user, String password,
+                                                                    boolean secure) throws Exception {
+        TeiidDataSource ds = new TeiidDataSource();
+        ds.setDatabaseName(vdb);
+        ds.setUser(user);
+        ds.setPassword(password);
+        ds.setServerName(host);
+        ds.setPortNumber(port);
+        ds.setSecure(secure);
+
+        //
+        // Ensure any runtime exceptions are always caught and thrown as KExceptions
+        //
+        try {
+            return ds.getConnection();
+        } catch (Throwable t) {
+            throw new KException(t);
+        }
+    }
+
+    @Override
+    protected Driver getTeiidDriver() {
+        return TeiidDriver.getInstance();
+    }
+}

--- a/plugins/teiid-8.11/src/main/java/org/komodo/teiid/QueryServiceImpl.java
+++ b/plugins/teiid-8.11/src/main/java/org/komodo/teiid/QueryServiceImpl.java
@@ -23,34 +23,20 @@ package org.komodo.teiid;
 
 import java.sql.Connection;
 import org.komodo.plugin.framework.teiid.AbstractQueryService;
-import org.komodo.spi.KException;
-import org.komodo.spi.runtime.TeiidInstance;
-import org.komodo.spi.runtime.TeiidJdbcInfo;
 import org.komodo.spi.type.DataTypeManager;
-import org.teiid.jdbc.TeiidDataSource;
 
 public class QueryServiceImpl extends AbstractQueryService {
 
-    public QueryServiceImpl(DataTypeManager dataTypeManager, String user, String password) {
-        super(dataTypeManager, user, password);
+    public QueryServiceImpl(DataTypeManager dataTypeManager,
+                                                    String host, int port,
+                                                    String user, String password,
+                                                    boolean secure) {
+        super(dataTypeManager,host, port, user, password, secure);
     }
 
     @Override
-    protected Connection getConnection(String vdb, String user, String password) throws Exception {
-        TeiidDataSource ds = new TeiidDataSource();
-        ds.setDatabaseName(vdb);
-        ds.setUser(user);
-        ds.setPassword(password);
-        ds.setServerName(TeiidInstance.DEFAULT_HOST);
-        ds.setPortNumber(TeiidJdbcInfo.DEFAULT_PORT);
-
-        //
-        // Ensure any runtime exceptions are always caught and thrown as KExceptions
-        //
-        try {
-            return ds.getConnection();
-        } catch (Throwable t) {
-            throw new KException(t);
-        }
+    protected Connection getConnection(String vdb, String host, int port,
+                                                                           String user, String password, boolean secure) throws Exception {
+        return ConnectionManager.getInstance().getConnection(vdb, host, port, user, password, secure);
     }
 }

--- a/plugins/teiid-8.11/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
+++ b/plugins/teiid-8.11/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
@@ -73,8 +73,8 @@ public class TeiidServiceImpl extends AbstractTeiidService {
     }
 
     @Override
-    public QueryService getQueryService(String user, String passwd) throws Exception {
-        return new QueryServiceImpl(getDataTypeManager(), user, passwd);
+    public QueryService getQueryService(String host, int port, String user, String passwd, boolean secure) throws Exception {
+        return new QueryServiceImpl(getDataTypeManager(), host, port, user, passwd, secure);
     }
 
     @Override

--- a/plugins/teiid-8.12/src/main/java/org/komodo/teiid/ConnectionManager.java
+++ b/plugins/teiid-8.12/src/main/java/org/komodo/teiid/ConnectionManager.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.teiid;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import org.komodo.plugin.framework.teiid.AbstractConnectionManager;
+import org.komodo.spi.KException;
+import org.komodo.spi.constants.StringConstants;
+import org.teiid.jdbc.TeiidDataSource;
+import org.teiid.jdbc.TeiidDriver;
+
+public class ConnectionManager extends AbstractConnectionManager implements StringConstants {
+
+    private static ConnectionManager instance;
+
+    public static ConnectionManager getInstance() {
+        if (instance == null)
+            instance = new ConnectionManager();
+
+        return instance;
+    }
+
+    @Override
+    public Connection getConnection(String vdb, String host, int port,
+                                                                    String user, String password,
+                                                                    boolean secure) throws Exception {
+        TeiidDataSource ds = new TeiidDataSource();
+        ds.setDatabaseName(vdb);
+        ds.setUser(user);
+        ds.setPassword(password);
+        ds.setServerName(host);
+        ds.setPortNumber(port);
+        ds.setSecure(secure);
+
+        //
+        // Ensure any runtime exceptions are always caught and thrown as KExceptions
+        //
+        try {
+            return ds.getConnection();
+        } catch (Throwable t) {
+            throw new KException(t);
+        }
+    }
+
+    @Override
+    protected Driver getTeiidDriver() {
+        return TeiidDriver.getInstance();
+    }
+}

--- a/plugins/teiid-8.12/src/main/java/org/komodo/teiid/QueryServiceImpl.java
+++ b/plugins/teiid-8.12/src/main/java/org/komodo/teiid/QueryServiceImpl.java
@@ -23,34 +23,20 @@ package org.komodo.teiid;
 
 import java.sql.Connection;
 import org.komodo.plugin.framework.teiid.AbstractQueryService;
-import org.komodo.spi.KException;
-import org.komodo.spi.runtime.TeiidInstance;
-import org.komodo.spi.runtime.TeiidJdbcInfo;
 import org.komodo.spi.type.DataTypeManager;
-import org.teiid.jdbc.TeiidDataSource;
 
 public class QueryServiceImpl extends AbstractQueryService {
 
-    public QueryServiceImpl(DataTypeManager dataTypeManager, String user, String password) {
-        super(dataTypeManager, user, password);
+    public QueryServiceImpl(DataTypeManager dataTypeManager,
+                                                    String host, int port,
+                                                    String user, String password,
+                                                    boolean secure) {
+        super(dataTypeManager,host, port, user, password, secure);
     }
 
     @Override
-    protected Connection getConnection(String vdb, String user, String password) throws Exception {
-        TeiidDataSource ds = new TeiidDataSource();
-        ds.setDatabaseName(vdb);
-        ds.setUser(user);
-        ds.setPassword(password);
-        ds.setServerName(TeiidInstance.DEFAULT_HOST);
-        ds.setPortNumber(TeiidJdbcInfo.DEFAULT_PORT);
-
-        //
-        // Ensure any runtime exceptions are always caught and thrown as KExceptions
-        //
-        try {
-            return ds.getConnection();
-        } catch (Throwable t) {
-            throw new KException(t);
-        }
+    protected Connection getConnection(String vdb, String host, int port,
+                                                                           String user, String password, boolean secure) throws Exception {
+        return ConnectionManager.getInstance().getConnection(vdb, host, port, user, password, secure);
     }
 }

--- a/plugins/teiid-8.12/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
+++ b/plugins/teiid-8.12/src/main/java/org/komodo/teiid/TeiidServiceImpl.java
@@ -73,8 +73,8 @@ public class TeiidServiceImpl extends AbstractTeiidService {
     }
 
     @Override
-    public QueryService getQueryService(String user, String passwd) throws Exception {
-        return new QueryServiceImpl(getDataTypeManager(), user, passwd);
+    public QueryService getQueryService(String host, int port, String user, String passwd, boolean secure) throws Exception {
+        return new QueryServiceImpl(getDataTypeManager(), host, port, user, passwd, secure);
     }
 
     @Override

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -376,6 +376,16 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
          * The teiid segment for running a query against the teiid server
          */
         String QUERY_SEGMENT = "query";
+
+        /**
+         * The teiid segment for running a ping against the teiid server
+         */
+        String PING_SEGMENT = "ping";
+
+        /**
+         * The name of the URI ping type parameter
+         */
+        String PING_TYPE_PARAMETER = "pingType";
     }
 
     private static final int TIMEOUT = 1;

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -473,6 +473,11 @@ public final class RelationalMessages {
         TEIID_SERVICE_QUERY_ERROR,
 
         /**
+         * Error indicating a ping type is missing
+         */
+        TEIID_SERVICE_PING_MISSING_TYPE,
+
+        /**
          * The importexport service lacks at least one storage attribute
          */
         IMPORT_EXPORT_SERVICE_NO_PARAMETERS_ERROR,

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/TeiidAttributesSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/TeiidAttributesSerializer.java
@@ -54,11 +54,17 @@ public final class TeiidAttributesSerializer extends TypeAdapter< KomodoTeiidAtt
                 case KomodoTeiidAttributes.ADMIN_PASSWD_LABEL:
                     teiidAttrs.setAdminPasswd(in.nextString());
                     break;
+                case KomodoTeiidAttributes.ADMIN_SECURE_LABEL:
+                    teiidAttrs.setAdminSecure(in.nextBoolean());
+                    break;
                 case KomodoTeiidAttributes.JDBC_USER_LABEL:
                     teiidAttrs.setJdbcUser(in.nextString());
                     break;
                 case KomodoTeiidAttributes.JDBC_PASSWD_LABEL:
                     teiidAttrs.setJdbcPasswd(in.nextString());
+                    break;
+                case KomodoTeiidAttributes.JDBC_SECURE_LABEL:
+                    teiidAttrs.setJdbcSecure(in.nextBoolean());
                     break;
                 default:
                     throw new IOException( Messages.getString( UNEXPECTED_JSON_TOKEN, name ) );
@@ -87,11 +93,23 @@ public final class TeiidAttributesSerializer extends TypeAdapter< KomodoTeiidAtt
         out.name(KomodoTeiidAttributes.ADMIN_PASSWD_LABEL);
         out.value(value.getAdminPasswd());
 
+        Boolean adminSecure = value.isAdminSecure();
+        if (adminSecure != null) {
+            out.name(KomodoTeiidAttributes.ADMIN_SECURE_LABEL);
+            out.value(adminSecure);
+        }
+
         out.name(KomodoTeiidAttributes.JDBC_USER_LABEL);
         out.value(value.getJdbcUser());
 
         out.name(KomodoTeiidAttributes.JDBC_PASSWD_LABEL);
         out.value(value.getJdbcPasswd());
+
+        Boolean jdbcSecure = value.isJdbcSecure();
+        if (jdbcSecure != null) {
+            out.name(KomodoTeiidAttributes.JDBC_SECURE_LABEL);
+            out.value(jdbcSecure);
+        }
 
         out.endObject();
     }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoTeiidAttributes.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoTeiidAttributes.java
@@ -46,6 +46,11 @@ public class KomodoTeiidAttributes implements KRestEntity {
     public static final String ADMIN_PASSWD_LABEL = "adminPasswd"; //$NON-NLS-1$
 
     /**
+     * Label for the admin secure flag
+     */
+    public static final String ADMIN_SECURE_LABEL = "adminSecure"; //$NON-NLS-1$
+
+    /**
      * Label for the jdbc user name
      */
     public static final String JDBC_USER_LABEL = "jdbcUser"; //$NON-NLS-1$
@@ -55,17 +60,28 @@ public class KomodoTeiidAttributes implements KRestEntity {
      */
     public static final String JDBC_PASSWD_LABEL = "jdbcPasswd"; //$NON-NLS-1$
 
+    /**
+     * Label for the jdbc secure flag
+     */
+    public static final String JDBC_SECURE_LABEL = "jdbcSecure"; //$NON-NLS-1$
+
     @JsonProperty(ADMIN_USER_LABEL)
     private String adminUser;
 
     @JsonProperty(ADMIN_PASSWD_LABEL)
     private String adminPasswd;
 
+    @JsonProperty(ADMIN_SECURE_LABEL)
+    private Boolean adminSecure;
+
     @JsonProperty(JDBC_USER_LABEL)
     private String jdbcUser;
 
     @JsonProperty(JDBC_PASSWD_LABEL)
     private String jdbcPasswd;
+
+    @JsonProperty(JDBC_SECURE_LABEL)
+    private Boolean jdbcSecure;
 
     /**
      * Default constructor for deserialization
@@ -115,6 +131,20 @@ public class KomodoTeiidAttributes implements KRestEntity {
     }
 
     /**
+     * @return admin secure
+     */
+    public Boolean isAdminSecure() {
+        return adminSecure;
+    }
+
+    /**
+     * @param adminSecure
+     */
+    public void setAdminSecure(boolean adminSecure) {
+        this.adminSecure = adminSecure;
+    }
+
+    /**
      * @return jdbc user
      */
     public String getJdbcUser() {
@@ -142,13 +172,29 @@ public class KomodoTeiidAttributes implements KRestEntity {
         this.jdbcPasswd = jdbcPasswd;
     }
 
+    /**
+     * @return jdbc secure
+     */
+    public Boolean isJdbcSecure() {
+        return jdbcSecure;
+    }
+
+    /**
+     * @param jdbcSecure
+     */
+    public void setJdbcSecure(boolean jdbcSecure) {
+        this.jdbcSecure = jdbcSecure;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((adminPasswd == null) ? 0 : adminPasswd.hashCode());
+        result = prime * result + (adminSecure ? 1231 : 1237);
         result = prime * result + ((adminUser == null) ? 0 : adminUser.hashCode());
         result = prime * result + ((jdbcPasswd == null) ? 0 : jdbcPasswd.hashCode());
+        result = prime * result + (jdbcSecure ? 1231 : 1237);
         result = prime * result + ((jdbcUser == null) ? 0 : jdbcUser.hashCode());
         return result;
     }
@@ -167,6 +213,8 @@ public class KomodoTeiidAttributes implements KRestEntity {
                 return false;
         } else if (!adminPasswd.equals(other.adminPasswd))
             return false;
+        if (adminSecure != other.adminSecure)
+            return false;
         if (adminUser == null) {
             if (other.adminUser != null)
                 return false;
@@ -176,6 +224,8 @@ public class KomodoTeiidAttributes implements KRestEntity {
             if (other.jdbcPasswd != null)
                 return false;
         } else if (!jdbcPasswd.equals(other.jdbcPasswd))
+            return false;
+        if (jdbcSecure != other.jdbcSecure)
             return false;
         if (jdbcUser == null) {
             if (other.jdbcUser != null)
@@ -187,7 +237,7 @@ public class KomodoTeiidAttributes implements KRestEntity {
 
     @Override
     public String toString() {
-        return "KomodoTeiidAttributes [adminUser=" + adminUser + ", adminPasswd=" + adminPasswd + ", jdbcUser=" + jdbcUser
-               + ", jdbcPasswd=" + jdbcPasswd + "]";
+        return "KomodoTeiidAttributes [adminUser=" + adminUser + ", adminPasswd=" + adminPasswd + ", adminSecure=" + adminSecure
+               + ", jdbcUser=" + jdbcUser + ", jdbcPasswd=" + jdbcPasswd + ", jdbcSecure=" + jdbcSecure + "]";
     }
 }

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -109,6 +109,7 @@ Error.TEIID_SERVICE_QUERY_MISSING_QUERY = No query has been specified
 Error.TEIID_SERVICE_QUERY_MISSING_TARGET = No target has been specified
 Error.TEIID_SERVICE_QUERY_TARGET_NOT_DEPLOYED = The target of the query has not yet been deployed
 Error.TEIID_SERVICE_QUERY_ERROR = An error occurred dealing with the executing a teiid query: %s
+Error.TEIID_SERVICE_PING_MISSING_TYPE = The ping type of 'admin' or 'jdbc' is required
 
 Error.IMPORT_EXPORT_SERVICE_NO_PARAMETERS_ERROR = The import export service requires at least one parameter
 Error.IMPORT_EXPORT_SERVICE_UNSUPPORTED_TYPE_ERROR = The storage type requested from the import export service is unsupported


### PR DESCRIPTION
* TeiidImpl
 * Fixes mistake in getting the wrong port for JDBC

* AbstractQueryService
* QueryServiceImpl
 * Extend parameters of service constructor to include host, port and
   secure flag
 * Delegate connection implementations to a ConnectionManager

* AbstractTeiidInstance
* TeiidInstanceImpl
 * Push pingJdbc() into abstract class
 * Fixes mistake in getUrl(). Should be jdbc url not the admin url
 * Corrects ping() to break in switch statement

* AbstractConnectionManager
* ConnectionManager
 * Provides 2 different methods of retrieving an SQL Connection for Teiid

* KomodoTeiidAttributes
* TeiidAttributesSerializer
 * Add secure flag attributes for both admin and jdbc connections