### PR TITLE
TEIIDTOOLS-137 support for join builder in DSB

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/ViewBuilderCriteriaPredicate.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/ViewBuilderCriteriaPredicate.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source.
+*
+* See the LEGAL.txt file distributed with this work for information regarding copyright ownership and licensing.
+*
+* See the AUTHORS.txt file distributed with this work for a full listing of individual contributors.
+*/
+package org.komodo.relational;
+
+import java.util.Map;
+import org.komodo.utils.StringUtils;
+
+/**
+ * Contains Criteria Predicates supplied to ViewDdlBuilder
+ */
+public class ViewBuilderCriteriaPredicate {
+    
+    private static final String LH_COLUMN_KEY = "lhColName";  //$NON-NLS-1$
+    private static final String RH_COLUMN_KEY = "rhColName";  //$NON-NLS-1$
+    private static final String OPERATOR_KEY = "operatorName";  //$NON-NLS-1$
+    private static final String COMBINE_KEYWORD_KEY = "combineKeyword";  //$NON-NLS-1$
+
+    private static final String UNDEFINED = "undef";  //$NON-NLS-1$
+    
+    private String lhColumn;
+    private String rhColumn;
+    private String operator;
+    private String combineKeyword;
+
+    
+    /**
+     * Constructor
+     */
+    public ViewBuilderCriteriaPredicate() {
+    }
+    
+    /**
+     * Construct the Criteria predicate using the provided map
+     * @param predicateMap the map of predicate values
+     */
+    public ViewBuilderCriteriaPredicate(Map<String,String> predicateMap) {
+        setLhColumn(predicateMap.get(LH_COLUMN_KEY));
+        setRhColumn(predicateMap.get(RH_COLUMN_KEY));
+        setOperator(predicateMap.get(OPERATOR_KEY));
+        setCombineKeyword(predicateMap.get(COMBINE_KEYWORD_KEY));
+    }
+    /**
+     * @return the lhColumn
+     */
+    public String getLhColumn() {
+        return StringUtils.isBlank(this.lhColumn) ? UNDEFINED : this.lhColumn;
+    }
+    /**
+     * @param lhColumn the lhColumn to set
+     */
+    public void setLhColumn(String lhColumn) {
+        this.lhColumn = lhColumn;
+    }
+    /**
+     * @return the rhColumn
+     */
+    public String getRhColumn() {
+        return StringUtils.isBlank(this.rhColumn) ? UNDEFINED : this.rhColumn;
+    }
+    /**
+     * @param rhColumn the rhColumn to set
+     */
+    public void setRhColumn(String rhColumn) {
+        this.rhColumn = rhColumn;
+    }
+    /**
+     * @return the operator
+     */
+    public String getOperator() {
+        return StringUtils.isBlank(this.operator) ? UNDEFINED : this.operator;
+    }
+    /**
+     * @param operator the operator to set
+     */
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+    /**
+     * @return the combineKeyword
+     */
+    public String getCombineKeyword() {
+        return StringUtils.isBlank(this.combineKeyword) ? UNDEFINED : this.combineKeyword;
+    }
+    /**
+     * @param combineKeyword the combineKeyword to set
+     */
+    public void setCombineKeyword(String combineKeyword) {
+        this.combineKeyword = combineKeyword;
+    }
+
+    /**
+     * @return 'true' if all values are provided
+     */
+    public boolean isComplete() {
+        if(StringUtils.isBlank(this.lhColumn) || StringUtils.isBlank(this.rhColumn) || StringUtils.isBlank(this.operator) || StringUtils.isBlank(this.combineKeyword)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/komodo-relational/src/test/java/org/komodo/relational/ViewDdlBuilderTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/ViewDdlBuilderTest.java
@@ -166,10 +166,16 @@ public class ViewDdlBuilderTest extends RelationalModelTest {
         String lhCriteriaCol = "LHCol1";
         String rhCriteriaCol = "RHCol2";
         
+        List<ViewBuilderCriteriaPredicate> criteriaPredicates = new ArrayList<ViewBuilderCriteriaPredicate>();
+        ViewBuilderCriteriaPredicate predicate = new ViewBuilderCriteriaPredicate();
+        predicate.setLhColumn(lhCriteriaCol);
+        predicate.setRhColumn(rhCriteriaCol);
+        predicate.setOperator("=");
+        criteriaPredicates.add(predicate);
         String viewDdl = ViewDdlBuilder.getODataViewJoinDdl(getTransaction(), "MyView", 
                                                             lhTable, lhTableAlias, lhColNames, 
                                                             rhTable, rhTableAlias, rhColNames, 
-                                                            lhCriteriaCol, rhCriteriaCol, ViewDdlBuilder.JOIN_INNER);
+                                                            ViewDdlBuilder.JOIN_INNER, criteriaPredicates);
         assertThat(viewDdl, is(EXPECTED_DDL));
     }
 
@@ -182,7 +188,7 @@ public class ViewDdlBuilderTest extends RelationalModelTest {
         + "LEFT OUTER JOIN \n"
         + "rhTable AS B \n"
         + "ON \n"
-        + "A.LHCol1 = B.RHCol2;";
+        + "A.LHCol1 > B.RHCol2;";
         
         String lhTableAlias = "A";
         String rhTableAlias = "B";
@@ -210,10 +216,16 @@ public class ViewDdlBuilderTest extends RelationalModelTest {
         String lhCriteriaCol = "LHCol1";
         String rhCriteriaCol = "RHCol2";
         
+        List<ViewBuilderCriteriaPredicate> criteriaPredicates = new ArrayList<ViewBuilderCriteriaPredicate>();
+        ViewBuilderCriteriaPredicate predicate = new ViewBuilderCriteriaPredicate();
+        predicate.setLhColumn(lhCriteriaCol);
+        predicate.setRhColumn(rhCriteriaCol);
+        predicate.setOperator(">");
+        criteriaPredicates.add(predicate);
         String viewDdl = ViewDdlBuilder.getODataViewJoinDdl(getTransaction(), "MyView", 
                                                             lhTable, lhTableAlias, lhColNames, 
                                                             rhTable, rhTableAlias, rhColNames, 
-                                                            lhCriteriaCol, rhCriteriaCol, ViewDdlBuilder.JOIN_LEFT_OUTER);
+                                                            ViewDdlBuilder.JOIN_LEFT_OUTER, criteriaPredicates);
         assertThat(viewDdl, is(EXPECTED_DDL));
     }
 
@@ -226,7 +238,7 @@ public class ViewDdlBuilderTest extends RelationalModelTest {
         + "RIGHT OUTER JOIN \n"
         + "rhTable AS B \n"
         + "ON \n"
-        + "A.LHCol1 = B.RHCol2;";
+        + "A.LHCol1 < B.RHCol2;";
         
         String lhTableAlias = "A";
         String rhTableAlias = "B";
@@ -254,10 +266,16 @@ public class ViewDdlBuilderTest extends RelationalModelTest {
         String lhCriteriaCol = "LHCol1";
         String rhCriteriaCol = "RHCol2";
         
+        List<ViewBuilderCriteriaPredicate> criteriaPredicates = new ArrayList<ViewBuilderCriteriaPredicate>();
+        ViewBuilderCriteriaPredicate predicate = new ViewBuilderCriteriaPredicate();
+        predicate.setLhColumn(lhCriteriaCol);
+        predicate.setRhColumn(rhCriteriaCol);
+        predicate.setOperator("<");
+        criteriaPredicates.add(predicate);
         String viewDdl = ViewDdlBuilder.getODataViewJoinDdl(getTransaction(), "MyView", 
                                                             lhTable, lhTableAlias, lhColNames, 
                                                             rhTable, rhTableAlias, rhColNames, 
-                                                            lhCriteriaCol, rhCriteriaCol, ViewDdlBuilder.JOIN_RIGHT_OUTER);
+                                                            ViewDdlBuilder.JOIN_RIGHT_OUTER, criteriaPredicates);
         assertThat(viewDdl, is(EXPECTED_DDL));
     }
 
@@ -270,7 +288,7 @@ public class ViewDdlBuilderTest extends RelationalModelTest {
         + "FULL OUTER JOIN \n"
         + "rhTable AS B \n"
         + "ON \n"
-        + "A.LHCol1 = B.RHCol2;";
+        + "A.LHCol1 <= B.RHCol2;";
         
         String lhTableAlias = "A";
         String rhTableAlias = "B";
@@ -298,10 +316,16 @@ public class ViewDdlBuilderTest extends RelationalModelTest {
         String lhCriteriaCol = "LHCol1";
         String rhCriteriaCol = "RHCol2";
         
+        List<ViewBuilderCriteriaPredicate> criteriaPredicates = new ArrayList<ViewBuilderCriteriaPredicate>();
+        ViewBuilderCriteriaPredicate predicate = new ViewBuilderCriteriaPredicate();
+        predicate.setLhColumn(lhCriteriaCol);
+        predicate.setRhColumn(rhCriteriaCol);
+        predicate.setOperator("<=");
+        criteriaPredicates.add(predicate);
         String viewDdl = ViewDdlBuilder.getODataViewJoinDdl(getTransaction(), "MyView", 
                                                             lhTable, lhTableAlias, lhColNames, 
                                                             rhTable, rhTableAlias, rhColNames, 
-                                                            lhCriteriaCol, rhCriteriaCol, ViewDdlBuilder.JOIN_FULL_OUTER);
+                                                            ViewDdlBuilder.JOIN_FULL_OUTER, criteriaPredicates);
         assertThat(viewDdl, is(EXPECTED_DDL));
     }
     
@@ -337,13 +361,63 @@ public class ViewDdlBuilderTest extends RelationalModelTest {
         rhColNames.add("RHCol1");
         rhColNames.add("RHCol2");
         
-        String lhCriteriaCol = null;
-        String rhCriteriaCol = null;
-        
         String viewDdl = ViewDdlBuilder.getODataViewJoinDdl(getTransaction(), "MyView", 
                                                             lhTable, lhTableAlias, lhColNames, 
                                                             rhTable, rhTableAlias, rhColNames, 
-                                                            lhCriteriaCol, rhCriteriaCol, ViewDdlBuilder.JOIN_INNER);
+                                                            ViewDdlBuilder.JOIN_INNER, null);
+        assertThat(viewDdl, is(EXPECTED_DDL));
+    }
+    
+    @Test
+    public void shouldGeneratedODataViewInnerJoinMulipleCriteriaDDL() throws Exception {
+        String EXPECTED_DDL = "CREATE VIEW MyView (RowId integer PRIMARY KEY,  LHCol1 string, LHCol2 string,  RHCol1 string, RHCol2 string) AS \n"
+        + "SELECT ROW_NUMBER() OVER (ORDER BY A.LHCol1), A.LHCol1, A.LHCol2, B.RHCol1, B.RHCol2 \n"
+        + "FROM \n"
+        + "lhTable AS A \n"
+        + "INNER JOIN \n"
+        + "rhTable AS B \n"
+        + "ON \n"
+        + "A.LHCol1 = B.RHCol2 AND A.LHCol3 > B.RHCol4;";
+
+        String lhTableAlias = "A";
+        String rhTableAlias = "B";
+        
+        Table lhTable = createTable("MyVDB", VDB_PATH, "MyModel", "lhTable");
+        Column lhCol1 = lhTable.addColumn(getTransaction(), "LHCol1");
+        lhCol1.setDatatypeName(getTransaction(), "string");
+        Column lhCol2 = lhTable.addColumn(getTransaction(), "LHCol2");
+        lhCol2.setDatatypeName(getTransaction(), "string");
+        
+        Table rhTable = createTable("MyVDB", VDB_PATH, "MyModel", "rhTable");
+        Column rhCol1 = rhTable.addColumn(getTransaction(), "RHCol1");
+        rhCol1.setDatatypeName(getTransaction(), "string");
+        Column rhCol2 = rhTable.addColumn(getTransaction(), "RHCol2");
+        rhCol2.setDatatypeName(getTransaction(), "string");
+                
+        List<String> lhColNames = new ArrayList<String>();
+        lhColNames.add("LHCol1");
+        lhColNames.add("LHCol2");
+        
+        List<String> rhColNames = new ArrayList<String>();
+        rhColNames.add("RHCol1");
+        rhColNames.add("RHCol2");
+        
+        List<ViewBuilderCriteriaPredicate> criteriaPredicates = new ArrayList<ViewBuilderCriteriaPredicate>();
+        ViewBuilderCriteriaPredicate predicate1 = new ViewBuilderCriteriaPredicate();
+        predicate1.setLhColumn("LHCol1");
+        predicate1.setRhColumn("RHCol2");
+        predicate1.setOperator("=");
+        predicate1.setCombineKeyword("AND");
+        criteriaPredicates.add(predicate1);
+        ViewBuilderCriteriaPredicate predicate2 = new ViewBuilderCriteriaPredicate();
+        predicate2.setLhColumn("LHCol3");
+        predicate2.setRhColumn("RHCol4");
+        predicate2.setOperator(">");
+        criteriaPredicates.add(predicate2);
+        String viewDdl = ViewDdlBuilder.getODataViewJoinDdl(getTransaction(), "MyView", 
+                                                            lhTable, lhTableAlias, lhColNames, 
+                                                            rhTable, rhTableAlias, rhColNames, 
+                                                            ViewDdlBuilder.JOIN_INNER, criteriaPredicates);
         assertThat(viewDdl, is(EXPECTED_DDL));
     }
 

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceUpdateAttributesSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/DataserviceUpdateAttributesSerializer.java
@@ -26,6 +26,7 @@ import static org.komodo.rest.relational.json.KomodoJsonMarshaller.BUILDER;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Map;
 import org.komodo.rest.Messages;
 import org.komodo.rest.relational.request.KomodoDataserviceUpdateAttributes;
 import com.google.gson.TypeAdapter;
@@ -39,6 +40,7 @@ import com.google.gson.stream.JsonWriter;
 public final class DataserviceUpdateAttributesSerializer extends TypeAdapter< KomodoDataserviceUpdateAttributes > {
 
     private static final Type STRING_LIST_TYPE = new TypeToken< List< String > >() {/* nothing to do */}.getType();
+    private static final Type MAP_LIST_TYPE = new TypeToken< List< Map<String,String> > >() {/* nothing to do */}.getType();
 
     /**
      * {@inheritDoc}
@@ -80,11 +82,9 @@ public final class DataserviceUpdateAttributesSerializer extends TypeAdapter< Ko
                 case KomodoDataserviceUpdateAttributes.DATASERVICE_JOIN_TYPE_LABEL:
                     updateAttrs.setJoinType(in.nextString());
                     break;
-                case KomodoDataserviceUpdateAttributes.DATASERVICE_JOIN_LH_COLUMN_LABEL:
-                    updateAttrs.setLhJoinColumn(in.nextString());
-                    break;
-                case KomodoDataserviceUpdateAttributes.DATASERVICE_JOIN_RH_COLUMN_LABEL:
-                    updateAttrs.setRhJoinColumn(in.nextString());
+                case KomodoDataserviceUpdateAttributes.DATASERVICE_CRITERIA_PREDICATES_LABEL:
+                    List<Map<String,String>> predicates = BUILDER.fromJson(in, List.class);
+                    updateAttrs.setCriteriaPredicates(predicates);
                     break;
                 case KomodoDataserviceUpdateAttributes.DATASERVICE_VIEW_DDL_LABEL:
                     updateAttrs.setViewDdl(in.nextString());
@@ -138,11 +138,10 @@ public final class DataserviceUpdateAttributesSerializer extends TypeAdapter< Ko
         out.name(KomodoDataserviceUpdateAttributes.DATASERVICE_JOIN_TYPE_LABEL);
         out.value(value.getJoinType());
 
-        out.name(KomodoDataserviceUpdateAttributes.DATASERVICE_JOIN_LH_COLUMN_LABEL);
-        out.value(value.getLhJoinColumn());
-        
-        out.name(KomodoDataserviceUpdateAttributes.DATASERVICE_JOIN_RH_COLUMN_LABEL);
-        out.value(value.getRhJoinColumn());
+        if (! value.getCriteriaPredicates().isEmpty()) {
+            out.name(KomodoDataserviceUpdateAttributes.DATASERVICE_CRITERIA_PREDICATES_LABEL);
+            BUILDER.toJson(value.getCriteriaPredicates(), MAP_LIST_TYPE, out);
+        }
 
         out.name(KomodoDataserviceUpdateAttributes.DATASERVICE_VIEW_DDL_LABEL);
         out.value(value.getViewDdl());

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoDataserviceUpdateAttributes.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/request/KomodoDataserviceUpdateAttributes.java
@@ -24,6 +24,7 @@ package org.komodo.rest.relational.request;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.ws.rs.core.MediaType;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
@@ -79,14 +80,9 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
     public static final String DATASERVICE_JOIN_TYPE_LABEL = "joinType"; //$NON-NLS-1$
 
     /**
-     * Label for the service view lh join column
+     * Label for the criteria predicates for the service join
      */
-    public static final String DATASERVICE_JOIN_LH_COLUMN_LABEL = "lhJoinColumn"; //$NON-NLS-1$
-
-    /**
-     * Label for the service view rh join column
-     */
-    public static final String DATASERVICE_JOIN_RH_COLUMN_LABEL = "rhJoinColumn"; //$NON-NLS-1$
+    public static final String DATASERVICE_CRITERIA_PREDICATES_LABEL = "criteriaPredicates"; //$NON-NLS-1$
 
     /**
      * Label for the service view ddl
@@ -117,11 +113,8 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
     @JsonProperty(DATASERVICE_JOIN_TYPE_LABEL)
     private String joinType;
     
-    @JsonProperty(DATASERVICE_JOIN_LH_COLUMN_LABEL)
-    private String lhJoinColumn;
-
-    @JsonProperty(DATASERVICE_JOIN_RH_COLUMN_LABEL)
-    private String rhJoinColumn;
+    @JsonProperty(DATASERVICE_CRITERIA_PREDICATES_LABEL)
+    private List<Map<String,String>> criteriaPredicates;
 
     @JsonProperty(DATASERVICE_VIEW_DDL_LABEL)
     private String viewDdl;
@@ -272,33 +265,26 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
     }
 
     /**
-     * @return left join column
+     * @return the criteria predicates
      */
-    public String getLhJoinColumn() {
-        return lhJoinColumn;
+    public List<Map<String,String>> getCriteriaPredicates() {
+        if (criteriaPredicates == null)
+            return Collections.emptyList();
+
+        return Collections.unmodifiableList(this.criteriaPredicates);
     }
 
     /**
-     * @param joinCol the join column
+     * set the criteria predicates
+     * @param predicates the predicates
      */
-    public void setLhJoinColumn(String joinCol) {
-        this.lhJoinColumn = joinCol;
-    }
+    public void setCriteriaPredicates(List<Map<String,String>> predicates) {
+        if (this.criteriaPredicates == null)
+            this.criteriaPredicates = new ArrayList<>();
 
-    /**
-     * @return right join column
-     */
-    public String getRhJoinColumn() {
-        return rhJoinColumn;
+        this.criteriaPredicates.addAll(predicates);
     }
-
-    /**
-     * @param joinCol the join column
-     */
-    public void setRhJoinColumn(String joinCol) {
-        this.rhJoinColumn = joinCol;
-    }
-
+    
     /**
      * @return view ddl
      */
@@ -326,8 +312,7 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
         result = prime * result + ((rhModelSourcePath == null) ? 0 : rhModelSourcePath.hashCode());
         result = prime * result + ((rhColumnNames == null) ? 0 : rhColumnNames.hashCode());
         result = prime * result + ((joinType == null) ? 0 : joinType.hashCode());
-        result = prime * result + ((lhJoinColumn == null) ? 0 : lhJoinColumn.hashCode());
-        result = prime * result + ((rhJoinColumn == null) ? 0 : rhJoinColumn.hashCode());
+        result = prime * result + ((criteriaPredicates == null) ? 0 : criteriaPredicates.hashCode());
         result = prime * result + ((viewDdl == null) ? 0 : viewDdl.hashCode());
         return result;
     }
@@ -381,15 +366,10 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
                 return false;
         } else if (!joinType.equals(other.joinType))
             return false;
-        if (lhJoinColumn == null) {
-            if (other.lhJoinColumn != null)
+        if (criteriaPredicates == null) {
+            if (other.criteriaPredicates != null)
                 return false;
-        } else if (!lhJoinColumn.equals(other.lhJoinColumn))
-            return false;
-        if (rhJoinColumn == null) {
-            if (other.rhJoinColumn != null)
-                return false;
-        } else if (!rhJoinColumn.equals(other.rhJoinColumn))
+        } else if (!criteriaPredicates.equals(other.criteriaPredicates))
             return false;
         if (viewDdl == null) {
             if (other.viewDdl != null)
@@ -417,11 +397,8 @@ public class KomodoDataserviceUpdateAttributes implements KRestEntity {
         if(joinType!=null) {
             sb.append(", joinType =" + joinType);
         }
-        if(lhJoinColumn!=null) {
-            sb.append(", lhJoinColumn =" + lhJoinColumn);
-        }
-        if(rhJoinColumn!=null) {
-            sb.append(", rhJoinColumn =" + rhJoinColumn);
+        if(criteriaPredicates!=null) {
+            sb.append(", criteriaPredicates length =" + criteriaPredicates.size());
         }
         if(viewDdl!=null) {
             sb.append(", viewDdl =" + viewDdl);

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestDataserviceViewInfo.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestDataserviceViewInfo.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.core.MediaType;
+import org.komodo.relational.ViewBuilderCriteriaPredicate;
 import org.komodo.rest.KRestEntity;
 
 /**
@@ -48,9 +49,7 @@ public final class RestDataserviceViewInfo implements KRestEntity {
     private String tableName;
     private List<String> columnNames;
     private String joinType;
-    private String lhCriteriaCol;
-    private String rhCriteriaCol;
-    private String criteria;
+    private List<ViewBuilderCriteriaPredicate> criteriaPredicates = new ArrayList<ViewBuilderCriteriaPredicate>();
     private String viewDdl;
     private boolean viewEditable;
     
@@ -169,52 +168,25 @@ public final class RestDataserviceViewInfo implements KRestEntity {
     }
 
     /**
-     * @param type the join type
+     * @param joinType the join type
      */
     public void setJoinType(String joinType) {
         this.joinType = joinType;
     }
     
     /**
-     * @return the lh criteria column name
+     * @return the criteria predicates
      */
-    public String getLHCriteriaColumn() {
-        return lhCriteriaCol;
+    public List<ViewBuilderCriteriaPredicate> getCriteriaPredicates() {
+        return this.criteriaPredicates;
     }
 
     /**
-     * @param colName the lh criteria column name
+     * @param predicates the criteria predicates
      */
-    public void setLHCriteriaColumn(String colName) {
-        this.lhCriteriaCol = colName;
-    }
-
-    /**
-     * @return the rh criteria column name
-     */
-    public String getRHCriteriaColumn() {
-        return rhCriteriaCol;
-    }
-
-    /**
-     * @param colName the rh criteria column name
-     */
-    public void setRHCriteriaColumn(String colName) {
-        this.rhCriteriaCol = colName;
+    public void setCriteriaPredicates(List<ViewBuilderCriteriaPredicate> predicates) {
+        this.criteriaPredicates = predicates;
     }
     
-    /**
-     * @return the criteria
-     */
-    public String getCriteria() {
-        return criteria;
-    }
-
-    /**
-     * @param criteria the criteria
-     */
-    public void setCriteria(String criteria) {
-        this.criteria = criteria;
-    }
     
 }


### PR DESCRIPTION
- changed rest methods for specifying join service.  now accepts multiple criteriaPredicates instead of the LH and RH columns for criteria.
- changed ViewDdlBuilder to accept the predicate list and build the DDL.
- changes in KomodoDataserviceService to utilize the updated ViewDdlBuilder.  