### PR TITLE
TEIIDTOOLS-140 Text Mode Editing of Service View

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/ViewDdlBuilder.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/ViewDdlBuilder.java
@@ -252,10 +252,12 @@ public class ViewDdlBuilder {
         } else {
             sb.append("\nINNER JOIN \n").append(rhTableNameAliased+StringConstants.SPACE); //$NON-NLS-1$
         }
-        sb.append("\nON \n"); //$NON-NLS-1$
-        sb.append(lhTableAlias+StringConstants.DOT).append(escapeSQLName(teiidVersion,lhCriteriaCol))
-        .append(StringConstants.SPACE+StringConstants.EQUALS+StringConstants.SPACE)
-        .append(rhTableAlias+StringConstants.DOT).append(escapeSQLName(teiidVersion,rhCriteriaCol));
+        if(!StringUtils.isBlank(lhCriteriaCol) && !StringUtils.isBlank(rhCriteriaCol)) {
+            sb.append("\nON \n"); //$NON-NLS-1$
+            sb.append(lhTableAlias+StringConstants.DOT).append(escapeSQLName(teiidVersion,lhCriteriaCol))
+            .append(StringConstants.SPACE+StringConstants.EQUALS+StringConstants.SPACE)
+            .append(rhTableAlias+StringConstants.DOT).append(escapeSQLName(teiidVersion,rhCriteriaCol));
+        }
         sb.append(StringConstants.SEMI_COLON);
 
         return sb.toString();

--- a/komodo-relational/src/test/java/org/komodo/relational/ViewDdlBuilderTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/ViewDdlBuilderTest.java
@@ -304,5 +304,47 @@ public class ViewDdlBuilderTest extends RelationalModelTest {
                                                             lhCriteriaCol, rhCriteriaCol, ViewDdlBuilder.JOIN_FULL_OUTER);
         assertThat(viewDdl, is(EXPECTED_DDL));
     }
+    
+    @Test
+    public void shouldGeneratedODataViewJoinNoCriteriaDDL() throws Exception {
+        String EXPECTED_DDL = "CREATE VIEW MyView (RowId integer PRIMARY KEY,  LHCol1 string, LHCol2 string,  RHCol1 string, RHCol2 string) AS \n"
+        + "SELECT ROW_NUMBER() OVER (ORDER BY A.LHCol1), A.LHCol1, A.LHCol2, B.RHCol1, B.RHCol2 \n"
+        + "FROM \n"
+        + "lhTable AS A \n"
+        + "INNER JOIN \n"
+        + "rhTable AS B ;";
+
+        String lhTableAlias = "A";
+        String rhTableAlias = "B";
+        
+        Table lhTable = createTable("MyVDB", VDB_PATH, "MyModel", "lhTable");
+        Column lhCol1 = lhTable.addColumn(getTransaction(), "LHCol1");
+        lhCol1.setDatatypeName(getTransaction(), "string");
+        Column lhCol2 = lhTable.addColumn(getTransaction(), "LHCol2");
+        lhCol2.setDatatypeName(getTransaction(), "string");
+        
+        Table rhTable = createTable("MyVDB", VDB_PATH, "MyModel", "rhTable");
+        Column rhCol1 = rhTable.addColumn(getTransaction(), "RHCol1");
+        rhCol1.setDatatypeName(getTransaction(), "string");
+        Column rhCol2 = rhTable.addColumn(getTransaction(), "RHCol2");
+        rhCol2.setDatatypeName(getTransaction(), "string");
+                
+        List<String> lhColNames = new ArrayList<String>();
+        lhColNames.add("LHCol1");
+        lhColNames.add("LHCol2");
+        
+        List<String> rhColNames = new ArrayList<String>();
+        rhColNames.add("RHCol1");
+        rhColNames.add("RHCol2");
+        
+        String lhCriteriaCol = null;
+        String rhCriteriaCol = null;
+        
+        String viewDdl = ViewDdlBuilder.getODataViewJoinDdl(getTransaction(), "MyView", 
+                                                            lhTable, lhTableAlias, lhColNames, 
+                                                            rhTable, rhTableAlias, rhColNames, 
+                                                            lhCriteriaCol, rhCriteriaCol, ViewDdlBuilder.JOIN_INNER);
+        assertThat(viewDdl, is(EXPECTED_DDL));
+    }
 
 }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -272,7 +272,17 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
          * The name of the URI path segment for a setting a dataservice's service vdb for join view
          */
         String SERVICE_VDB_FOR_JOIN_TABLES = "ServiceVdbForJoinTables"; //$NON-NLS-1$
