### PR TITLE
TEIIDTOOLS-60 Removes modelDefinition filter from ModelImpl

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/model/internal/ModelImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/model/internal/ModelImpl.java
@@ -24,9 +24,7 @@ package org.komodo.relational.model.internal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import org.komodo.core.KomodoLexicon;
 import org.komodo.modeshape.visitor.DdlNodeVisitor;
-import org.komodo.relational.ExcludeQNamesFilter;
 import org.komodo.relational.Messages;
 import org.komodo.relational.Messages.Relational;
 import org.komodo.relational.RelationalModelFactory;
@@ -76,11 +74,6 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
                                                                       VirtualProcedure.IDENTIFIER };
 
     /**
-     * A filter to exclude specific properties.
-     */
-    private static final Filter PROPS_FILTER = new ExcludeQNamesFilter( KomodoLexicon.VdbModel.MODEL_DEFINITION );
-
-    /**
      * @param uow
      *        the transaction (cannot be <code>null</code> or have a state that is not {@link State#NOT_STARTED})
      * @param repository
@@ -94,12 +87,6 @@ public final class ModelImpl extends RelationalObjectImpl implements Model {
                       final Repository repository,
                       final String workspacePath ) throws KException {
         super( uow, repository, workspacePath );
-
-        // add in filter to hide the model definition type
-        final Filter[] updatedFilters = new Filter[ DEFAULT_FILTERS.length + 1 ];
-        System.arraycopy( DEFAULT_FILTERS, 0, updatedFilters, 0, DEFAULT_FILTERS.length );
-        updatedFilters[ DEFAULT_FILTERS.length ] = PROPS_FILTER;
-        setFilters( updatedFilters );
     }
 
     @Override

--- a/komodo-relational/src/test/java/org/komodo/relational/model/internal/ModelImplTest.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/model/internal/ModelImplTest.java
@@ -630,6 +630,15 @@ public final class ModelImplTest extends RelationalModelTest {
         this.model.setModelDefinition( getTransaction(), "blah blah blah" );
         assertThat( this.model.getMetadataType( getTransaction() ), is( Model.DEFAULT_METADATA_TYPE ) );
     }
+    
+    @Test
+    public void shouldSetModelDefinition() throws Exception {
+        this.model.setModelDefinition( getTransaction(), "CREATE VIEW Tweet AS select * FROM twitterview.getTweets;" );
+        commit();
+        
+        String mDefn = this.model.getModelDefinition(getTransaction());
+        assertThat( mDefn, is( "CREATE VIEW Tweet AS select * FROM twitterview.getTweets;" ) );
+    }
 
     @Test
     public void shouldSetModelType() throws Exception {

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestVdbModel.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/RestVdbModel.java
@@ -176,7 +176,7 @@ public final class RestVdbModel extends RestBasicEntity {
      */
     public String getDdl() {
         Object ddl = tuples.get(JsonConstants.DDL_ATTRIBUTE);
-        return ddl != null ? ddl.toString() : null;
+        return ddl != null ? ddl.toString() : EMPTY_STRING;
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoTeiidService.java
@@ -1117,13 +1117,16 @@ public class KomodoTeiidService extends KomodoService {
                 vdb = wkspMgr.resolve( uow, kobject, Vdb.class );
             }
 
-            // Check for existence of Model and replace if found
+            // Check for existence of Model.  If it exists, reset its modelDefinition.  If doesnt exist, create a new model.
             Model[] models = vdb.getModels(uow, modelName);
-            for(Model model : models) {
-                model.remove(uow);
+            Model modelToUpdate = null;
+            if(models.length>0) {
+                modelToUpdate = models[0];
             }
-            Model newModel = vdb.addModel(uow, modelName);
-            newModel.setModelDefinition(uow, modelDdl);
+            if(modelToUpdate==null) {
+                modelToUpdate = vdb.addModel(uow, modelName);
+            }
+            modelToUpdate.setModelDefinition(uow, modelDdl);
 
             KomodoStatusObject kso = new KomodoStatusObject("Update Vdb Status"); //$NON-NLS-1$
             kso.addAttribute(vdbName, "Successfully updated"); //$NON-NLS-1$


### PR DESCRIPTION
Removes the property filtering of 'modelDefinition' property for Models in support of TEIIDTOOLS-60.
- previously 'getModelDefinition' would always return empty string.  After removal of the filter 'getModelDefinition' now returns the DDL that was last set.
- Added corresponding test case to ModelImpl
- KomodoTeiidService.updateModelFromDdl - model is added if it does not exist, otherwise existing models modelDefinition is reset