### PR TITLE
TEIIDTOOLS-143 Validation and minor changes

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -1723,6 +1723,7 @@ public final class KomodoDataserviceService extends KomodoService {
             }
             
             // Create the view infos for the left and right tables
+            int nTable = 0;
             for (String viewTable : tableSourceVdbMap.keySet()) {
                 RestDataserviceViewInfo viewInfo = new RestDataserviceViewInfo();
                 
@@ -1731,22 +1732,29 @@ public final class KomodoDataserviceService extends KomodoService {
                     viewInfo.setInfoType(RestDataserviceViewInfo.LH_TABLE_INFO);
                 } else if(viewTable.equals(rightTableName)){
                     viewInfo.setInfoType(RestDataserviceViewInfo.RH_TABLE_INFO);
+                } else if(leftTableName.equals(StringConstants.EMPTY_STRING) && nTable==0) {
+                    viewInfo.setInfoType(RestDataserviceViewInfo.LH_TABLE_INFO);
+                } else if(rightTableName.equals(StringConstants.EMPTY_STRING) && nTable==1) {
+                    viewInfo.setInfoType(RestDataserviceViewInfo.RH_TABLE_INFO);
                 }
                 // Source VDB and table
                 viewInfo.setSourceVdbName(tableSourceVdbMap.get(viewTable));
                 viewInfo.setTableName(viewTable);
                 
                 String mapKey = viewTable;
-                if(viewInfo.getInfoType().equals(RestDataserviceViewInfo.LH_TABLE_INFO) && leftTableAliased) {
-                    mapKey = mapKey+StringConstants.SPACE+SQLConstants.Reserved.AS+StringConstants.SPACE+LH_TABLE_ALIAS;
-                } else if(viewInfo.getInfoType().equals(RestDataserviceViewInfo.RH_TABLE_INFO) && rightTableAliased) {
-                    mapKey = mapKey+StringConstants.SPACE+SQLConstants.Reserved.AS+StringConstants.SPACE+RH_TABLE_ALIAS;
-                } 
+                if(viewInfo.getInfoType()!=null) {
+                    if(viewInfo.getInfoType().equals(RestDataserviceViewInfo.LH_TABLE_INFO) && leftTableAliased) {
+                        mapKey = mapKey+StringConstants.SPACE+SQLConstants.Reserved.AS+StringConstants.SPACE+LH_TABLE_ALIAS;
+                    } else if(viewInfo.getInfoType().equals(RestDataserviceViewInfo.RH_TABLE_INFO) && rightTableAliased) {
+                        mapKey = mapKey+StringConstants.SPACE+SQLConstants.Reserved.AS+StringConstants.SPACE+RH_TABLE_ALIAS;
+                    } 
+                }
                 List<String> colsForTable = tableColumnMap.get(mapKey);
                 if(colsForTable!=null && !colsForTable.isEmpty()) {
                     viewInfo.setColumnNames(colsForTable);
                 }
                 viewInfos.add(viewInfo);
+                nTable++;
             }
             
             // Get criteria info for the view - if two tables were found

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
@@ -31,6 +31,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -2628,6 +2629,7 @@ public class KomodoTeiidService extends KomodoService {
                     rs.close();
 
                     // Create mapping of catalog to schema list
+                    Collections.sort(allCats, String.CASE_INSENSITIVE_ORDER);
                     Map<String,List<String>> catalogSchemaMap = new HashMap<String, List<String>>();
                     for(String catlg : allCats) {
                         ResultSet rs2;
@@ -2649,12 +2651,15 @@ public class KomodoTeiidService extends KomodoService {
                             String schemaName = rs2.getString(1);
                             schemaList.add(schemaName);
                         }
+                        Collections.sort(schemaList, String.CASE_INSENSITIVE_ORDER);
                         catalogSchemaMap.put(catlg, schemaList);
                         rs2.close();
                     }
 
                     // Generate the infos
-                    for(String catName : catalogSchemaMap.keySet()) {
+                    List<String> catNames = new ArrayList<String>(catalogSchemaMap.keySet());
+                    Collections.sort(catNames, String.CASE_INSENSITIVE_ORDER);
+                    for(String catName : catNames) {
                         RestTeiidDataSourceJdbcCatalogSchemaInfo info = new RestTeiidDataSourceJdbcCatalogSchemaInfo();
                         info.setItemName(catName);
                         info.setItemType(CATALOG);
@@ -2670,6 +2675,7 @@ public class KomodoTeiidService extends KomodoService {
                         allCats.add(catalog);
                     }
                     resultSet.close();
+                    Collections.sort(allCats, String.CASE_INSENSITIVE_ORDER);
                     // Create infos
                     for(String cat : allCats) {
                         RestTeiidDataSourceJdbcCatalogSchemaInfo info = new RestTeiidDataSourceJdbcCatalogSchemaInfo();
@@ -2687,6 +2693,7 @@ public class KomodoTeiidService extends KomodoService {
                     }
                     resultSet.close();
 
+                    Collections.sort(allSchemas, String.CASE_INSENSITIVE_ORDER);
                     for(String sch : allSchemas) {
                         RestTeiidDataSourceJdbcCatalogSchemaInfo info = new RestTeiidDataSourceJdbcCatalogSchemaInfo();
                         info.setItemName(sch);

--- a/server/komodo-rest/src/main/resources/defaultTranslatorMappings.xml
+++ b/server/komodo-rest/src/main/resources/defaultTranslatorMappings.xml
@@ -36,6 +36,8 @@
     <translator driver="osisoft-pi">osisoft-pi</translator>
     <translator driver="mysql">mysql</translator>
     <translator driver="mysql5">mysql5</translator>
+    <translator driver="teiid">teiid</translator>
+    <translator driver="teiid-local">teiid</translator>
     
     <!-- TODO RA-->
     <!--


### PR DESCRIPTION
- KomodoDataserviceService - change in getServiceViewInfoForDataService. When tables cannot be determined from the sql - still provides the identified lh and rh source tables.
- KomodoTeiidService - now alphabetically orders the returned jdbc catalog / schema info using in dsb filtering.
- added teiid and teiid-local drivers to the default translator mappings file