+        
+        /**
+         * The name of the URI path segment for getting the DDL for single table view
+         */
+        String SERVICE_VIEW_DDL_FOR_SINGLE_TABLE = "ServiceViewDdlForSingleTable"; //$NON-NLS-1$
 
+        /**
+         * The name of the URI path segment for getting the DDL for join view
+         */
+        String SERVICE_VIEW_DDL_FOR_JOIN_TABLES = "ServiceViewDdlForJoinTables"; //$NON-NLS-1$
+        
         /**
          * The name of the URI path segment for the collection of Datasources in the Komodo workspace.
          */

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -363,6 +363,11 @@ public final class RelationalMessages {
         DATASERVICE_SERVICE_SET_SERVICE_MISSING_JOIN_RH_COLUMN,
         
         /**
+         * An error indicating set attempt failed because the expected view ddl was missing
+         */
+        DATASERVICE_SERVICE_SET_SERVICE_MISSING_VIEWDDL,
+        
+        /**
          * An error indicating set attempt failed
          */
         DATASERVICE_SERVICE_SET_SERVICE_ERROR,

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceUpdateAttributesSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceUpdateAttributesSerializer.java
@@ -86,6 +86,9 @@ public final class DataserviceUpdateAttributesSerializer extends TypeAdapter< Ko
                 case KomodoDataserviceUpdateAttributes.DATASERVICE_JOIN_RH_COLUMN_LABEL:
                     updateAttrs.setRhJoinColumn(in.nextString());
                     break;
+                case KomodoDataserviceUpdateAttributes.DATASERVICE_VIEW_DDL_LABEL:
+                    updateAttrs.setViewDdl(in.nextString());
+                    break;
                 default:
                     throw new IOException( Messages.getString( UNEXPECTED_JSON_TOKEN, name ) );
             }
@@ -140,6 +143,9 @@ public final class DataserviceUpdateAttributesSerializer extends TypeAdapter< Ko
         
         out.name(KomodoDataserviceUpdateAttributes.DATASERVICE_JOIN_RH_COLUMN_LABEL);
         out.value(value.getRhJoinColumn());
+
+        out.name(KomodoDataserviceUpdateAttributes.DATASERVICE_VIEW_DDL_LABEL);
+        out.value(value.getViewDdl());
 
         out.endObject();
     }

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoDataserviceUpdateAttributes.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoDataserviceUpdateAttributes.java
@@ -88,6 +88,11 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
      */
     public static final String DATASERVICE_JOIN_RH_COLUMN_LABEL = "rhJoinColumn"; //$NON-NLS-1$
 
+    /**
+     * Label for the service view ddl
+     */
+    public static final String DATASERVICE_VIEW_DDL_LABEL = "viewDdl"; //$NON-NLS-1$
+
     @JsonProperty(DATASERVICE_NAME_LABEL)
     private String dataserviceName;
 
@@ -117,6 +122,9 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
 
     @JsonProperty(DATASERVICE_JOIN_RH_COLUMN_LABEL)
     private String rhJoinColumn;
+
+    @JsonProperty(DATASERVICE_VIEW_DDL_LABEL)
+    private String viewDdl;
 
     /**
      * Default constructor for deserialization
@@ -291,6 +299,20 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
         this.rhJoinColumn = joinCol;
     }
 
+    /**
+     * @return view ddl
+     */
+    public String getViewDdl() {
+        return viewDdl;
+    }
+
+    /**
+     * @param ddl the view ddl
+     */
+    public void setViewDdl(String ddl) {
+        this.viewDdl = ddl;
+    }
+
 
     @Override
     public int hashCode() {
@@ -306,6 +328,7 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
         result = prime * result + ((joinType == null) ? 0 : joinType.hashCode());
         result = prime * result + ((lhJoinColumn == null) ? 0 : lhJoinColumn.hashCode());
         result = prime * result + ((rhJoinColumn == null) ? 0 : rhJoinColumn.hashCode());
+        result = prime * result + ((viewDdl == null) ? 0 : viewDdl.hashCode());
         return result;
     }
 
