### PR TITLE
TEIIDTOOLS-143 Adds ddl validation service

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -249,6 +249,11 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
         String DATA_SERVICE_PLACEHOLDER = "{dataserviceName}"; //$NON-NLS-1$
 
         /**
+         * The name of the URI path segment for determining ddl valid status
+         */
+        String VALIDATE_DDL = "validateDdl"; //$NON-NLS-1$
+
+        /**
          * The name of the URI path segment for finding source vdb matches for a DataService
          */
         String SOURCE_VDB_MATCHES = "sourceVdbMatches"; //$NON-NLS-1$

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
@@ -31,6 +31,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -2628,6 +2629,7 @@ public class KomodoTeiidService extends KomodoService {
                     rs.close();
 
                     // Create mapping of catalog to schema list
+                    Collections.sort(allCats, String.CASE_INSENSITIVE_ORDER);
                     Map<String,List<String>> catalogSchemaMap = new HashMap<String, List<String>>();
                     for(String catlg : allCats) {
                         ResultSet rs2;
@@ -2649,12 +2651,15 @@ public class KomodoTeiidService extends KomodoService {
                             String schemaName = rs2.getString(1);
                             schemaList.add(schemaName);
                         }
+                        Collections.sort(schemaList, String.CASE_INSENSITIVE_ORDER);
                         catalogSchemaMap.put(catlg, schemaList);
                         rs2.close();
                     }
 
                     // Generate the infos
-                    for(String catName : catalogSchemaMap.keySet()) {
+                    List<String> catNames = new ArrayList<String>(catalogSchemaMap.keySet());
+                    Collections.sort(catNames, String.CASE_INSENSITIVE_ORDER);
+                    for(String catName : catNames) {
                         RestTeiidDataSourceJdbcCatalogSchemaInfo info = new RestTeiidDataSourceJdbcCatalogSchemaInfo();
                         info.setItemName(catName);
                         info.setItemType(CATALOG);
@@ -2670,6 +2675,7 @@ public class KomodoTeiidService extends KomodoService {
                         allCats.add(catalog);
                     }
                     resultSet.close();
+                    Collections.sort(allCats, String.CASE_INSENSITIVE_ORDER);
                     // Create infos
                     for(String cat : allCats) {
                         RestTeiidDataSourceJdbcCatalogSchemaInfo info = new RestTeiidDataSourceJdbcCatalogSchemaInfo();
@@ -2687,6 +2693,7 @@ public class KomodoTeiidService extends KomodoService {
                     }
                     resultSet.close();
 
+                    Collections.sort(allSchemas, String.CASE_INSENSITIVE_ORDER);
                     for(String sch : allSchemas) {
                         RestTeiidDataSourceJdbcCatalogSchemaInfo info = new RestTeiidDataSourceJdbcCatalogSchemaInfo();
                         info.setItemName(sch);

--- a/server/komodo-rest/src/main/resources/defaultTranslatorMappings.xml
+++ b/server/komodo-rest/src/main/resources/defaultTranslatorMappings.xml
@@ -36,6 +36,8 @@
     <translator driver="osisoft-pi">osisoft-pi</translator>
     <translator driver="mysql">mysql</translator>
     <translator driver="mysql5">mysql5</translator>
+    <translator driver="teiid">teiid</translator>
+    <translator driver="teiid-local">teiid</translator>
     
     <!-- TODO RA-->
     <!--

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
@@ -582,5 +582,66 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
         assertTrue(entity.contains("infoType"));
         assertTrue(entity.contains("CREATE VIEW MyDataServiceView"));
     }
+    
+    @Test
+    public void shouldFailDdlValidationNoDDL() throws Exception {
+        URI dataservicesUri = _uriBuilder.workspaceDataservicesUri();
+        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.VALIDATE_DDL).build();
+
+        // Required param (viewDdl).
+        KomodoDataserviceUpdateAttributes updateAttr = new KomodoDataserviceUpdateAttributes();
+        updateAttr.setViewDdl("");
+
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, updateAttr);
+
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
+        assertTrue(entity.contains("No DDL to validate"));
+    }
+    
+    @Test
+    public void shouldFailDdlValidationUnknownToken() throws Exception {
+        URI dataservicesUri = _uriBuilder.workspaceDataservicesUri();
+        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.VALIDATE_DDL).build();
+
+        // Required param (viewDdl).
+        KomodoDataserviceUpdateAttributes updateAttr = new KomodoDataserviceUpdateAttributes();
+        updateAttr.setViewDdl("CRE");
+
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, updateAttr);
+
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
+        assertTrue(entity.contains("Check your DDL for completeness"));
+    }
+    
+    @Test
+    public void shouldValidateDdl() throws Exception {
+        String VALID_DDL = "CREATE VIEW MyView (RowId integer PRIMARY KEY, Col1 string, Col2 string) AS \n"
+        + "SELECT ROW_NUMBER() OVER (ORDER BY Col1), Col1, Col2 \n"
+        + "FROM MyTable;";
+        
+        URI dataservicesUri = _uriBuilder.workspaceDataservicesUri();
+        URI uri = UriBuilder.fromUri(dataservicesUri).path(V1Constants.VALIDATE_DDL).build();
+
+        // Required param (viewDdl).
+        KomodoDataserviceUpdateAttributes updateAttr = new KomodoDataserviceUpdateAttributes();
+        updateAttr.setViewDdl(VALID_DDL);
+
+        ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
+        addJsonConsumeContentType(request);
+        addBody(request, updateAttr);
+
+        ClientResponse<String> response = request.post(String.class);
+
+        final String entity = response.getEntity();
+        assertTrue(entity.contains("Success"));
+    }
 
 }


### PR DESCRIPTION
- Added a service method to KomodoDataserviceService - takes ddl and runs the parser on it.  The parsing status is returned.
- minor change to KomodoTeiidService to sort jdbc schema results into alphabetical order
- added teiid translator to the default translator mappings file.