### PR TITLE
TEIIDTOOLS-86 filter info issue with h2 sources

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
@@ -2634,7 +2634,15 @@ public class KomodoTeiidService extends KomodoService {
                         try {
                             rs2 = connection.getMetaData().getSchemas(catlg,null);
                         } catch (Exception ex) {
-                            continue;
+                            if(allCats.size()==1) {
+                                try {
+                                    rs2 = connection.getMetaData().getSchemas();
+                                } catch (Exception ex1) {
+                                    continue;
+                                }
+                            } else {
+                                continue;
+                            }
                         }
                         List<String> schemaList = new ArrayList<String>();
                         while (rs2.next()) {


### PR DESCRIPTION
Fixes issue getting jdbc info for h2 sources.  Even though the source supports catalog and schema, the getSchema call with a catalog name fails.  Now tries an alternate getSchema method on failure for the case of a single catalog.