@@ -368,6 +391,11 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
                 return false;
         } else if (!rhJoinColumn.equals(other.rhJoinColumn))
             return false;
+        if (viewDdl == null) {
+            if (other.viewDdl != null)
+                return false;
+        } else if (!viewDdl.equals(other.viewDdl))
+            return false;
         return true;
     }
 
@@ -394,6 +422,9 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
         }
         if(rhJoinColumn!=null) {
             sb.append(", rhJoinColumn =" + rhJoinColumn);
+        }
+        if(viewDdl!=null) {
+            sb.append(", viewDdl =" + viewDdl);
         }
         sb.append("]");
         return sb.toString();

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestDataserviceViewInfo.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestDataserviceViewInfo.java
@@ -33,6 +33,7 @@ import org.komodo.rest.KRestEntity;
  */
 public final class RestDataserviceViewInfo implements KRestEntity {
 
+    public static final String DDL_INFO = "DDL";
     public static final String LH_TABLE_INFO = "LHTABLE";
     public static final String RH_TABLE_INFO = "RHTABLE";
     public static final String CRITERIA_INFO = "CRITERIA";
@@ -50,6 +51,8 @@ public final class RestDataserviceViewInfo implements KRestEntity {
     private String lhCriteriaCol;
     private String rhCriteriaCol;
     private String criteria;
+    private String viewDdl;
+    private boolean viewEditable;
     
     /**
      * Constructor for use when deserializing
@@ -80,6 +83,34 @@ public final class RestDataserviceViewInfo implements KRestEntity {
      */
     public void setInfoType(String type) {
         this.infoType = type;
+    }
+    
+    /**
+     * @return the view ddl
+     */
+    public String getViewDdl() {
+        return viewDdl;
+    }
+
+    /**
+     * @param ddl the View DDL
+     */
+    public void setViewDdl(String ddl) {
+        this.viewDdl = ddl;
+    }
+    
+    /**
+     * @return 'true' if editor can recognize view
+     */
+    public boolean isViewEditable() {
+        return viewEditable;
+    }
+
+    /**
+     * @param canEdit 'true' if the editor can recognize the view
+     */
+    public void setViewEditable(boolean canEdit) {
+        this.viewEditable = canEdit;
     }
     
     /**

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -148,7 +148,8 @@ Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_MODELSOURCE_PATH = The modelSource
 Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_JOIN_TYPE = The joinType is required for this operation for DataService: %s
 Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_JOIN_LH_COLUMN = The join left criteria column is required for this operation for DataService: %s
 Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_JOIN_RH_COLUMN = The join right criteria column is required for this operation for DataService: %s
-        
+Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_VIEWDDL = The service view DDL is required for this operation for DataService: %s
+     
 Error.DATASOURCE_SERVICE_GET_DATASOURCES_ERROR = An error occurred constructing the JSON document representing the DataSources in the Komodo workspace: %s
 Error.DATASOURCE_SERVICE_GET_DATASOURCE_ERROR = An error occurred constructing the JSON document for DataSource: %s
 Error.DATASOURCE_SERVICE_GET_DRIVERS_ERROR = An error occurred constructing the JSON document representing the Drivers for DataService: %s


### PR DESCRIPTION
Changes to KomodoDataserviceService which support text editing of the dataservice view.
- modified the existing 'ServiceVdbForSingleTable' and 'ServiceVdbForJoinTables' rest calls.  They now will accept a 'viewDdl' parameter in the request in addition to the other params.  If the viewDdl is supplied, then is used for the view definition (instead of generating the DDL using the other supplied parameters).
- added 2 methods 'ServiceViewDdlForSingleTable' and 'ServiceViewDdlForJoinTables'.  Returns the view DDL generated for the supplied parameters.  Allows user to get the DDL which would be generated without actually updating the service view.
- made a few other improvements to the existing methods in KomodoDataserviceService