### PR TITLE
Adding methods for jdbc connection info

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -267,6 +267,16 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
         String SOURCE_PLACEHOLDER = "{sourceName}"; //$NON-NLS-1$
 
         /**
+         * The name of the URI path segment for the collection of catalogs
+         */
+        String JDBC_CATALOG_SCHEMA_SEGMENT = "JdbcCatalogSchema"; //$NON-NLS-1$
+
+        /**
+         * The name of the URI path segment for the jdbc info
+         */
+        String JDBC_INFO_SEGMENT = "JdbcInfo"; //$NON-NLS-1$
+
+        /**
          * The name of the URI path segment for the collection of tables of a model
          */
         String TABLES_SEGMENT = "Tables"; //$NON-NLS-1$

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -1028,6 +1028,31 @@ public final class RelationalMessages {
         TEIID_SERVICE_UPDATE_DDL_DNE,
         
         /**
+         * An error indicating data source isn not a JDBC source.
+         */
+        TEIID_SERVICE_GET_DATA_SOURCE_NOT_JDBC_ERROR,
+        
+        /**
+         * An error indicating attempt to get source JDBC connection failed.
+         */
+        TEIID_SERVICE_GET_DATA_SOURCE_CONNECTION_ERROR,
+        
+        /**
+         * An error indicating attempt to fetch source JDBC tables failed.
+         */
+        TEIID_SERVICE_GET_DATA_SOURCE_TABLE_FETCH_ERROR,
+        
+        /**
+         * An error indicating attempt to get source tables failed.
+         */
+        TEIID_SERVICE_GET_DATA_SOURCE_TABLES_ERROR,
+
+        /**
+         * An error indicating attempt to get source catalog and schema failed.
+         */
+        TEIID_SERVICE_GET_DATA_SOURCE_CATALOG_SCHEMA_ERROR,
+
+           /**
          * An error indicating update attempt failed
          */
         TEIID_SERVICE_UPDATE_ERROR,

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/datasource/RestDataSourceJdbcInfo.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/datasource/RestDataSourceJdbcInfo.java
@@ -1,0 +1,260 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.datasource;
+
+import javax.ws.rs.core.MediaType;
+import org.komodo.rest.KRestEntity;
+
+/**
+ * A DataSourceJdbcInfo object that can be used by GSON to build a JSON document representation.
+ */
+public class RestDataSourceJdbcInfo implements KRestEntity {
+
+    /**
+     * Label used to describe supports catalogs
+     */
+    public static final String SUPPORTS_CATALOGS_LABEL = "supportsCatalogs";
+
+    /**
+     * Label used to describe supports schemas
+     */
+    public static final String SUPPORTS_SCHEMAS_LABEL = "supportsSchemas";
+    
+    /**
+     * Label used to describe readonly
+     */
+    public static final String READONLY_LABEL = "readonly";
+    
+    /**
+     * Label used to describe product name
+     */
+    public static final String PRODUCT_NAME_LABEL = "productName";
+    
+    /**
+     * Label used to describe product version
+     */
+    public static final String PRODUCT_VERSION_LABEL = "productVersion";
+    
+    /**
+     * Label used to describe driver major version
+     */
+    public static final String DRIVER_MAJOR_VERSION_LABEL = "driverMajorVersion";
+    
+    /**
+     * Label used to describe driver minor version
+     */
+    public static final String DRIVER_MINOR_VERSION_LABEL = "driverMinorVersion";
+    
+    /**
+     * Label used to describe driver name
+     */
+    public static final String DRIVER_NAME_LABEL = "driverName";
+    
+    /**
+     * Label used to describe database url
+     */
+    public static final String DATABASE_URL_LABEL = "databaseUrl";
+    
+    /**
+     * Label used to describe username
+     */
+    public static final String USERNAME_LABEL = "username";
+
+
+    private boolean supportsCatalogs;
+
+    private boolean supportsSchemas;
+
+    private boolean readonly;
+
+    private String productName;
+
+    private String productVersion;
+
+    private int driverMajorVersion;
+
+    private int driverMinorVersion;
+
+    private String driverName;
+
+    private String driverUrl;
+
+    private String username;
+
+    /**
+     * Constructor for use when deserializing
+     */
+    public RestDataSourceJdbcInfo() {
+        super();
+    }
+
+    @Override
+    public Object getXml() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean supports(MediaType mediaType) {
+        return MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+    }
+
+    /**
+     * @return the supportsCatalogs
+     */
+    public boolean isSupportsCatalogs() {
+        return this.supportsCatalogs;
+    }
+
+    /**
+     * @param supportsCatalogs the supportsCatalogs to set
+     */
+    public void setSupportsCatalogs(boolean supportsCatalogs) {
+        this.supportsCatalogs = supportsCatalogs;
+    }
+
+    /**
+     * @return the supportsSchemas
+     */
+    public boolean isSupportsSchemas() {
+        return this.supportsSchemas;
+    }
+
+    /**
+     * @param supportsSchemas the supportsSchemas to set
+     */
+    public void setSupportsSchemas(boolean supportsSchemas) {
+        this.supportsSchemas = supportsSchemas;
+    }
+
+    /**
+     * @return the readonly
+     */
+    public boolean isReadonly() {
+        return this.readonly;
+    }
+
+    /**
+     * @param readonly the readonly to set
+     */
+    public void setReadonly(boolean readonly) {
+        this.readonly = readonly;
+    }
+
+    /**
+     * @return the productName
+     */
+    public String getProductName() {
+        return this.productName;
+    }
+
+    /**
+     * @param productName the productName to set
+     */
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+
+    /**
+     * @return the productVersion
+     */
+    public String getProductVersion() {
+        return this.productVersion;
+    }
+
+    /**
+     * @param productVersion the productVersion to set
+     */
+    public void setProductVersion(String productVersion) {
+        this.productVersion = productVersion;
+    }
+
+    /**
+     * @return the driverMajorVersion
+     */
+    public int getDriverMajorVersion() {
+        return this.driverMajorVersion;
+    }
+
+    /**
+     * @param driverMajorVersion the driverMajorVersion to set
+     */
+    public void setDriverMajorVersion(int driverMajorVersion) {
+        this.driverMajorVersion = driverMajorVersion;
+    }
+
+    /**
+     * @return the driverMinorVersion
+     */
+    public int getDriverMinorVersion() {
+        return this.driverMinorVersion;
+    }
+
+    /**
+     * @param driverMinorVersion the driverMinorVersion to set
+     */
+    public void setDriverMinorVersion(int driverMinorVersion) {
+        this.driverMinorVersion = driverMinorVersion;
+    }
+
+    /**
+     * @return the driverName
+     */
+    public String getDriverName() {
+        return this.driverName;
+    }
+
+    /**
+     * @param driverName the driverName to set
+     */
+    public void setDriverName(String driverName) {
+        this.driverName = driverName;
+    }
+
+    /**
+     * @return the driverUrl
+     */
+    public String getDriverUrl() {
+        return this.driverUrl;
+    }
+
+    /**
+     * @param driverUrl the driverUrl to set
+     */
+    public void setDriverUrl(String driverUrl) {
+        this.driverUrl = driverUrl;
+    }
+
+    /**
+     * @return the username
+     */
+    public String getUsername() {
+        return this.username;
+    }
+
+    /**
+     * @param username the username to set
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataSourceJdbcTableAttributesSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataSourceJdbcTableAttributesSerializer.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.json;
+
+import static org.komodo.rest.Messages.Error.UNEXPECTED_JSON_TOKEN;
+import java.io.IOException;
+import org.komodo.rest.Messages;
+import org.komodo.rest.relational.request.KomodoDataSourceJdbcTableAttributes;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * A GSON serializer/deserializer for {@status KomodoDataSourceJdbcTableAttribute}s.
+ */
+public final class DataSourceJdbcTableAttributesSerializer extends TypeAdapter< KomodoDataSourceJdbcTableAttributes > {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see com.google.gson.TypeAdapter#read(com.google.gson.stream.JsonReader)
+     */
+    @Override
+    public KomodoDataSourceJdbcTableAttributes read( final JsonReader in ) throws IOException {
+        final KomodoDataSourceJdbcTableAttributes updateAttrs = new KomodoDataSourceJdbcTableAttributes();
+        in.beginObject();
+
+        while ( in.hasNext() ) {
+            final String name = in.nextName();
+
+            switch ( name ) {
+                case KomodoDataSourceJdbcTableAttributes.DATA_SOURCE_NAME_LABEL:
+                    updateAttrs.setDataSourceName(in.nextString());
+                    break;
+                case KomodoDataSourceJdbcTableAttributes.CATALOG_FILTER_LABEL:
+                    updateAttrs.setCatalogFilter(in.nextString());
+                    break;
+                case KomodoDataSourceJdbcTableAttributes.SCHEMA_FILTER_LABEL:
+                    updateAttrs.setSchemaFilter(in.nextString());
+                    break;
+                case KomodoDataSourceJdbcTableAttributes.TABLE_FILTER_LABEL:
+                    updateAttrs.setTableFilter(in.nextString());
+                    break;
+                default:
+                    throw new IOException( Messages.getString( UNEXPECTED_JSON_TOKEN, name ) );
+            }
+        }
+
+        in.endObject();
+
+        return updateAttrs;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see com.google.gson.TypeAdapter#write(com.google.gson.stream.JsonWriter, java.lang.Object)
+     */
+    @Override
+    public void write( final JsonWriter out,
+                       final KomodoDataSourceJdbcTableAttributes value ) throws IOException {
+
+        out.beginObject();
+
+        out.name(KomodoDataSourceJdbcTableAttributes.DATA_SOURCE_NAME_LABEL);
+        out.value(value.getDataSourceName());
+
+        out.name(KomodoDataSourceJdbcTableAttributes.CATALOG_FILTER_LABEL);
+        out.value(value.getCatalogFilter());
+
+        out.name(KomodoDataSourceJdbcTableAttributes.SCHEMA_FILTER_LABEL);
+        out.value(value.getSchemaFilter());
+
+        out.name(KomodoDataSourceJdbcTableAttributes.TABLE_FILTER_LABEL);
+        out.value(value.getTableFilter());
+
+        out.endObject();
+    }
+
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/KomodoJsonMarshaller.java
@@ -23,7 +23,6 @@ package org.komodo.rest.relational.json;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.komodo.rest.KRestEntity;
 import org.komodo.rest.RestBasicEntity;
 import org.komodo.rest.RestLink;
@@ -41,6 +40,7 @@ import org.komodo.rest.relational.json.datasource.DSSPropertyPairPropertySeriali
 import org.komodo.rest.relational.json.datasource.DSSPropertySerializer;
 import org.komodo.rest.relational.json.datasource.DSSSerializer;
 import org.komodo.rest.relational.json.datasource.DataSourceSerializer;
+import org.komodo.rest.relational.request.KomodoDataSourceJdbcTableAttributes;
 import org.komodo.rest.relational.request.KomodoDataserviceUpdateAttributes;
 import org.komodo.rest.relational.request.KomodoFileAttributes;
 import org.komodo.rest.relational.request.KomodoPathAttribute;
@@ -76,7 +76,6 @@ import org.komodo.rest.schema.json.TeiidXsdReader;
 import org.komodo.spi.repository.KomodoType;
 import org.komodo.utils.ArgCheck;
 import org.komodo.utils.KLog;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -105,6 +104,7 @@ public final class KomodoJsonMarshaller {
                                                   .registerTypeAdapter(KomodoSearcherAttributes.class, new SearcherAttributesSerializer())
                                                   .registerTypeAdapter(KomodoTeiidAttributes.class, new TeiidAttributesSerializer())
                                                   .registerTypeAdapter(KomodoDataserviceUpdateAttributes.class, new DataserviceUpdateAttributesSerializer())
+                                                  .registerTypeAdapter(KomodoDataSourceJdbcTableAttributes.class, new DataSourceJdbcTableAttributesSerializer())
                                                   .registerTypeAdapter(KomodoVdbUpdateAttributes.class, new VdbUpdateAttributesSerializer())
                                                   .registerTypeAdapter(RestProperty.class, new RestPropertySerializer())
                                                   .registerTypeAdapter(RestVdb.class, new VdbSerializer())

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoDataSourceJdbcTableAttributes.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoDataSourceJdbcTableAttributes.java
@@ -1,0 +1,192 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.request;
+
+import javax.ws.rs.core.MediaType;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import org.komodo.rest.KRestEntity;
+
+
+/**
+ * Object to be serialised by GSON that encapsulates properties for JDBC table request
+ */
+@JsonSerialize(include=Inclusion.NON_NULL)
+public class KomodoDataSourceJdbcTableAttributes implements KRestEntity {
+
+    /**
+     * Label for the DataSource name
+     */
+    public static final String DATA_SOURCE_NAME_LABEL = "dataSourceName"; //$NON-NLS-1$
+
+    /**
+     * Label for the Catalog filter
+     */
+    public static final String CATALOG_FILTER_LABEL = "catalogFilter"; //$NON-NLS-1$
+
+    /**
+     * Label for the Schema filter
+     */
+    public static final String SCHEMA_FILTER_LABEL = "schemaFilter"; //$NON-NLS-1$
+
+    /**
+     * Label for the table filter
+     */
+    public static final String TABLE_FILTER_LABEL = "tableFilter"; //$NON-NLS-1$
+
+    @JsonProperty(DATA_SOURCE_NAME_LABEL)
+    private String dataSourceName;
+
+    @JsonProperty(CATALOG_FILTER_LABEL)
+    private String catalogFilter;
+
+    @JsonProperty(SCHEMA_FILTER_LABEL)
+    private String schemaFilter;
+
+    @JsonProperty(TABLE_FILTER_LABEL)
+    private String tableFilter;
+
+    /**
+     * Default constructor for deserialization
+     */
+    public KomodoDataSourceJdbcTableAttributes() {
+        // do nothing
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean supports(MediaType mediaType) {
+        return MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+    }
+
+    @Override
+    @JsonIgnore
+    public Object getXml() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return dataSourceName
+     */
+    public String getDataSourceName() {
+        return dataSourceName;
+    }
+
+    /**
+     * @param dataSourceName the DataSource name
+     */
+    public void setDataSourceName(String dataSourceName) {
+        this.dataSourceName = dataSourceName;
+    }
+
+    /**
+     * @return catalogFilter
+     */
+    public String getCatalogFilter() {
+        return catalogFilter;
+    }
+
+    /**
+     * @param catalogFilter the catalog filter
+     */
+    public void setCatalogFilter(String catalogFilter) {
+        this.catalogFilter = catalogFilter;
+    }
+
+    /**
+     * @return schemaFilter
+     */
+    public String getSchemaFilter() {
+        return schemaFilter;
+    }
+
+    /**
+     * @param schemaFilter the Schema Filter
+     */
+    public void setSchemaFilter(String schemaFilter) {
+        this.schemaFilter = schemaFilter;
+    }
+
+    /**
+     * @return tableFilter
+     */
+    public String getTableFilter() {
+        return tableFilter;
+    }
+
+    /**
+     * @param tableFilter the Table Filter
+     */
+    public void setTableFilter(String tableFilter) {
+        this.tableFilter = tableFilter;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((dataSourceName == null) ? 0 : dataSourceName.hashCode());
+        result = prime * result + ((catalogFilter == null) ? 0 : catalogFilter.hashCode());
+        result = prime * result + ((schemaFilter == null) ? 0 : schemaFilter.hashCode());
+        result = prime * result + ((tableFilter == null) ? 0 : tableFilter.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        KomodoDataSourceJdbcTableAttributes other = (KomodoDataSourceJdbcTableAttributes)obj;
+        if (dataSourceName == null) {
+            if (other.dataSourceName != null)
+                return false;
+        } else if (!dataSourceName.equals(other.dataSourceName))
+            return false;
+        if (catalogFilter == null) {
+            if (other.catalogFilter != null)
+                return false;
+        } else if (!catalogFilter.equals(other.catalogFilter))
+            return false;
+        if (schemaFilter == null) {
+            if (other.schemaFilter != null)
+                return false;
+        } else if (!schemaFilter.equals(other.schemaFilter))
+            return false;
+        if (tableFilter == null) {
+            if (other.tableFilter != null)
+                return false;
+        } else if (!tableFilter.equals(other.tableFilter))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "KomodoVdbUpdateAttributes [dataSourceName=" + dataSourceName + ", catalogFilter=" + catalogFilter + ", schemaFilter=" + schemaFilter + ", tableFilter=" + tableFilter + "]";
+    }
+}

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestTeiidDataSourceJdbcCatalogSchemaInfo.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestTeiidDataSourceJdbcCatalogSchemaInfo.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.komodo.rest.relational.response;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.ws.rs.core.MediaType;
+import org.komodo.rest.KRestEntity;
+import org.komodo.spi.KException;
+
+/**
+ * A DataSource JDBC Catalog and Schema info object that can be used by GSON to build a JSON document representation.
+ */
+public final class RestTeiidDataSourceJdbcCatalogSchemaInfo implements KRestEntity {
+
+    /**
+     * Type identifier for Catalogs
+     */
+    public static final String TYPE_CATALOG = "Catalog"; //$NON-NLS-1$
+
+    /**
+     * Type identifier for Schema
+     */
+    public static final String TYPE_SCHEMA = "Schema"; //$NON-NLS-1$
+    
+    /**
+     * Label used to indicate the name of the item
+     */
+    public static final String TEIID_JDBC_ITEM_NAME_LABEL = "itemName"; //$NON-NLS-1$
+
+    /**
+     * Label used to indicate the type of the item (Catalog or Schema)
+     */
+    public static final String TEIID_JDBC_ITEM_TYPE_LABEL = "itemType"; //$NON-NLS-1$
+
+    /**
+     * Label used to indicate child schema names (only used if itemType is a Catalog)
+     */
+    public static final String TEIID_JDBC_CATALOG_SCHEMA_NAMES_LABEL = "catalogSchema"; //$NON-NLS-1$
+
+    private String name;
+    private String type;
+    private List<String> schemaNames;
+    
+    /**
+     * Constructor for use when deserializing
+     */
+    public RestTeiidDataSourceJdbcCatalogSchemaInfo() {
+        super();
+    }
+
+    /**
+     * Constructor for use when serializing.
+     * @param itemName the name of the item
+     * @param itemType the type of item (schema or catalog)
+     * @param catalogSchemaNames the list of schema (only used for for catalogs supporting schema)
+     *
+     * @throws KException if error occurs
+     */
+    public RestTeiidDataSourceJdbcCatalogSchemaInfo(String itemName, String itemType, List<String> catalogSchemaNames) throws KException {
+        super();
+
+        setItemName(itemName);
+        setItemType(itemType);
+
+        setCatalogSchemaNames(catalogSchemaNames);
+    }
+    
+    @Override
+    public Object getXml() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean supports(MediaType mediaType) {
+        return MediaType.APPLICATION_JSON_TYPE.equals(mediaType);
+    }
+
+    /**
+     * @return the item name
+     */
+    public String getItemName() {
+        return name;
+    }
+
+    /**
+     * @param itemName the item name
+     */
+    public void setItemName(String itemName) {
+        this.name = itemName;
+    }
+    
+    /**
+     * @return the item type
+     */
+    public String getItemType() {
+        return type;
+    }
+
+    /**
+     * @param itemType the item type
+     */
+    public void setItemType(String itemType) {
+        this.type = itemType;
+    }
+    
+    /**
+     * @return the list of schema names for a catalog item
+     */
+    public String[] getCatalogSchemaNames() {
+        return schemaNames != null ? (String[]) schemaNames.toArray(new String[0]) : EMPTY_ARRAY;
+    }
+
+    /**
+     * @param schemaNames the schema names for a catalog
+     */
+    public void setCatalogSchemaNames(Collection<String> schemaNames) {
+        if (schemaNames == null || schemaNames.size() == 0)
+            this.schemaNames = Collections.emptyList();
+
+        this.schemaNames = new ArrayList<String>();
+        for (Object value: schemaNames) {
+            this.schemaNames.add(value.toString());
+        }
+    }
+
+}

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -221,6 +221,11 @@ Error.TEIID_SERVICE_UPDATE_DDL_DNE = The teiid model DDL is empty.
 Error.TEIID_SERVICE_UPDATE_ERROR = An error occurred while updating a vdb from the repository
 Error.TEIID_SERVICE_DEFAULT_TRANSLATOR_MAPPINGS_NOT_FOUND_ERROR = The default translator mapping file was not found.
 Error.TEIID_SERVICE_LOAD_DEFAULT_TRANSLATOR_MAPPINGS_ERROR = An error occurred attempting to load the default translator mappings: %s
+Error.TEIID_SERVICE_GET_DATA_SOURCE_NOT_JDBC_ERROR = The specified source is not a JDBC source.
+Error.TEIID_SERVICE_GET_DATA_SOURCE_CONNECTION_ERROR = An error occurred attempting to get the source JDBC connection.
+Error.TEIID_SERVICE_GET_DATA_SOURCE_TABLE_FETCH_ERROR = An error occurred attempting to fetch the source JDBC tables.
+Error.TEIID_SERVICE_GET_DATA_SOURCE_TABLES_ERROR = An error occurred getting the source tables.
+Error.TEIID_SERVICE_GET_DATA_SOURCE_CATALOG_SCHEMA_ERROR = An error occurred getting the source catalog and schema.
 
 Error.IMPORT_EXPORT_SERVICE_NO_PARAMETERS_ERROR = The import export service requires at least one parameter
 Error.IMPORT_EXPORT_SERVICE_UNSUPPORTED_TYPE_ERROR = The storage type requested from the import export service is unsupported


### PR DESCRIPTION
Adds methods to KomodoTeiidService for getting JDBC source info
- JdbcInfo - if the connection is jdbc, more info about the jdbc connection is returned
- JdbcCatalogSchema - if the connection is jdbc, the catalog-schema info are returned (depending on what the particular source supports)