### PR TITLE
TEIIDTOOLS-42 set ddl on service vdb source model

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/model/Table.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/model/Table.java
@@ -26,6 +26,7 @@ import org.komodo.relational.TypeResolver;
 import org.komodo.relational.model.internal.TableImpl;
 import org.komodo.repository.ObjectImpl;
 import org.komodo.spi.KException;
+import org.komodo.spi.repository.Exportable;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.KomodoType;
 import org.komodo.spi.repository.Repository.UnitOfWork;
@@ -35,7 +36,7 @@ import org.teiid.modeshape.sequencer.ddl.TeiidDdlLexicon.CreateTable;
 /**
  * Represents a relational model table.
  */
-public interface Table extends OptionContainer, RelationalObject, SchemaElement {
+public interface Table extends Exportable, OptionContainer, RelationalObject, SchemaElement {
 
     /**
      * The type identifier.

--- a/komodo-relational/src/test/java/org/komodo/relational/model/internal/ModelImplTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/model/internal/ModelImplTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import java.util.Arrays;
+import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
 import org.komodo.relational.RelationalModelTest;
@@ -642,6 +643,20 @@ public final class ModelImplTest extends RelationalModelTest {
         final boolean value = !Model.DEFAULT_VISIBLE;
         this.model.setVisible( getTransaction(), value );
         assertThat( this.model.isVisible( getTransaction() ), is( value ) );
+    }
+
+    @Test
+    public void shouldExportDdl() throws Exception {
+        final int numTables = 5;
+
+        for ( int i = 0; i < numTables; ++i ) {
+            this.model.addTable( getTransaction(), "table" + i );
+        }
+        
+        byte[] bytes = this.model.export(getTransaction(), new Properties());
+        String exportedDdl = new String(bytes);
+        
+        assertThat( exportedDdl.contains("CREATE FOREIGN TABLE table1"), is( true ) );
     }
 
 }

--- a/komodo-relational/src/test/java/org/komodo/relational/model/internal/TableImplTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/model/internal/TableImplTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.mock;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Properties;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
@@ -923,6 +924,26 @@ public final class TableImplTest extends RelationalModelTest {
         final String value = "uuid";
         this.table.setUuid( getTransaction(), value );
         assertThat( this.table.getUuid( getTransaction() ), is( value ) );
+    }
+    
+    @Test
+    public void shouldExportDdl() throws Exception {
+        final Column column1 = this.table.addColumn( getTransaction(), "column1" );
+        column1.setDescription( getTransaction(), "Col1 Description" );
+        column1.setDatatypeName( getTransaction(), "string" );
+        column1.setNameInSource( getTransaction(), "Col1_NIS" );
+        final Column column2 = this.table.addColumn( getTransaction(), "column2" );
+        column2.setDescription( getTransaction(), "Col2 Description" );
+        column2.setDatatypeName( getTransaction(), "string" );
+        column2.setNameInSource( getTransaction(), "Col2_NIS" );
+        
+        byte[] bytes = this.table.export(getTransaction(), new Properties());
+        String exportedDdl = new String(bytes);
+        
+        assertThat( exportedDdl.contains("CREATE FOREIGN TABLE"), is( true ) );
+        assertThat( exportedDdl.contains("myTable"), is( true ) );
+        assertThat( exportedDdl.contains("column1"), is( true ) );
+        assertThat( exportedDdl.contains("column2"), is( true ) );
     }
 
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -577,6 +577,11 @@ public final class KomodoDataserviceService extends KomodoService {
         	Model sourceModel = serviceVdb.addModel(uow, svcModelSourceName);
         	sourceModel.setModelType(uow, Type.PHYSICAL);
 
+            // The source model DDL contains the table DDL only.  This limits the source metadata which is loaded on deployment.
+        	byte[] bytes = sourceTable.export(uow, null);
+        	String tableString = new String(bytes);
+            sourceModel.setModelDefinition(uow, tableString);
+            
         	// Add a ModelSource of same name to the physical model and set its Jndi and translator
         	ModelSource modelSource = sourceModel.addSource(uow, svcModelSourceName);
         	modelSource.setJndiName(uow, svcModelSource.getJndiName(uow));


### PR DESCRIPTION
The service vdb generation in KomodoDataserviceService was modified to set the source model DDL for the single table service case.  The source model DDL is now limited to the selected table - so that on deployment only the required metadata is loaded instead of all tables.

- modified KomodoDataserviceService
- made Table exportable so that a specific table could be exported.
- added unit test for ddl export