### PR TITLE
Add ability to omit table constraints on ddl export

### DIFF
--- a/komodo-modeshape-vdb/src/main/java/org/komodo/modeshape/visitor/DdlNodeVisitor.java
+++ b/komodo-modeshape-vdb/src/main/java/org/komodo/modeshape/visitor/DdlNodeVisitor.java
@@ -40,10 +40,10 @@ import javax.jcr.nodetype.NodeType;
 import org.komodo.modeshape.AbstractNodeVisitor;
 import org.komodo.modeshape.teiid.TeiidSqlNodeVisitor;
 import org.komodo.spi.constants.StringConstants;
+import org.komodo.spi.ddl.TeiidDDLConstants;
 import org.komodo.spi.lexicon.TeiidSqlConstants;
 import org.komodo.spi.lexicon.TeiidSqlConstants.NonReserved;
 import org.komodo.spi.lexicon.TeiidSqlConstants.Reserved;
-import org.komodo.spi.ddl.TeiidDDLConstants;
 import org.komodo.spi.metadata.MetadataNamespaces;
 import org.komodo.spi.runtime.version.TeiidVersion;
 import org.komodo.spi.type.DataTypeManager.DataTypeName;
@@ -73,6 +73,11 @@ public class DdlNodeVisitor extends AbstractNodeVisitor
         EXCLUDE_TABLES,
 
         /**
+         * Exclude Table Constraints
+         */
+        EXCLUDE_TABLE_CONSTRAINTS,
+
+        /**
          * Exclude Procedures
          */
         EXCLUDE_PROCEDURES,
@@ -86,6 +91,8 @@ public class DdlNodeVisitor extends AbstractNodeVisitor
     private StringBuilder ddlBuffer = new StringBuilder();
 
     private boolean includeTables = true;
+
+    private boolean includeTableConstraints = true;
 
     private boolean includeProcedures = true;
 
@@ -252,6 +259,9 @@ public class DdlNodeVisitor extends AbstractNodeVisitor
                 switch (exclusion) {
                     case EXCLUDE_TABLES:
                         this.includeTables = false;
+                        break;
+                    case EXCLUDE_TABLE_CONSTRAINTS:
+                        this.includeTableConstraints = false;
                         break;
                     case EXCLUDE_PROCEDURES:
                         this.includeProcedures = false;
@@ -716,7 +726,9 @@ public class DdlNodeVisitor extends AbstractNodeVisitor
                     append(COMMA);
             }
 
-            constraints(node);
+            if(includeTableConstraints) {
+                constraints(node);
+            }
             append(NEW_LINE);
             append(CLOSE_BRACKET);
         }

--- a/komodo-relational/src/main/java/org/komodo/relational/model/internal/TableImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/model/internal/TableImpl.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.komodo.modeshape.visitor.DdlNodeVisitor;
+import org.komodo.modeshape.visitor.DdlNodeVisitor.VisitorExclusions;
 import org.komodo.relational.Messages;
 import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalModelFactory;
@@ -42,6 +43,7 @@ import org.komodo.relational.model.StatementOption;
 import org.komodo.relational.model.Table;
 import org.komodo.relational.model.UniqueConstraint;
 import org.komodo.spi.KException;
+import org.komodo.spi.constants.ExportConstants;
 import org.komodo.spi.repository.Descriptor;
 import org.komodo.spi.repository.DocumentType;
 import org.komodo.spi.repository.KomodoObject;
@@ -1042,7 +1044,13 @@ public class TableImpl extends RelationalObjectImpl implements Table {
     }
 
     private String exportDdl(UnitOfWork transaction, Properties exportProperties) throws Exception {
-        DdlNodeVisitor visitor = new DdlNodeVisitor(TeiidVersionProvider.getInstance().getTeiidVersion(), false);
+        List<VisitorExclusions> exclusions = new ArrayList<VisitorExclusions>();
+        if( exportProperties != null && !exportProperties.isEmpty() ) {
+            if(exportProperties.containsKey(ExportConstants.EXCLUDE_TABLE_CONSTRAINTS_KEY)) {
+                exclusions.add(VisitorExclusions.EXCLUDE_TABLE_CONSTRAINTS);
+            }
+        }
+        DdlNodeVisitor visitor = new DdlNodeVisitor(TeiidVersionProvider.getInstance().getTeiidVersion(), false, exclusions.toArray(new VisitorExclusions[0]));
         visitor.visit(node(transaction));
 
         String result = visitor.getDdl();

--- a/komodo-spi/src/main/java/org/komodo/spi/constants/ExportConstants.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/constants/ExportConstants.java
@@ -2,5 +2,6 @@ package org.komodo.spi.constants;
 
 public interface ExportConstants {
 
-	String USE_TABS_PROP_KEY = "useTabs";
+    String USE_TABS_PROP_KEY = "useTabs";
+    String EXCLUDE_TABLE_CONSTRAINTS_KEY = "excludeTableConstraints";
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -35,6 +35,7 @@ import static org.komodo.rest.relational.RelationalMessages.Error.DATASERVICE_SE
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -75,6 +76,7 @@ import org.komodo.rest.relational.response.KomodoStatusObject;
 import org.komodo.rest.relational.response.RestDataSourceDriver;
 import org.komodo.rest.relational.response.RestVdb;
 import org.komodo.spi.KException;
+import org.komodo.spi.constants.ExportConstants;
 import org.komodo.spi.constants.StringConstants;
 import org.komodo.spi.repository.KomodoObject;
 import org.komodo.spi.repository.Repository.UnitOfWork;
@@ -582,7 +584,9 @@ public final class KomodoDataserviceService extends KomodoService {
         	sourceModel.setModelType(uow, Type.PHYSICAL);
 
             // The source model DDL contains the table DDL only.  This limits the source metadata which is loaded on deployment.
-        	byte[] bytes = sourceTable.export(uow, null);
+            Properties exportProps = new Properties();
+            exportProps.put( ExportConstants.EXCLUDE_TABLE_CONSTRAINTS_KEY, true );
+        	byte[] bytes = sourceTable.export(uow, exportProps);
         	String tableString = new String(bytes);
             sourceModel.setModelDefinition(uow, tableString);
             


### PR DESCRIPTION
- adds property for excluding constraints when exporting table ddl
- KomodoDataserviceService was modified so that the exported DDL for the source table does not include the table constraints