### PR TITLE
Changed pom's to use the BOM source / target.  

### DIFF
--- a/komodo-core-tests/pom.xml
+++ b/komodo-core-tests/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-core/pom.xml
+++ b/komodo-core/pom.xml
@@ -20,8 +20,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-importer/pom.xml
+++ b/komodo-importer/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-modeshape-sequencer-teiid-sql-tests/pom.xml
+++ b/komodo-modeshape-sequencer-teiid-sql-tests/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-modeshape-sequencer-teiid-sql/pom.xml
+++ b/komodo-modeshape-sequencer-teiid-sql/pom.xml
@@ -86,8 +86,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-modeshape-vdb/pom.xml
+++ b/komodo-modeshape-vdb/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-modeshape/pom.xml
+++ b/komodo-modeshape/pom.xml
@@ -17,8 +17,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-parent/pom.xml
+++ b/komodo-parent/pom.xml
@@ -112,6 +112,10 @@
 
 		<debug.argline />
 
+                <!-- overriding the BOM 1.6 source/target -->
+                <maven.compiler.target>1.8</maven.compiler.target>
+                <maven.compiler.source>1.8</maven.compiler.source>
+
 		<!--Skip long running tests by default -->
 		<skipLongRunningTests>true</skipLongRunningTests>
 

--- a/komodo-relational-commands/pom.xml
+++ b/komodo-relational-commands/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/komodo-relational/pom.xml
+++ b/komodo-relational/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-shell-api/pom.xml
+++ b/komodo-shell-api/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-shell/pom.xml
+++ b/komodo-shell/pom.xml
@@ -20,8 +20,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-spi/pom.xml
+++ b/komodo-spi/pom.xml
@@ -29,8 +29,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-teiid-client/pom.xml
+++ b/komodo-teiid-client/pom.xml
@@ -192,8 +192,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 

--- a/komodo-test-utils/pom.xml
+++ b/komodo-test-utils/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-ui/pom.xml
+++ b/komodo-ui/pom.xml
@@ -32,8 +32,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-utils-logger/pom.xml
+++ b/komodo-utils-logger/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/komodo-utils/pom.xml
+++ b/komodo-utils/pom.xml
@@ -16,8 +16,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+                                        <source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
changed pom's to use the BOM source / target.   But since current BOM is set to 1.6, added override to sepcify 1.8 until BOM can be changed to use EAP related BOM.

This will make it easier when future changes to the BOM are made and the project can automatically pick up the change.