### PR TITLE
TeiidTools-48: Provide application about information

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/teiid/internal/TeiidImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/teiid/internal/TeiidImpl.java
@@ -478,7 +478,7 @@ public class TeiidImpl extends RelationalChildRestrictedObject implements Teiid,
     /**
      * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
-     * @return value of teiid host property
+     * @return value of teiid version property
      * @throws KException
      *         if error occurs
      */

--- a/komodo-spi/src/main/java/org/komodo/spi/runtime/TeiidInstance.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/runtime/TeiidInstance.java
@@ -61,10 +61,23 @@ public interface TeiidInstance extends ExecutionAdmin, HostProvider {
     String DATASOURCE_DISPLAYNAME = "display-name"; //$NON-NLS-1$
     
     /**
-     * @return the version information of this instance
+     * @return the version information of this instance, either the client or runtime version
+     *                  depending on connection, ie. unconnected returns client while connected returns runtime.
+     *
      * @throws Exception 
      */
     TeiidVersion getVersion();
+
+    /**
+     * @return the client version of this instance
+     */
+    TeiidVersion getClientVersion();
+
+    /**
+     * @return the runtime / server version of this instance
+     * @throws Exception 
+     */
+    TeiidVersion getRuntimeVersion() throws Exception;
 
     /**
      * Disconnect then connect to this instance. This is preferable to 
@@ -97,6 +110,11 @@ public interface TeiidInstance extends ExecutionAdmin, HostProvider {
      * @return the unique identifier of this instance
      */
     String getId();
+
+    /**
+     * @return the version of teiid this instance was built with
+     */
+    TeiidVersion getSupportedVersion();
 
     /**
      * @return the teiid instance parent

--- a/komodo-spi/src/main/java/org/komodo/spi/runtime/version/DefaultTeiidVersion.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/runtime/version/DefaultTeiidVersion.java
@@ -22,6 +22,7 @@
 package org.komodo.spi.runtime.version;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import org.komodo.spi.Messages;
@@ -47,6 +48,12 @@ public class DefaultTeiidVersion implements TeiidVersion {
             return version;
         } catch (Exception ex) {
             throw new RuntimeException(ex);
+        } finally {
+            try {
+                reader.close();
+            } catch (IOException e) {
+                // Do Nothing
+            }
         }
     }
 

--- a/komodo-teiid-client/src/main/java/org/komodo/teiid/ExtensionConstants.java
+++ b/komodo-teiid-client/src/main/java/org/komodo/teiid/ExtensionConstants.java
@@ -47,8 +47,15 @@ public interface ExtensionConstants extends StringConstants {
 
     String READ_CHILDREN_NAMES = "read-children-names";
 
+    String READ_ATTRIBUTE = "read-attribute";
+
+    String NAME = "name";
+
     String CONNECTION_FIELD = "connection";
 
     String DOMAIN_MODE_FIELD = "domainMode";
 
+    String TEIID = "teiid";
+
+    String TEIID_RUNTIME_VERSION = "runtime-version";
 }

--- a/komodo-teiid-client/src/main/java/org/komodo/teiid/Messages.java
+++ b/komodo-teiid-client/src/main/java/org/komodo/teiid/Messages.java
@@ -55,7 +55,8 @@ public class Messages implements StringConstants {
         reconnectErrorMsg,
         noSuchField,
         buildOperationFailure,
-        requestDriverFailure;
+        requestDriverFailure,
+        requestTeiidVersionFailure;
 
         @Override
         public String toString() {

--- a/komodo-teiid-client/src/main/java/org/komodo/teiid/impl/JbossExtensions.java
+++ b/komodo-teiid-client/src/main/java/org/komodo/teiid/impl/JbossExtensions.java
@@ -33,6 +33,8 @@ import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.dmr.ModelNode;
 import org.komodo.spi.runtime.DataSourceDriver;
+import org.komodo.spi.runtime.version.DefaultTeiidVersion;
+import org.komodo.spi.runtime.version.TeiidVersion;
 import org.komodo.teiid.ExtensionConstants;
 import org.komodo.teiid.Messages;
 import org.teiid.adminapi.Admin;
@@ -235,5 +237,20 @@ public class JbossExtensions implements ExtensionConstants {
             }
         }
         return dataSourceDrivers;
+    }
+
+    public TeiidVersion getTeiidRuntimeVersion(Admin admin) throws Exception {
+        if (admin == null)
+            throw new Exception(Messages.getString(Messages.TeiidInstance.requestTeiidVersionFailure));
+
+        final ModelNode request = buildRequest(admin, TEIID, READ_ATTRIBUTE, NAME, TEIID_RUNTIME_VERSION);
+        ModelNode outcome = getConnection(admin).execute(request);
+        if (Util.isSuccess(outcome)) {
+            ModelNode result = outcome.get(RESULT);
+            String versionId = result.asString();
+            return new DefaultTeiidVersion(versionId);
+        }
+
+        throw new Exception(Messages.getString(Messages.TeiidInstance.requestTeiidVersionFailure));
     }
 }

--- a/komodo-teiid-client/src/main/java/org/komodo/teiid/impl/TeiidInstanceImpl.java
+++ b/komodo-teiid-client/src/main/java/org/komodo/teiid/impl/TeiidInstanceImpl.java
@@ -77,6 +77,11 @@ public class TeiidInstanceImpl extends AbstractTeiidInstance {
     }
 
     @Override
+    public TeiidVersion getRuntimeVersion() throws Exception {
+        return ext.getTeiidRuntimeVersion(admin);
+    }
+
+    @Override
     protected boolean isCoherent() {
         return admin != null;
     }

--- a/komodo-teiid-client/src/main/resources/org/komodo/teiid/messages.properties
+++ b/komodo-teiid-client/src/main/resources/org/komodo/teiid/messages.properties
@@ -8,6 +8,7 @@ TeiidInstance.reconnectErrorMsg = Cannot establish a connection to the Teiid ins
 TeiidInstance.noSuchField = Cannot retrieve the jboss extension field {0}
 TeiidInstance.buildOperationFailure = The request operation {0} failed construction
 TeiidInstance.requestDriverFailure = The request to retrieve the data source drivers failed: '{0}'
+TeiidInstance.requestTeiidVersionFailure = The request to retrieve the teiid runtime version failed
 
 ExecutionAdmin.mergeVdbUnsupported = This method is no longer supported and is only provided for backward compatibility with Teiid 7.7.1
 ExecutionAdmin.dynamicVdbInvalidName = The supplied Dynamic VDB deployment name "{0}" does not end with "vdb.xml"

--- a/komodo-teiid-client/src/test/java/org/komodo/teiid/TestTeiidInstance.java
+++ b/komodo-teiid-client/src/test/java/org/komodo/teiid/TestTeiidInstance.java
@@ -52,6 +52,7 @@ import org.komodo.spi.runtime.TeiidParent;
 import org.komodo.spi.runtime.TeiidVdb;
 import org.komodo.spi.runtime.version.DefaultTeiidVersion;
 import org.komodo.spi.runtime.version.TeiidVersion;
+import org.komodo.spi.runtime.version.TeiidVersionProvider;
 import org.komodo.teiid.impl.TeiidInstanceImpl;
 import org.komodo.test.utils.DummyEventManager;
 import org.komodo.test.utils.TestUtilities;
@@ -276,6 +277,15 @@ public class TestTeiidInstance {
             assertTrue(driverNames.contains(driver.getName()));
             assertTrue(classNames.contains(driver.getClassName()));
         }
+    }
+
+    @Test
+    public void testRuntimeVersion() throws Exception {
+        getTeiidInstance().connect();
+        assertTrue(getTeiidInstance().isConnected());
+        TeiidVersion version = getTeiidInstance().getRuntimeVersion();
+        assertNotNull(version);
+        assertEquals(TeiidVersionProvider.getInstance().getTeiidVersion(), version);
     }
 
     @Test

--- a/server/komodo-rest/pom.xml
+++ b/server/komodo-rest/pom.xml
@@ -27,6 +27,12 @@
 		<!-- To be injected into swagger index.html -->
 		<rest-context>vdb-builder</rest-context>
 		<rest-version>v1</rest-version>
+
+		<app.rest.name>${rest-context}</app.rest.name>
+		<app.rest.title>Vdb Builder</app.rest.title>
+		<app.rest.version>${project.version}</app.rest.version>
+		<app.rest.description>A tool that allows creating, editing and managing dynamic VDBs and their contents</app.rest.description>
+
 	</properties>
 
 	<profiles>
@@ -451,6 +457,17 @@
 	</dependencies>
 
 	<build>
+		<!-- Write out the app properties to file -->
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>**/*.properties</include>
+				</includes>
+			</resource>
+		</resources>
+
 		<!-- Set the name of the war, used as the context root when the app is 
 			deployed -->
 		<finalName>${rest-context}</finalName>

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -100,15 +101,56 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
      */
     public static interface V1Constants extends JsonConstants {
 
-        /**
-         * Application name and context
-         */
-        String APP_NAME = "vdb-builder"; //$NON-NLS-1$
+        class App {
 
-        /**
-         * Version of the application
-         */
-        String APP_VERSION = "0.0.3"; //$NON-NLS-1$
+            private static final Properties properties = new Properties();
+
+            private static void init() {
+                InputStream fileStream = KomodoRestV1Application.class.getClassLoader().getResourceAsStream("app.properties");
+
+                try {
+                    properties.load(fileStream);
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+
+            /**
+             * Application name and context
+             */
+            public static String name() {
+                init();
+
+                return properties.getProperty("app.name");
+            }
+
+            /**
+             * Application display title
+             */
+            public static String title() {
+                init();
+
+                return properties.getProperty("app.title");
+            }
+
+            /**
+             * Application description
+             */
+            public static String description() {
+                init();
+
+                return properties.getProperty("app.description");
+            }
+
+            /**
+             * Version of the application
+             */
+            public static String version() {
+                init();
+
+                return properties.getProperty("app.version");
+            }
+        }
 
         /**
          * The komodo engine's data directory system property
@@ -567,11 +609,11 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
         converters.addConverter(new RestDataserviceConverter());
 
         BeanConfig beanConfig = new BeanConfig();
-        beanConfig.setTitle("Vdb Builder");
-        beanConfig.setDescription("A tool that allows creating, editing and managing dynamic VDBs and their contents");
-        beanConfig.setVersion(V1Constants.APP_VERSION);
-        beanConfig.setSchemes(new String[]{"http"});
-        beanConfig.setBasePath(V1Constants.APP_NAME + V1Constants.APP_PATH);
+        beanConfig.setTitle(V1Constants.App.title());
+        beanConfig.setDescription(V1Constants.App.description());
+        beanConfig.setVersion(V1Constants.App.version());
+        beanConfig.setSchemes(new String[]{"https"});
+        beanConfig.setBasePath(V1Constants.App.name() + V1Constants.APP_PATH);
 
         // No need to setHost as it will pick up the one its running on
 

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestTeiidStatus.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestTeiidStatus.java
@@ -36,6 +36,8 @@ import org.komodo.spi.runtime.TeiidDataSource;
 import org.komodo.spi.runtime.TeiidInstance;
 import org.komodo.spi.runtime.TeiidTranslator;
 import org.komodo.spi.runtime.TeiidVdb;
+import org.komodo.spi.runtime.version.DefaultTeiidVersion;
+import org.komodo.spi.runtime.version.TeiidVersion;
 
 /**
  * A Teiid Status object that can be used by GSON to build a JSON document representation.
@@ -46,6 +48,11 @@ public final class RestTeiidStatus extends RestTeiid {
      * Label used to describe whether teiid instance is available
      */
     public static final String TEIID_INSTANCE_AVAILABLE_LABEL = "instanceAvailable";
+
+    /**
+     * Label used to describe the version of teiid used to build this
+     */
+    public static final String TEIID_BUILT_VERSION_LABEL = "builtVersion";
 
     /**
      * Label used to describe teiid connection url
@@ -126,6 +133,8 @@ public final class RestTeiidStatus extends RestTeiid {
         addLink(new RestLink(LinkType.PARENT, getUriBuilder().cachedTeiidUri(teiid.getId(uow))));
         removeLink(LinkType.CHILDREN);
 
+        setBuiltWithVersion(new DefaultTeiidVersion(super.getVersion()));
+
         synchronized (TeiidInstance.TEIID_INSTANCE_LOCK) {
             TeiidInstance teiidInstance = teiid.getTeiidInstance(uow);
             setTeiidInstanceAvailable(teiidInstance != null);
@@ -136,6 +145,7 @@ public final class RestTeiidStatus extends RestTeiid {
             try {
                 teiidInstance.connect();
 
+                setVersion(teiidInstance.getVersion().toString());
                 setConnectionUrl(teiidInstance.getUrl());
                 setConnected(teiidInstance.isConnected());
                 setConnectionError(teiidInstance.getConnectionError());
@@ -166,6 +176,15 @@ public final class RestTeiidStatus extends RestTeiid {
                 throw new KException(ex);
             }
         }
+    }
+
+    public String getBuiltWithVersion() {
+        Object versionObj = tuples.get(TEIID_BUILT_VERSION_LABEL);
+        return versionObj != null ? versionObj.toString() : null;
+    }
+
+    protected void setBuiltWithVersion(TeiidVersion teiidVersion) {
+        tuples.put(TEIID_BUILT_VERSION_LABEL, teiidVersion.toString());
     }
 
     public boolean isTeiidInstanceAvailable() {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -50,6 +50,7 @@ import org.komodo.relational.vdb.Vdb;
 import org.komodo.relational.workspace.WorkspaceManager;
 import org.komodo.repository.SynchronousCallback;
 import org.komodo.rest.KomodoRestException;
+import org.komodo.rest.KomodoRestV1Application;
 import org.komodo.rest.KomodoRestV1Application.V1Constants;
 import org.komodo.rest.KomodoService;
 import org.komodo.rest.relational.RelationalMessages;
@@ -79,6 +80,14 @@ public final class KomodoUtilService extends KomodoService {
     private static final String REPO_CONFIG_LABEL = "Repository Configuration"; //$NON-NLS-1$
 
     private static final String REPO_VDB_TOTAL = "Repository Vdb Total"; //$NON-NLS-1$
+
+    static final String APP_NAME = "App Name"; //$NON-NLS-1$
+
+    static final String APP_TITLE = "App Title"; //$NON-NLS-1$
+
+    static final String APP_DESCRIPTION = "App Description"; //$NON-NLS-1$
+
+    static final String APP_VERSION = "App Version"; //$NON-NLS-1$
 
     /**
      * The sample vdbs provided by this service
@@ -123,6 +132,11 @@ public final class KomodoUtilService extends KomodoService {
 
         KomodoStatusObject repoStatus = new KomodoStatusObject();
 
+        repoStatus.addAttribute(APP_NAME, KomodoRestV1Application.V1Constants.App.name());
+        repoStatus.addAttribute(APP_TITLE, KomodoRestV1Application.V1Constants.App.title());
+        repoStatus.addAttribute(APP_DESCRIPTION, KomodoRestV1Application.V1Constants.App.description());
+        repoStatus.addAttribute(APP_VERSION, KomodoRestV1Application.V1Constants.App.version());
+
         Id id = this.repo.getId();
         repoStatus.addAttribute(REPO_WKSP_LABEL, id.getWorkspaceName());
         repoStatus.addAttribute(REPO_CONFIG_LABEL, id.getConfiguration().toString());
@@ -133,7 +147,6 @@ public final class KomodoUtilService extends KomodoService {
             // find VDBs
             uow = systemTx("getVdbs", true); //$NON-NLS-1$
             Vdb[] vdbs = getWorkspaceManager(uow).findVdbs(uow);
-
             repoStatus.addAttribute(REPO_VDB_TOTAL, Integer.toString(vdbs.length));
 
         } catch (final Exception e) {

--- a/server/komodo-rest/src/main/resources/app.properties
+++ b/server/komodo-rest/src/main/resources/app.properties
@@ -1,0 +1,4 @@
+app.name=${app.rest.name}
+app.title=${app.rest.title}
+app.version=${app.rest.version}
+app.description=${app.rest.description}

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoUtilServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoUtilServiceTest.java
@@ -82,6 +82,12 @@ public final class KomodoUtilServiceTest extends AbstractKomodoServiceTest {
         for (String expected : EXPECTED) {
             assertTrue(entity.contains(expected));
         }
+
+        // This are generated on build from maven variables so check they are listed
+        assertTrue(entity.contains(KomodoUtilService.APP_NAME));
+        assertTrue(entity.contains(KomodoUtilService.APP_TITLE));
+        assertTrue(entity.contains(KomodoUtilService.APP_VERSION));
+        assertTrue(entity.contains(KomodoUtilService.APP_DESCRIPTION));
     }
 
     @Test


### PR DESCRIPTION
ScreeGrab: http://phantomjinx.co.uk/stuff/ds-dashboard.png

* TeiidInstanceImpl
* JbossExtensions
 * Extends the version concept in teiid instance to include the concepts of
  ** supported version
  ** client version (mostly the same as supported version)
  ** runtime version (the reported server instance version)

* KomodoRestV1Application
 * Externalise the app name, title and version properties to pick them up
   from maven filtered properties file.

* New properties added to rest operation payloads for delivery to client