### PR TITLE
Dataservice methods added for odata work

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/Dataservice.java
@@ -133,6 +133,9 @@ public interface Dataservice extends Exportable, RelationalObject {
     };
 
     /**
+     * @param transaction
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @return the value of the <code>description</code> property (can be empty)
      * @throws KException
      *         if an error occurs
@@ -164,7 +167,7 @@ public interface Dataservice extends Exportable, RelationalObject {
                    final String... namePatterns ) throws KException;
 
     /**
-     * @param uow
+     * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @param vdbName
@@ -186,7 +189,7 @@ public interface Dataservice extends Exportable, RelationalObject {
      * Convenience method for adding a Vdb and setting the service vdb name to
      * the newly added Vdb's name
      *
-     * @param uow
+     * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @param vdbName
@@ -233,6 +236,15 @@ public interface Dataservice extends Exportable, RelationalObject {
      * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @return the version of the dataservice vdb
+     * @throws KException if an error occurs
+     */
+    int getServiceVdbVersion(UnitOfWork uow) throws KException;
+    
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @return the service VDB (may be <code>null</code> if not defined)
      * @throws KException
      *         if an error occurs
@@ -240,7 +252,7 @@ public interface Dataservice extends Exportable, RelationalObject {
     Vdb getServiceVdb( final UnitOfWork uow ) throws KException;
 
     /**
-     * @param transaction
+     * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
      * @param vdbName
      *        the new value of the <code>service vdb name</code> property
@@ -249,6 +261,24 @@ public interface Dataservice extends Exportable, RelationalObject {
      */
     void setServiceVdbName(UnitOfWork uow, String vdbName) throws KException;
 
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @return the name of the dataservice view (may be <code>null</code> if not found)
+     * @throws KException if an error occurs
+     */
+    String getServiceViewName(UnitOfWork uow) throws KException;
+    
+    /**
+     * @param uow
+     *        the transaction (cannot be <code>null</code> or have a state that is not
+     *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+     * @return the name of the dataservice view model (may be <code>null</code> if not found)
+     * @throws KException if an error occurs
+     */
+    String getServiceViewModelName(UnitOfWork uow) throws KException;
+    
     /**
      * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not
@@ -293,6 +323,8 @@ public interface Dataservice extends Exportable, RelationalObject {
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @param driverName
      *        the name of the driver being created (cannot be empty)
+     * @param content 
+     *        the driver content
      * @return the Driver (never <code>null</code>)
      * @throws KException
      *         if an error occurs
@@ -300,7 +332,7 @@ public interface Dataservice extends Exportable, RelationalObject {
     Driver addDriver( final UnitOfWork uow, final String driverName, final byte[] content) throws KException;
 
     /**
-     * @param transaction
+     * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @return the deployment plan for the drivers

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceConveyor.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceConveyor.java
@@ -539,6 +539,13 @@ public class DataserviceConveyor implements StringConstants {
             // Deploy the vdbs
             //
             String[] vdbPlan = dataservice.getVdbPlan(transaction);
+            
+            // If no VDBs, return with an error
+            if(vdbPlan.length==0) {
+                status.addErrorMessage("The dataservice contains no VDBs");
+                return status;
+            }
+            
             for (String vdbName : vdbPlan) {
                 status.addProgressMessage("Starting deployment of vdb " + vdbName);
 

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceImpl.java
@@ -34,6 +34,9 @@ import org.komodo.relational.datasource.internal.DatasourceImpl;
 import org.komodo.relational.driver.Driver;
 import org.komodo.relational.driver.internal.DriverImpl;
 import org.komodo.relational.internal.RelationalObjectImpl;
+import org.komodo.relational.model.Model;
+import org.komodo.relational.model.Model.Type;
+import org.komodo.relational.model.View;
 import org.komodo.relational.teiid.Teiid;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.vdb.internal.VdbImpl;
@@ -396,7 +399,7 @@ public class DataserviceImpl extends RelationalObjectImpl implements Dataservice
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.relational.vdb.Vdb#getServiceVdbName(org.komodo.spi.repository.Repository.UnitOfWork)
+     * @see org.komodo.relational.dataservice.Dataservice#getServiceVdbName(org.komodo.spi.repository.Repository.UnitOfWork)
      */
     @Override
     public String getServiceVdbName(final UnitOfWork uow) throws KException {
@@ -406,7 +409,7 @@ public class DataserviceImpl extends RelationalObjectImpl implements Dataservice
     /**
      * {@inheritDoc}
      *
-     * @see org.komodo.relational.vdb.Vdb#setServiceVdbName(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
+     * @see org.komodo.relational.dataservice.Dataservice#setServiceVdbName(org.komodo.spi.repository.Repository.UnitOfWork, java.lang.String)
      */
     @Override
     public void setServiceVdbName(final UnitOfWork uow, final String vdbName) throws KException {
@@ -478,5 +481,61 @@ public class DataserviceImpl extends RelationalObjectImpl implements Dataservice
     public DeployStatus deploy(UnitOfWork uow, Teiid teiid) {
         DataserviceConveyor conveyor = new DataserviceConveyor(getRepository());
         return conveyor.deploy(uow, this, teiid);
+    }
+
+    /* (non-Javadoc)
+     * @see org.komodo.relational.dataservice.Dataservice#getDataserviceView(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getServiceViewName(UnitOfWork uow) throws KException {
+        String viewName = null;
+        // Only ONE virtual model should exist in the dataservice vdb.
+        // The returned view name is the first view in the first virtual model found - or null if none found.
+        Vdb serviceVdb = getServiceVdb(uow);
+        if( serviceVdb != null ) {
+            Model[] models = serviceVdb.getModels(uow);
+            for(Model model : models) {
+                Model.Type modelType = model.getModelType(uow);
+                if(modelType == Type.VIRTUAL) {
+                    View[] views = model.getViews(uow);
+                    for(View view : views) {
+                        viewName = view.getName(uow);
+                        break;
+                    }
+                }
+            }
+        }
+        return viewName;
+    }
+
+    /* (non-Javadoc)
+     * @see org.komodo.relational.dataservice.Dataservice#getDataserviceViewModel(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public String getServiceViewModelName(UnitOfWork uow) throws KException {
+        String viewModelName = null;
+        // Only ONE virtual model should exist in the dataservice vdb.
+        // The returned view model is the first virtual model found - or null if none found.
+        Vdb serviceVdb = getServiceVdb(uow);
+        if( serviceVdb != null ) {
+            Model[] models = serviceVdb.getModels(uow);
+            for(Model model : models) {
+                Model.Type modelType = model.getModelType(uow);
+                if(modelType == Type.VIRTUAL) {
+                    viewModelName = model.getName(uow);
+                    break;
+                }
+            }
+        }
+        return viewModelName;
+    }
+
+    /* (non-Javadoc)
+     * @see org.komodo.relational.dataservice.Dataservice#getDataserviceVdbVersion(org.komodo.spi.repository.Repository.UnitOfWork)
+     */
+    @Override
+    public int getServiceVdbVersion(UnitOfWork uow) throws KException {
+        Vdb serviceVdb = getServiceVdb(uow);
+        return serviceVdb != null ? serviceVdb.getVersion(uow) : 1;
     }
 }

--- a/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/dataservice/internal/DataserviceImplTest.java
@@ -50,6 +50,7 @@ import org.komodo.relational.dataservice.DataserviceManifest;
 import org.komodo.relational.driver.Driver;
 import org.komodo.relational.importer.dsource.DatasourceImporter;
 import org.komodo.relational.importer.vdb.VdbImporter;
+import org.komodo.relational.model.Model;
 import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.spi.repository.KomodoObject;
@@ -213,6 +214,59 @@ public final class DataserviceImplTest extends RelationalModelTest {
         assertThat( this.dataservice.hasChild( getTransaction(), SERVICE_NAME, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( true ) );
         assertThat( this.dataservice.getChild( getTransaction(), SERVICE_NAME ), is( serviceVDB ) );
         assertThat( this.dataservice.getChild( getTransaction(), SERVICE_NAME, VdbLexicon.Vdb.VIRTUAL_DATABASE ), is( serviceVDB ) );
+    }
+
+    @Test
+    public void shouldGetServiceVdbNameAndVersion() throws Exception {
+        // Add child VDB
+        final String name = "childVdb";
+        this.dataservice.addVdb(getTransaction(), name, "externalPath");
+        
+        // Add service VDB (same name as dataservice node)
+        final Vdb serviceVDB = this.dataservice.addServiceVdb(getTransaction(), "serviceVdbName", "externalPath");
+        serviceVDB.setVersion(getTransaction(), 2);
+        
+        assertThat( serviceVDB, is( notNullValue() ) );
+        assertThat( serviceVDB.getName( getTransaction() ), is( "serviceVdbName" ) );
+        assertThat( serviceVDB.getVersion( getTransaction() ), is( 2 ) );
+        assertThat( this.dataservice.getVdbs( getTransaction() ).length, is( 2 ) );
+        assertThat( this.dataservice.getServiceVdbName( getTransaction() ), is ("serviceVdbName") );
+        assertThat( this.dataservice.getServiceVdbVersion( getTransaction() ), is ( 2 ) );
+        assertThat( this.dataservice.getServiceVdb( getTransaction() )==null, is( false ) );
+    }
+
+    @Test
+    public void shouldGetServiceVdbViewModelAndView() throws Exception {
+        // Add child VDB
+        final String name = "childVdb";
+        this.dataservice.addVdb(getTransaction(), name, "externalPath");
+        
+        // Add service VDB (same name as dataservice node)
+        final String serviceVdbName = "serviceVdbName";
+        final Vdb serviceVDB = this.dataservice.addServiceVdb(getTransaction(), serviceVdbName, "externalPath");
+        serviceVDB.setVersion(getTransaction(), 2);
+        
+        // Add a physical and virtual model to the service VDB
+        Model physModel = serviceVDB.addModel(getTransaction(), "physicalModel");
+        physModel.setModelType(getTransaction(), Model.Type.PHYSICAL);
+        final String serviceViewModel = "serviceViewModel";
+        Model virtualModel = serviceVDB.addModel(getTransaction(), serviceViewModel);
+        virtualModel.setModelType(getTransaction(), Model.Type.VIRTUAL);
+        
+        // Add a view to the virtual model
+        final String serviceView = "serviceView";
+        virtualModel.addView(getTransaction(), serviceView);
+        
+        assertThat( serviceVDB, is( notNullValue() ) );
+        assertThat( serviceVDB.getName( getTransaction() ), is( serviceVdbName ) );
+        assertThat( serviceVDB.getVersion( getTransaction() ), is( 2 ) );
+        assertThat( this.dataservice.getVdbs( getTransaction() ).length, is( 2 ) );
+        assertThat( this.dataservice.getServiceVdbName( getTransaction() ), is ( serviceVdbName ) );
+        assertThat( this.dataservice.getServiceVdbVersion( getTransaction() ), is ( 2 ) );
+        assertThat( this.dataservice.getServiceVdb( getTransaction() )==null, is( false ) );
+
+        assertThat( this.dataservice.getServiceViewModelName( getTransaction() ), is( serviceViewModel ) );
+        assertThat( this.dataservice.getServiceViewName( getTransaction() ), is( serviceView ) );
     }
 
     @Test

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/dataservice/RestDataservice.java
@@ -44,6 +44,27 @@ public final class RestDataservice extends RestBasicEntity {
     public static final String DESCRIPTION_LABEL = KomodoService.encode(KomodoLexicon.LibraryComponent.DESCRIPTION);
 
     /**
+     * Label used to describe dataservice view modelName
+     */
+    public static final String DATASERVICE_VIEW_MODEL_LABEL = "serviceViewModel"; //$NON-NLS-1$
+
+    /**
+     * Label used to describe dataservice viewName
+     */
+    public static final String DATASERVICE_VIEW_LABEL = "serviceView"; //$NON-NLS-1$
+
+    /**
+     * Label used to describe dataservice vdbName
+     */
+    public static final String DATASERVICE_VDB_NAME_LABEL = "serviceVdbName"; //$NON-NLS-1$
+
+    /**
+     * Label used to describe dataservice vdbVersion
+     */
+    public static final String DATASERVICE_VDB_VERSION_LABEL = "serviceVdbVersion"; //$NON-NLS-1$
+
+
+    /**
      * Constructor for use when deserializing
      */
     public RestDataservice() {
@@ -69,7 +90,12 @@ public final class RestDataservice extends RestBasicEntity {
         Properties settings = getUriBuilder().createSettings(SettingNames.DATA_SERVICE_NAME, getId());
         URI parentUri = getUriBuilder().dataserviceParentUri(dataService, uow);
         getUriBuilder().addSetting(settings, SettingNames.DATA_SERVICE_PARENT_PATH, parentUri);
-
+        
+        setServiceVdbName(dataService.getServiceVdbName(uow));
+        setServiceVdbVersion(dataService.getServiceVdbVersion(uow));
+        setServiceViewModel(dataService.getServiceViewModelName(uow));
+        setServiceViewName(dataService.getServiceViewName(uow));
+        
         addLink(new RestLink(LinkType.SELF, getUriBuilder().dataserviceUri(LinkType.SELF, settings)));
         addLink(new RestLink(LinkType.PARENT, getUriBuilder().dataserviceUri(LinkType.PARENT, settings)));
         createChildLink();
@@ -91,5 +117,64 @@ public final class RestDataservice extends RestBasicEntity {
         tuples.put(DESCRIPTION_LABEL, description);
     }
 
+    /**
+     * @return the service view model name (can be empty)
+     */
+    public String getServiceViewModel() {
+        Object modelName = tuples.get(DATASERVICE_VIEW_MODEL_LABEL);
+        return modelName != null ? modelName.toString() : null;
+    }
+
+    /**
+     * @param modelName the view model name to set
+     */
+    public void setServiceViewModel(String modelName) {
+        tuples.put(DATASERVICE_VIEW_MODEL_LABEL, modelName);
+    }
+
+    /**
+     * @return the service view name (can be empty)
+     */
+    public String getServiceViewName() {
+        Object viewName = tuples.get(DATASERVICE_VIEW_LABEL);
+        return viewName != null ? viewName.toString() : null;
+    }
+
+    /**
+     * @param viewName the service view name to set
+     */
+    public void setServiceViewName(String viewName) {
+        tuples.put(DATASERVICE_VIEW_LABEL, viewName);
+    }
+
+    /**
+     * @return the service vdb name (can be empty)
+     */
+    public String getServiceVdbName() {
+        Object serviceVdbName = tuples.get(DATASERVICE_VDB_NAME_LABEL);
+        return serviceVdbName != null ? serviceVdbName.toString() : null;
+    }
+
+    /**
+     * @param serviceVdbName the service vdb name to set 
+     */
+    public void setServiceVdbName(String serviceVdbName) {
+        tuples.put(DATASERVICE_VDB_NAME_LABEL, serviceVdbName);
+    }
+
+    /**
+     * @return the VDB description (can be empty)
+     */
+    public int getServiceVdbVersion() {
+        Object version = tuples.get(DATASERVICE_VDB_VERSION_LABEL);
+        return version != null ? (int)version : 1;
+    }
+
+    /**
+     * @param version the version to set
+     */
+    public void setServiceVdbVersion(int version) {
+        tuples.put(DATASERVICE_VDB_VERSION_LABEL, version);
+    }
 
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
@@ -809,16 +809,18 @@ public class KomodoTeiidService extends KomodoService {
 
             List<String> progressMessages = deployStatus.getProgressMessages();
             for (int i = 0; i < progressMessages.size(); ++i) {
-                status.addAttribute("ProgressMessage-" + (i + 1), progressMessages.get(i));
+                status.addAttribute("ProgressMessage" + (i + 1), progressMessages.get(i));
             }
 
-            if (deployStatus.ok())
+            if (deployStatus.ok()) {
+                status.addAttribute("deploymentSuccess", Boolean.TRUE.toString());
                 status.addAttribute(dataService.getName(uow),
                                     RelationalMessages.getString(RelationalMessages.Info.DATA_SERVICE_SUCCESSFULLY_DEPLOYED));
-            else {
+            } else {
+                status.addAttribute("deploymentSuccess", Boolean.FALSE.toString());
                 List<String> errorMessages = deployStatus.getErrorMessages();
                 for (int i = 0; i < errorMessages.size(); ++i) {
-                    status.addAttribute("ErrorMessage-" + (i + 1), errorMessages.get(i));
+                    status.addAttribute("ErrorMessage" + (i + 1), errorMessages.get(i));
                 }
 
                 status.addAttribute(dataService.getName(uow),

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataserviceTest.java
@@ -48,6 +48,10 @@ public final class RestDataserviceTest {
     private static final String DATASERVICE_DATA_PATH = "/workspace/dataservices/dataservice1";
     private static final KomodoType kType = KomodoType.DATASERVICE;
     private static final String DESCRIPTION = "my description";
+    private static final String SERVICE_VDB_NAME = "serviceVdbName";
+    private static final int SERVICE_VDB_VERSION = 1;
+    private static final String SERVICE_VIEW_MODEL = "serviceViewModel";
+    private static final String SERVICE_VIEW = "serviceView";
 
     private RestDataservice dataservice;
 
@@ -62,6 +66,10 @@ public final class RestDataserviceTest {
         copy.setHasChildren(dataservice.hasChildren());
         copy.setLinks(this.dataservice.getLinks());
         copy.setProperties(this.dataservice.getProperties());
+        copy.setServiceVdbName(this.dataservice.getServiceVdbName());
+        copy.setServiceVdbVersion(this.dataservice.getServiceVdbVersion());
+        copy.setServiceViewModel(this.dataservice.getServiceViewModel());
+        copy.setServiceViewName(this.dataservice.getServiceViewName());
 
         return copy;
     }
@@ -89,6 +97,10 @@ public final class RestDataserviceTest {
         this.dataservice = new RestDataservice(BASE_URI, theDataservice, false, transaction);
         this.dataservice.setId(DATASERVICE_NAME);
         this.dataservice.setDescription(DESCRIPTION);
+        this.dataservice.setServiceVdbName(SERVICE_VDB_NAME);
+        this.dataservice.setServiceVdbVersion(SERVICE_VDB_VERSION);
+        this.dataservice.setServiceViewModel(SERVICE_VIEW_MODEL);
+        this.dataservice.setServiceViewName(SERVICE_VIEW);
     }
 
     @Test
@@ -144,6 +156,34 @@ public final class RestDataserviceTest {
         final String newDescription = "blah";
         this.dataservice.setDescription(newDescription);
         assertEquals(this.dataservice.getDescription(), newDescription);
+    }
+    
+    @Test
+    public void shouldSetServiceVdbName() {
+        final String newServiceVdb = "blah";
+        this.dataservice.setServiceVdbName(newServiceVdb);
+        assertEquals(this.dataservice.getServiceVdbName(), newServiceVdb);
+    }
+    
+    @Test
+    public void shouldSetServiceVdbVersion() {
+        final int newServiceVdbVersion = 2;
+        this.dataservice.setServiceVdbVersion(newServiceVdbVersion);
+        assertEquals(this.dataservice.getServiceVdbVersion(), newServiceVdbVersion);
+    }
+    
+    @Test
+    public void shouldSetServiceViewModel() {
+        final String newServiceViewModel = "blah";
+        this.dataservice.setServiceViewModel(newServiceViewModel);
+        assertEquals(this.dataservice.getServiceViewModel(), newServiceViewModel);
+    }
+    
+    @Test
+    public void shouldSetServiceView() {
+        final String newServiceView = "blah";
+        this.dataservice.setServiceViewName(newServiceView);
+        assertEquals(this.dataservice.getServiceViewName(), newServiceView);
     }
 
 


### PR DESCRIPTION
- Adds methods to Dataservice so that info for building up the odata links can be obtained.  In particular, need the service vdb name and version, and the service view model and view.  The service view model and view method implementations will change as we refine dataservices.