### PR TITLE
Changes rest service terminology to use 'connection'

### DIFF
--- a/komodo-relational/src/main/java/org/komodo/relational/teiid/CachedTeiid.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/teiid/CachedTeiid.java
@@ -52,9 +52,9 @@ public interface CachedTeiid extends RelationalObject, TeiidArchetype {
      */
     String VDBS_FOLDER = "vdbs";  //$NON-NLS-1$
     /**
-     * The folder under which all cached datasources will be placed
+     * The folder under which all cached connections will be placed
      */
-    String DATA_SOURCES_FOLDER = "datasources";  //$NON-NLS-1$
+    String CONNECTIONS_FOLDER = "connections";  //$NON-NLS-1$
     /**
      * The folder under which all cached translators will be placed
      */

--- a/komodo-relational/src/main/java/org/komodo/relational/teiid/internal/CachedTeiidImpl.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/teiid/internal/CachedTeiidImpl.java
@@ -121,7 +121,7 @@ public class CachedTeiidImpl extends RelationalObjectImpl implements CachedTeiid
         
         // Add child folders which will contain the various types
         this.addChild(transaction, CachedTeiid.VDBS_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
-        this.addChild(transaction, CachedTeiid.DATA_SOURCES_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
+        this.addChild(transaction, CachedTeiid.CONNECTIONS_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
         this.addChild(transaction, CachedTeiid.TRANSLATORS_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
         this.addChild(transaction, CachedTeiid.DRIVERS_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
     }
@@ -508,10 +508,10 @@ public class CachedTeiidImpl extends RelationalObjectImpl implements CachedTeiid
         ArgCheck.isNotNull(transaction, "transaction"); //$NON-NLS-1$
         ArgCheck.isTrue((transaction.getState() == State.NOT_STARTED), "transaction state is not NOT_STARTED"); //$NON-NLS-1$
 
-        if(!super.hasChild(transaction, CachedTeiid.DATA_SOURCES_FOLDER, KomodoLexicon.Folder.NODE_TYPE)) {
+        if(!super.hasChild(transaction, CachedTeiid.CONNECTIONS_FOLDER, KomodoLexicon.Folder.NODE_TYPE)) {
             return new Datasource[0];
         }
-        KomodoObject folderNode = super.getChild(transaction, CachedTeiid.DATA_SOURCES_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
+        KomodoObject folderNode = super.getChild(transaction, CachedTeiid.CONNECTIONS_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
 
         final List<Datasource> result = new ArrayList<Datasource>();
         for (final KomodoObject kobject : folderNode.getChildrenOfType(transaction, DataVirtLexicon.Connection.NODE_TYPE, namePatterns)) {
@@ -531,10 +531,10 @@ public class CachedTeiidImpl extends RelationalObjectImpl implements CachedTeiid
         ArgCheck.isNotNull(transaction, "transaction"); //$NON-NLS-1$
         ArgCheck.isTrue((transaction.getState() == State.NOT_STARTED), "transaction state is not NOT_STARTED"); //$NON-NLS-1$
 
-        if(!super.hasChild(transaction, CachedTeiid.DATA_SOURCES_FOLDER, KomodoLexicon.Folder.NODE_TYPE)) {
+        if(!super.hasChild(transaction, CachedTeiid.CONNECTIONS_FOLDER, KomodoLexicon.Folder.NODE_TYPE)) {
             return null;
         }
-        KomodoObject folderNode = super.getChild(transaction, CachedTeiid.DATA_SOURCES_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
+        KomodoObject folderNode = super.getChild(transaction, CachedTeiid.CONNECTIONS_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
 
         if (folderNode.hasChild(transaction, name, DataVirtLexicon.Connection.NODE_TYPE)) {
             KomodoObject kobject = folderNode.getChild(transaction, name, DataVirtLexicon.Connection.NODE_TYPE);
@@ -688,10 +688,10 @@ public class CachedTeiidImpl extends RelationalObjectImpl implements CachedTeiid
             throw new KException(ex);
         }
         
-        if(!super.hasChild(transaction, CachedTeiid.DATA_SOURCES_FOLDER, KomodoLexicon.Folder.NODE_TYPE)) {
+        if(!super.hasChild(transaction, CachedTeiid.CONNECTIONS_FOLDER, KomodoLexicon.Folder.NODE_TYPE)) {
             return;
         }
-        KomodoObject folderNode = super.getChild(transaction, CachedTeiid.DATA_SOURCES_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
+        KomodoObject folderNode = super.getChild(transaction, CachedTeiid.CONNECTIONS_FOLDER, KomodoLexicon.Folder.NODE_TYPE);
 
         // No names supplied, remove all from the cache then refresh all
         if( dataSourceNames==null || dataSourceNames.length==0 ) {

--- a/server/komodo-rest/src/integration-test/java/org/komodo/rest/service/IT_KomodoTeiidServiceGetTests.java
+++ b/server/komodo-rest/src/integration-test/java/org/komodo/rest/service/IT_KomodoTeiidServiceGetTests.java
@@ -368,10 +368,10 @@ public final class IT_KomodoTeiidServiceGetTests extends AbstractKomodoTeiidServ
     }
 
     @Test
-    public void shouldGetDataSources() throws Exception {
+    public void shouldGetConnections() throws Exception {
         URI uri = UriBuilder.fromUri(_uriBuilder.baseUri())
                                           .path(V1Constants.TEIID_SEGMENT)
-                                          .path(V1Constants.DATA_SOURCES_SEGMENT)
+                                          .path(V1Constants.CONNECTIONS_SEGMENT)
                                           .build();
 
         ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -58,8 +58,8 @@ import org.komodo.rest.cors.KCorsFactory;
 import org.komodo.rest.cors.KCorsHandler;
 import org.komodo.rest.cors.OptionsExceptionMapper;
 import org.komodo.rest.json.JsonConstants;
+import org.komodo.rest.service.KomodoConnectionService;
 import org.komodo.rest.service.KomodoDataserviceService;
-import org.komodo.rest.service.KomodoDatasourceService;
 import org.komodo.rest.service.KomodoDriverService;
 import org.komodo.rest.service.KomodoImportExportService;
 import org.komodo.rest.service.KomodoSearchService;
@@ -264,9 +264,19 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
         String SERVICE_VIEW_INFO = "serviceViewInfo"; //$NON-NLS-1$
 
         /**
-         * The name of the URI path segment for a Dataservice's connections in the Komodo workspace.
+         * The name of the URI path segment for connections.
          */
         String CONNECTIONS_SEGMENT = "connections"; //$NON-NLS-1$
+
+        /**
+         * The name of the URI path segment for a connection.
+         */
+        String CONNECTION_SEGMENT = "connection"; //$NON-NLS-1$
+
+        /**
+         * Placeholder added to an URI to allow a specific connection id
+         */
+        String CONNECTION_PLACEHOLDER = "{connectionName}"; //$NON-NLS-1$
 
         /**
          * The name of the URI path segment for a setting a dataservice's service vdb for single table view
@@ -293,21 +303,6 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
          */
         String CRITERIA_FOR_JOIN_TABLES = "CriteriaForJoinTables"; //$NON-NLS-1$
         
-        /**
-         * The name of the URI path segment for the collection of Datasources in the Komodo workspace.
-         */
-        String DATA_SOURCES_SEGMENT = "datasources"; //$NON-NLS-1$
-
-        /**
-         * The name of the URI path segment for a Datasource in the Komodo workspace.
-         */
-        String DATA_SOURCE_SEGMENT = "datasource"; //$NON-NLS-1$
-
-        /**
-         * Placeholder added to an URI to allow a specific data source id
-         */
-        String DATA_SOURCE_PLACEHOLDER = "{datasourceName}"; //$NON-NLS-1$
-
         /**
          * The name of the URI path segment for the collection of Drivers in the Komodo workspace.
          */
@@ -589,7 +584,7 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
         objs.add( new KomodoExceptionMapper() );
         objs.add( new KomodoUtilService( this.kengine ) );
         objs.add( new KomodoDataserviceService( this.kengine ) );
-        objs.add( new KomodoDatasourceService( this.kengine ) );
+        objs.add( new KomodoConnectionService( this.kengine ) );
         objs.add( new KomodoDriverService( this.kengine ) );
         objs.add( new KomodoVdbService( this.kengine ) );
         objs.add( new KomodoSearchService( this.kengine ));

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoRestUriBuilder.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/KomodoRestUriBuilder.java
@@ -302,12 +302,12 @@ public final class KomodoRestUriBuilder implements KomodoRestV1Application.V1Con
     }
 
     /**
-     * @return the URI to use when requesting a collection of Datasources in the workspace (never <code>null</code>)
+     * @return the URI to use when requesting a collection of Connections in the workspace (never <code>null</code>)
      */
-    public URI workspaceDatasourcesUri() {
+    public URI workspaceConnectionsUri() {
         return UriBuilder.fromUri(this.baseUri)
                                    .path(WORKSPACE_SEGMENT)
-                                   .path(DATA_SOURCES_SEGMENT).build();
+                                   .path(CONNECTIONS_SEGMENT).build();
     }
 
     /**
@@ -902,7 +902,7 @@ public final class KomodoRestUriBuilder implements KomodoRestV1Application.V1Con
             return cachedTeiidUri(parent.getName(uow));
         }
 
-        return workspaceDatasourcesUri();
+        return workspaceConnectionsUri();
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoConnectionService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoConnectionService.java
@@ -63,12 +63,12 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
 /**
- * A Komodo REST service for obtaining Datasource information from the workspace.
+ * A Komodo REST service for obtaining Connection information from the workspace.
  */
 @Path(V1Constants.WORKSPACE_SEGMENT + StringConstants.FORWARD_SLASH +
-           V1Constants.DATA_SOURCES_SEGMENT)
-@Api(tags = {V1Constants.DATA_SOURCES_SEGMENT})
-public final class KomodoDatasourceService extends KomodoService {
+           V1Constants.CONNECTIONS_SEGMENT)
+@Api(tags = {V1Constants.CONNECTIONS_SEGMENT})
+public final class KomodoConnectionService extends KomodoService {
 
     private static final int ALL_AVAILABLE = -1;
 
@@ -78,28 +78,28 @@ public final class KomodoDatasourceService extends KomodoService {
      * @throws WebApplicationException
      *         if there is a problem obtaining the {@link WorkspaceManager workspace manager}
      */
-    public KomodoDatasourceService( final KEngine engine ) throws WebApplicationException {
+    public KomodoConnectionService( final KEngine engine ) throws WebApplicationException {
         super( engine );
     }
 
     /**
-     * Get the Datasources from the komodo repository
+     * Get the Connections from the komodo repository
      * @param headers
      *        the request headers (never <code>null</code>)
      * @param uriInfo
      *        the request URI information (never <code>null</code>)
-     * @return a JSON document representing all the Datasources in the Komodo workspace (never <code>null</code>)
+     * @return a JSON document representing all the Connections in the Komodo workspace (never <code>null</code>)
      * @throws KomodoRestException
-     *         if there is a problem constructing the Datasource JSON document
+     *         if there is a problem constructing the Connection JSON document
      */
     @GET
     @Produces( MediaType.APPLICATION_JSON )
-    @ApiOperation(value = "Return the collection of data sources",
+    @ApiOperation(value = "Return the collection of connections",
                             response = RestDataSource[].class)
     @ApiResponses(value = {
         @ApiResponse(code = 403, message = "An error has occurred.")
     })
-    public Response getDatasources( final @Context HttpHeaders headers,
+    public Response getConnections( final @Context HttpHeaders headers,
                                     final @Context UriInfo uriInfo ) throws KomodoRestException {
 
         SecurityPrincipal principal = checkSecurityContext(headers);
@@ -113,12 +113,12 @@ public final class KomodoDatasourceService extends KomodoService {
             final String searchPattern = uriInfo.getQueryParameters().getFirst( QueryParamKeys.PATTERN );
 
             // find Data sources
-            uow = createTransaction(principal, "getDatasources", true ); //$NON-NLS-1$
+            uow = createTransaction(principal, "getConnections", true ); //$NON-NLS-1$
             Datasource[] dataSources = null;
 
             if ( StringUtils.isBlank( searchPattern ) ) {
                 dataSources = getWorkspaceManager(uow).findDatasources( uow );
-                LOGGER.debug( "getDatasources:found '{0}' Datasources", dataSources.length ); //$NON-NLS-1$
+                LOGGER.debug( "getConnections:found '{0}' Datasources", dataSources.length ); //$NON-NLS-1$
             } else {
                 final String[] datasourcePaths = getWorkspaceManager(uow).findByType( uow, DataVirtLexicon.Connection.NODE_TYPE, null, searchPattern, false );
 
@@ -132,7 +132,7 @@ public final class KomodoDatasourceService extends KomodoService {
                         dataSources[ i++ ] = getWorkspaceManager(uow).resolve( uow, new ObjectImpl( getWorkspaceManager(uow).getRepository(), path, 0 ), Datasource.class );
                     }
 
-                    LOGGER.debug( "getDatasources:found '{0}' DataSources using pattern '{1}'", dataSources.length, searchPattern ); //$NON-NLS-1$
+                    LOGGER.debug( "getConnections:found '{0}' DataSources using pattern '{1}'", dataSources.length, searchPattern ); //$NON-NLS-1$
                 }
             }
 
@@ -183,7 +183,7 @@ public final class KomodoDatasourceService extends KomodoService {
                     if ( ( size == ALL_AVAILABLE ) || ( entities.size() < size ) ) {                        
                         RestDataSource entity = entityFactory.create(dataSource, uriInfo.getBaseUri(), uow, properties);
                         entities.add(entity);
-                        LOGGER.debug("getDatasources:Datasource '{0}' entity was constructed", dataSource.getName(uow)); //$NON-NLS-1$
+                        LOGGER.debug("getConnections:Datasource '{0}' entity was constructed", dataSource.getName(uow)); //$NON-NLS-1$
                     } else {
                         break;
                     }
@@ -213,28 +213,28 @@ public final class KomodoDatasourceService extends KomodoService {
      *        the request headers (never <code>null</code>)
      * @param uriInfo
      *        the request URI information (never <code>null</code>)
-     * @param datasourceName
-     *        the id of the Datasource being retrieved (cannot be empty)
-     * @return the JSON representation of the Datasource (never <code>null</code>)
+     * @param connectionName
+     *        the id of the Connection being retrieved (cannot be empty)
+     * @return the JSON representation of the Connection (never <code>null</code>)
      * @throws KomodoRestException
-     *         if there is a problem finding the specified workspace Datasource or constructing the JSON representation
+     *         if there is a problem finding the specified workspace Connection or constructing the JSON representation
      */
     @GET
-    @Path( V1Constants.DATA_SOURCE_PLACEHOLDER )
+    @Path( V1Constants.CONNECTION_PLACEHOLDER )
     @Produces( { MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML } )
-    @ApiOperation(value = "Find datasource by name", response = RestDataSource.class)
+    @ApiOperation(value = "Find connection by name", response = RestDataSource.class)
     @ApiResponses(value = {
-        @ApiResponse(code = 404, message = "No Datasource could be found with name"),
+        @ApiResponse(code = 404, message = "No Connection could be found with name"),
         @ApiResponse(code = 406, message = "Only JSON or XML is returned by this operation"),
         @ApiResponse(code = 403, message = "An error has occurred.")
     })
-    public Response getDatasource( final @Context HttpHeaders headers,
-                                    final @Context UriInfo uriInfo,
-                                    @ApiParam(
-                                              value = "Name of the datasource",
-                                              required = true
-                                    )
-                                    final @PathParam( "datasourceName" ) String datasourceName) throws KomodoRestException {
+    public Response getConnection( final @Context HttpHeaders headers,
+                                   final @Context UriInfo uriInfo,
+                                   @ApiParam(
+                                             value = "Name of the connection",
+                                             required = true
+                                   )
+                                   final @PathParam( "connectionName" ) String connectionName) throws KomodoRestException {
 
         SecurityPrincipal principal = checkSecurityContext(headers);
         if (principal.hasErrorResponse())
@@ -244,15 +244,15 @@ public final class KomodoDatasourceService extends KomodoService {
         UnitOfWork uow = null;
 
         try {
-            uow = createTransaction(principal, "getDatasource", true ); //$NON-NLS-1$
+            uow = createTransaction(principal, "getConnection", true ); //$NON-NLS-1$
 
-            Datasource datasource = findDatasource(uow, datasourceName);
+            Datasource datasource = findDatasource(uow, connectionName);
             if (datasource == null)
-                return commitNoDatasourceFound(uow, mediaTypes, datasourceName);
+                return commitNoDatasourceFound(uow, mediaTypes, connectionName);
 
             KomodoProperties properties = new KomodoProperties();
             final RestDataSource restDatasource = entityFactory.create(datasource, uriInfo.getBaseUri(), uow, properties);
-            LOGGER.debug("getVdb:VDB '{0}' entity was constructed", datasource.getName(uow)); //$NON-NLS-1$
+            LOGGER.debug("getConnection:Datasource '{0}' entity was constructed", datasource.getName(uow)); //$NON-NLS-1$
             return commit( uow, mediaTypes, restDatasource );
 
         } catch ( final Exception e ) {
@@ -264,53 +264,53 @@ public final class KomodoDatasourceService extends KomodoService {
                 throw ( KomodoRestException )e;
             }
 
-            return createErrorResponseWithForbidden(mediaTypes, e, RelationalMessages.Error.DATASOURCE_SERVICE_GET_DATASOURCE_ERROR, datasourceName);
+            return createErrorResponseWithForbidden(mediaTypes, e, RelationalMessages.Error.DATASOURCE_SERVICE_GET_DATASOURCE_ERROR, connectionName);
         }
     }
 
     /**
-     * Create a new DataSource in the komodo repository
+     * Create a new Connection in the komodo repository
      * @param headers
      *        the request headers (never <code>null</code>)
      * @param uriInfo
      *        the request URI information (never <code>null</code>)
-     * @param datasourceName
-     *        the datasource name (cannot be empty)
-     * @param datasourceJson
-     *        the datasource JSON representation (cannot be <code>null</code>)
-     * @return a JSON representation of the new datasource (never <code>null</code>)
+     * @param connectionName
+     *        the connection name (cannot be empty)
+     * @param connectionJson
+     *        the connection JSON representation (cannot be <code>null</code>)
+     * @return a JSON representation of the new connection (never <code>null</code>)
      * @throws KomodoRestException
-     *         if there is an error creating the DataSource
+     *         if there is an error creating the Connection
      */
     @POST
-    @Path( StringConstants.FORWARD_SLASH + V1Constants.DATA_SOURCE_PLACEHOLDER )
+    @Path( StringConstants.FORWARD_SLASH + V1Constants.CONNECTION_PLACEHOLDER )
     @Produces( MediaType.APPLICATION_JSON )
-    @ApiOperation(value = "Create a datasource in the workspace")
+    @ApiOperation(value = "Create a connection in the workspace")
     @ApiResponses(value = {
         @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
         @ApiResponse(code = 403, message = "An error has occurred.")
     })
-    public Response createDatasource( final @Context HttpHeaders headers,
-                                       final @Context UriInfo uriInfo,
-                                       @ApiParam(
-                                                 value = "Name of the datasource",
-                                                 required = true
-                                       )
-                                       final @PathParam( "datasourceName" ) String datasourceName,
-                                       @ApiParam(
-                                                 value = "" + 
-                                                         "JSON of the properties of the new data source:<br>" +
-                                                         OPEN_PRE_TAG +
-                                                         OPEN_BRACE + BR +
-                                                         NBSP + "keng\\_\\_id: \"id of the data source\"" + BR +
-                                                         NBSP + "dv\\_\\_driverName: \"name of the driver, eg. mysql\"" + BR +
-                                                         NBSP + "dv\\_\\_jndiName: \"the jndi name of the data source\"" + BR +
-                                                         NBSP + "dv\\_\\_type: \"true if jdbc, otherwise false\"" + BR +
-                                                         CLOSE_BRACE +
-                                                         CLOSE_PRE_TAG,
-                                                 required = true
-                                       )
-                                       final String datasourceJson) throws KomodoRestException {
+    public Response createConnection( final @Context HttpHeaders headers,
+                                      final @Context UriInfo uriInfo,
+                                      @ApiParam(
+                                                value = "Name of the connection",
+                                                required = true
+                                      )
+                                      final @PathParam( "connectionName" ) String connectionName,
+                                      @ApiParam(
+                                                value = "" + 
+                                                        "JSON of the properties of the new connection:<br>" +
+                                                        OPEN_PRE_TAG +
+                                                        OPEN_BRACE + BR +
+                                                        NBSP + "keng\\_\\_id: \"id of the connection\"" + BR +
+                                                        NBSP + "dv\\_\\_driverName: \"name of the driver, eg. mysql\"" + BR +
+                                                        NBSP + "dv\\_\\_jndiName: \"the jndi name of the connection\"" + BR +
+                                                        NBSP + "dv\\_\\_type: \"true if jdbc, otherwise false\"" + BR +
+                                                        CLOSE_BRACE +
+                                                        CLOSE_PRE_TAG,
+                                                required = true
+                                      )
+                                      final String connectionJson) throws KomodoRestException {
 
         SecurityPrincipal principal = checkSecurityContext(headers);
         if (principal.hasErrorResponse())
@@ -320,12 +320,12 @@ public final class KomodoDatasourceService extends KomodoService {
         if (! isAcceptable(mediaTypes, MediaType.APPLICATION_JSON_TYPE))
             return notAcceptableMediaTypesBuilder().build();
 
-        // Error if the datasource name is missing
-        if (StringUtils.isBlank( datasourceName )) {
+        // Error if the connection name is missing
+        if (StringUtils.isBlank( connectionName )) {
             return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_CREATE_MISSING_NAME);
         }
 
-        final RestDataSource restDatasource = KomodoJsonMarshaller.unmarshall( datasourceJson, RestDataSource.class );
+        final RestDataSource restDatasource = KomodoJsonMarshaller.unmarshall( connectionJson, RestDataSource.class );
         final String jsonDatasourceName = restDatasource.getId();
         // Error if the name is missing from the supplied json body
         if ( StringUtils.isBlank( jsonDatasourceName ) ) {
@@ -333,18 +333,18 @@ public final class KomodoDatasourceService extends KomodoService {
         }
 
         // Error if the name parameter is different than JSON name
-        final boolean namesMatch = datasourceName.equals( jsonDatasourceName );
+        final boolean namesMatch = connectionName.equals( jsonDatasourceName );
         if ( !namesMatch ) {
-            return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_SOURCE_NAME_ERROR, datasourceName, jsonDatasourceName);
+            return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_SOURCE_NAME_ERROR, connectionName, jsonDatasourceName);
         }
 
         UnitOfWork uow = null;
 
         try {
-            uow = createTransaction(principal, "createDatasource", false ); //$NON-NLS-1$
+            uow = createTransaction(principal, "createConnection", false ); //$NON-NLS-1$
 
-            // Error if the repo already contains a datasource with the supplied name.
-            if ( getWorkspaceManager(uow).hasChild( uow, datasourceName ) ) {
+            // Error if the repo already contains a connection with the supplied name.
+            if ( getWorkspaceManager(uow).hasChild( uow, connectionName ) ) {
                 return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_CREATE_ALREADY_EXISTS);
             }
 
@@ -360,44 +360,44 @@ public final class KomodoDatasourceService extends KomodoService {
                 throw (KomodoRestException)e;
             }
 
-            return createErrorResponseWithForbidden(mediaTypes, e, RelationalMessages.Error.DATASOURCE_SERVICE_CREATE_DATASOURCE_ERROR, datasourceName);
+            return createErrorResponseWithForbidden(mediaTypes, e, RelationalMessages.Error.DATASOURCE_SERVICE_CREATE_DATASOURCE_ERROR, connectionName);
         }
     }
 
     /**
-     * Clone a DataSource in the komodo repository
+     * Clone a Connection in the komodo repository
      * @param headers
      *        the request headers (never <code>null</code>)
      * @param uriInfo
      *        the request URI information (never <code>null</code>)
-     * @param datasourceName
-     *        the datasource name (cannot be empty)
-     * @param newDatasourceName
-     *        the new datasource name (cannot be empty)
-     * @return a JSON representation of the new datasource (never <code>null</code>)
+     * @param connectionName
+     *        the connection name (cannot be empty)
+     * @param newConnectionName
+     *        the new connection name (cannot be empty)
+     * @return a JSON representation of the new connection (never <code>null</code>)
      * @throws KomodoRestException
-     *         if there is an error creating the DataSource
+     *         if there is an error creating the Connection
      */
     @POST
-    @Path( StringConstants.FORWARD_SLASH + V1Constants.CLONE_SEGMENT + StringConstants.FORWARD_SLASH + V1Constants.DATA_SOURCE_PLACEHOLDER )
+    @Path( StringConstants.FORWARD_SLASH + V1Constants.CLONE_SEGMENT + StringConstants.FORWARD_SLASH + V1Constants.CONNECTION_PLACEHOLDER )
     @Produces( MediaType.APPLICATION_JSON )
-    @ApiOperation(value = "Clone a datasource in the workspace")
+    @ApiOperation(value = "Clone a connection in the workspace")
     @ApiResponses(value = {
         @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
         @ApiResponse(code = 403, message = "An error has occurred.")
     })
-    public Response cloneDatasource( final @Context HttpHeaders headers,
-                                       final @Context UriInfo uriInfo,
-                                       @ApiParam(
-                                                 value = "Name of the datasource",
-                                                 required = true
-                                       )
-                                       final @PathParam( "datasourceName" ) String datasourceName,
-                                       @ApiParam(
-                                                 value = "The new name of the datasource",
-                                                 required = true
-                                       )
-                                       final String newDatasourceName) throws KomodoRestException {
+    public Response cloneConnection( final @Context HttpHeaders headers,
+                                     final @Context UriInfo uriInfo,
+                                     @ApiParam(
+                                               value = "Name of the connection",
+                                               required = true
+                                     )
+                                     final @PathParam( "connectionName" ) String connectionName,
+                                     @ApiParam(
+                                               value = "The new name of the connection",
+                                               required = true
+                                     )
+                                     final String newConnectionName) throws KomodoRestException {
 
         SecurityPrincipal principal = checkSecurityContext(headers);
         if (principal.hasErrorResponse())
@@ -407,39 +407,39 @@ public final class KomodoDatasourceService extends KomodoService {
         if (! isAcceptable(mediaTypes, MediaType.APPLICATION_JSON_TYPE))
             return notAcceptableMediaTypesBuilder().build();
 
-        // Error if the datasource name is missing
-        if (StringUtils.isBlank( datasourceName )) {
+        // Error if the connection name is missing
+        if (StringUtils.isBlank( connectionName )) {
             return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_CLONE_MISSING_NAME);
         }
 
-        // Error if the new datasource name is missing
-        if ( StringUtils.isBlank( newDatasourceName ) ) {
+        // Error if the new connection name is missing
+        if ( StringUtils.isBlank( newConnectionName ) ) {
             return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_CLONE_MISSING_NEW_NAME);
         }
 
         // Error if the name parameter and new name are the same
-        final boolean namesMatch = datasourceName.equals( newDatasourceName );
+        final boolean namesMatch = connectionName.equals( newConnectionName );
         if ( namesMatch ) {
-            return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_CLONE_SAME_NAME_ERROR, newDatasourceName);
+            return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_CLONE_SAME_NAME_ERROR, newConnectionName);
         }
 
         UnitOfWork uow = null;
 
         try {
-            uow = createTransaction(principal, "cloneDatasource", false ); //$NON-NLS-1$
+            uow = createTransaction(principal, "cloneConnection", false ); //$NON-NLS-1$
 
-            // Error if the repo already contains a datasource with the supplied name.
-            if ( getWorkspaceManager(uow).hasChild( uow, newDatasourceName ) ) {
+            // Error if the repo already contains a connection with the supplied name.
+            if ( getWorkspaceManager(uow).hasChild( uow, newConnectionName ) ) {
                 return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_CLONE_ALREADY_EXISTS);
             }
 
-            // create new Datasource
+            // create new Connection
             // must be an update
-            final KomodoObject kobject = getWorkspaceManager(uow).getChild( uow, datasourceName, DataVirtLexicon.Connection.NODE_TYPE );
+            final KomodoObject kobject = getWorkspaceManager(uow).getChild( uow, connectionName, DataVirtLexicon.Connection.NODE_TYPE );
             final Datasource oldDatasource = getWorkspaceManager(uow).resolve( uow, kobject, Datasource.class );
             final RestDataSource oldEntity = entityFactory.create(oldDatasource, uriInfo.getBaseUri(), uow );
             
-            final Datasource datasource = getWorkspaceManager(uow).createDatasource( uow, null, newDatasourceName);
+            final Datasource datasource = getWorkspaceManager(uow).createDatasource( uow, null, newConnectionName);
 
             setProperties( uow, datasource, oldEntity );
 
@@ -460,48 +460,48 @@ public final class KomodoDatasourceService extends KomodoService {
     }
 
     /**
-     * Update a Datasource in the komodo repository
+     * Update a Connection in the komodo repository
      * @param headers
      *        the request headers (never <code>null</code>)
      * @param uriInfo
      *        the request URI information (never <code>null</code>)
-     * @param datasourceName
-     *        the datasource name (cannot be empty)
-     * @param datasourceJson
-     *        the datasource JSON representation (cannot be <code>null</code>)
-     * @return a JSON representation of the updated datasource (never <code>null</code>)
+     * @param connectionName
+     *        the connection name (cannot be empty)
+     * @param connectionJson
+     *        the connection JSON representation (cannot be <code>null</code>)
+     * @return a JSON representation of the updated connection (never <code>null</code>)
      * @throws KomodoRestException
      *         if there is an error updating the VDB
      */
     @PUT
-    @Path( StringConstants.FORWARD_SLASH + V1Constants.DATA_SOURCE_PLACEHOLDER )
+    @Path( StringConstants.FORWARD_SLASH + V1Constants.CONNECTION_PLACEHOLDER )
     @Produces( MediaType.APPLICATION_JSON )
-    @ApiOperation(value = "Update a datasource in the workspace")
+    @ApiOperation(value = "Update a connection in the workspace")
     @ApiResponses(value = {
         @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
         @ApiResponse(code = 403, message = "An error has occurred.")
     })
-    public Response updateDatasource( final @Context HttpHeaders headers,
-                                       final @Context UriInfo uriInfo,
-                                       @ApiParam(
-                                                 value = "Name of the datasource",
-                                                 required = true
-                                       )
-                                       final @PathParam( "datasourceName" ) String datasourceName,
-                                       @ApiParam(
-                                                 value = "" + 
-                                                         "JSON of the properties of the data source:<br>" +
-                                                         OPEN_PRE_TAG +
-                                                         OPEN_BRACE + BR +
-                                                         NBSP + "keng\\_\\_id: \"id of the data source\"" + BR +
-                                                         NBSP + "dv\\_\\_driverName: \"name of the driver, eg. mysql\"" + BR +
-                                                         NBSP + "dv\\_\\_jndiName: \"the jndi name of the data source\"" + BR +
-                                                         NBSP + "dv\\_\\_type: \"true if jdbc, otherwise false\"" + BR +
-                                                         CLOSE_BRACE +
-                                                         CLOSE_PRE_TAG,
-                                                 required = true
-                                       )
-                                       final String datasourceJson) throws KomodoRestException {
+    public Response updateConnection( final @Context HttpHeaders headers,
+                                      final @Context UriInfo uriInfo,
+                                      @ApiParam(
+                                                value = "Name of the connection",
+                                                required = true
+                                      )
+                                      final @PathParam( "connectionName" ) String connectionName,
+                                      @ApiParam(
+                                                value = "" + 
+                                                        "JSON of the properties of the connection:<br>" +
+                                                        OPEN_PRE_TAG +
+                                                        OPEN_BRACE + BR +
+                                                        NBSP + "keng\\_\\_id: \"id of the connection\"" + BR +
+                                                        NBSP + "dv\\_\\_driverName: \"name of the driver, eg. mysql\"" + BR +
+                                                        NBSP + "dv\\_\\_jndiName: \"the jndi name of the connection\"" + BR +
+                                                        NBSP + "dv\\_\\_type: \"true if jdbc, otherwise false\"" + BR +
+                                                        CLOSE_BRACE +
+                                                        CLOSE_PRE_TAG,
+                                                required = true
+                                      )
+                                      final String connectionJson) throws KomodoRestException {
 
         SecurityPrincipal principal = checkSecurityContext(headers);
         if (principal.hasErrorResponse())
@@ -511,12 +511,12 @@ public final class KomodoDatasourceService extends KomodoService {
         if (! isAcceptable(mediaTypes, MediaType.APPLICATION_JSON_TYPE))
             return notAcceptableMediaTypesBuilder().build();
 
-        // Error if the datasource name is missing
-        if (StringUtils.isBlank( datasourceName )) {
+        // Error if the connection name is missing
+        if (StringUtils.isBlank( connectionName )) {
             return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_UPDATE_MISSING_NAME);
         }
 
-        final RestDataSource restDatasource = KomodoJsonMarshaller.unmarshall( datasourceJson, RestDataSource.class );
+        final RestDataSource restDatasource = KomodoJsonMarshaller.unmarshall( connectionJson, RestDataSource.class );
         final String jsonDatasourceName = restDatasource.getId();
         // Error if the name is missing from the supplied json body
         if ( StringUtils.isBlank( jsonDatasourceName ) ) {
@@ -525,30 +525,30 @@ public final class KomodoDatasourceService extends KomodoService {
 
         UnitOfWork uow = null;
         try {
-            uow = createTransaction(principal, "updateDatasource", false ); //$NON-NLS-1$
+            uow = createTransaction(principal, "updateConnection", false ); //$NON-NLS-1$
 
-            final boolean exists = getWorkspaceManager(uow).hasChild( uow, datasourceName );
+            final boolean exists = getWorkspaceManager(uow).hasChild( uow, connectionName );
             // Error if the specified service does not exist
             if ( !exists ) {
                 return createErrorResponseWithForbidden(mediaTypes, RelationalMessages.Error.DATASOURCE_SERVICE_UPDATE_SOURCE_DNE);
             }
 
             // must be an update
-            final KomodoObject kobject = getWorkspaceManager(uow).getChild( uow, datasourceName, DataVirtLexicon.Connection.NODE_TYPE );
+            final KomodoObject kobject = getWorkspaceManager(uow).getChild( uow, connectionName, DataVirtLexicon.Connection.NODE_TYPE );
             final Datasource datasource = getWorkspaceManager(uow).resolve( uow, kobject, Datasource.class );
 
             // Transfers the properties from the rest object to the created komodo service.
             setProperties(uow, datasource, restDatasource);
 
             // rename if names did not match
-            final boolean namesMatch = datasourceName.equals( jsonDatasourceName );
+            final boolean namesMatch = connectionName.equals( jsonDatasourceName );
             if ( !namesMatch ) {
                 datasource.rename( uow, jsonDatasourceName );
             }
 
             KomodoProperties properties = new KomodoProperties();
             final RestDataSource entity = entityFactory.create(datasource, uriInfo.getBaseUri(), uow, properties);
-            LOGGER.debug("updateDatasource: datasource '{0}' entity was updated", datasource.getName(uow)); //$NON-NLS-1$
+            LOGGER.debug("updateConnection: datasource '{0}' entity was updated", datasource.getName(uow)); //$NON-NLS-1$
             final Response response = commit( uow, headers.getAcceptableMediaTypes(), entity );
             return response;
         } catch (final Exception e) {
@@ -565,9 +565,9 @@ public final class KomodoDatasourceService extends KomodoService {
     }
 
     private Response doAddDatasource( final UnitOfWork uow,
-                                       final URI baseUri,
-                                       final List<MediaType> mediaTypes,
-                                       final RestDataSource restDatasource ) throws KomodoRestException {
+                                      final URI baseUri,
+                                      final List<MediaType> mediaTypes,
+                                      final RestDataSource restDatasource ) throws KomodoRestException {
         assert( !uow.isRollbackOnly() );
         assert( uow.getState() == State.NOT_STARTED );
         assert( restDatasource != null );
@@ -622,32 +622,32 @@ public final class KomodoDatasourceService extends KomodoService {
     }
 
     /**
-     * Delete the specified Datasource from the komodo repository
+     * Delete the specified Connection from the komodo repository
      * @param headers
      *        the request headers (never <code>null</code>)
      * @param uriInfo
      *        the request URI information (never <code>null</code>)
-     * @param datasourceName
-     *        the name of the datasource to remove (cannot be <code>null</code>)
+     * @param connectionName
+     *        the name of the connection to remove (cannot be <code>null</code>)
      * @return a JSON document representing the results of the removal
      * @throws KomodoRestException
      *         if there is a problem performing the delete
      */
     @DELETE
-    @Path("{datasourceName}")
+    @Path("{connectionName}")
     @Produces( MediaType.APPLICATION_JSON )
-    @ApiOperation(value = "Delete a datasource from the workspace")
+    @ApiOperation(value = "Delete a connection from the workspace")
     @ApiResponses(value = {
         @ApiResponse(code = 406, message = "Only JSON is returned by this operation"),
         @ApiResponse(code = 403, message = "An error has occurred.")
     })
-    public Response deleteDatasource( final @Context HttpHeaders headers,
-                                       final @Context UriInfo uriInfo,
-                                       @ApiParam(
-                                                 value = "Name of the datasource",
-                                                 required = true
-                                       )
-                                       final @PathParam( "datasourceName" ) String datasourceName) throws KomodoRestException {
+    public Response deleteConnection( final @Context HttpHeaders headers,
+                                      final @Context UriInfo uriInfo,
+                                      @ApiParam(
+                                                value = "Name of the connection",
+                                                required = true
+                                      )
+                                      final @PathParam( "connectionName" ) String connectionName) throws KomodoRestException {
         SecurityPrincipal principal = checkSecurityContext(headers);
         if (principal.hasErrorResponse())
             return principal.getErrorResponse();
@@ -656,10 +656,10 @@ public final class KomodoDatasourceService extends KomodoService {
 
         UnitOfWork uow = null;
         try {
-            uow = createTransaction(principal, "removeDatasourceFromWorkspace", false); //$NON-NLS-1$
+            uow = createTransaction(principal, "removeConnectionFromWorkspace", false); //$NON-NLS-1$
 
             final WorkspaceManager mgr = WorkspaceManager.getInstance( repo, uow );
-            KomodoObject datasource = mgr.getChild(uow, datasourceName, DataVirtLexicon.Connection.NODE_TYPE);
+            KomodoObject datasource = mgr.getChild(uow, connectionName, DataVirtLexicon.Connection.NODE_TYPE);
 
             if (datasource == null)
                 return Response.noContent().build();
@@ -667,10 +667,10 @@ public final class KomodoDatasourceService extends KomodoService {
             mgr.delete(uow, datasource);
 
             KomodoStatusObject kso = new KomodoStatusObject("Delete Status"); //$NON-NLS-1$
-            if (mgr.hasChild(uow, datasourceName))
-                kso.addAttribute(datasourceName, "Deletion failure"); //$NON-NLS-1$
+            if (mgr.hasChild(uow, connectionName))
+                kso.addAttribute(connectionName, "Deletion failure"); //$NON-NLS-1$
             else
-                kso.addAttribute(datasourceName, "Successfully deleted"); //$NON-NLS-1$
+                kso.addAttribute(connectionName, "Successfully deleted"); //$NON-NLS-1$
 
             return commit(uow, mediaTypes, kso);
         } catch (final Exception e) {

--- a/server/komodo-rest/src/test/java/org/komodo/rest/AllTests.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/AllTests.java
@@ -40,7 +40,7 @@ import org.komodo.rest.relational.json.VdbPermissionSerializerTest;
 import org.komodo.rest.relational.json.VdbSerializerTest;
 import org.komodo.rest.relational.json.VdbTranslatorSerializerTest;
 import org.komodo.rest.service.KomodoDataserviceServiceTest;
-import org.komodo.rest.service.KomodoDatasourceServiceTest;
+import org.komodo.rest.service.KomodoConnectionServiceTest;
 import org.komodo.rest.service.KomodoDriverServiceTest;
 import org.komodo.rest.service.KomodoImportExportServiceTest;
 import org.komodo.rest.service.KomodoSearchServiceTest;
@@ -70,7 +70,7 @@ import org.komodo.rest.service.KomodoVdbServiceTest;
         VdbTranslatorSerializerTest.class,
 
         KomodoDataserviceServiceTest.class,
-        KomodoDatasourceServiceTest.class,
+        KomodoConnectionServiceTest.class,
         KomodoDriverServiceTest.class,
         KomodoImportExportServiceTest.class,
         KomodoSearchServiceTest.class,

--- a/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataSourceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/relational/RestDataSourceTest.java
@@ -200,7 +200,7 @@ public final class RestDataSourceTest implements V1Constants {
         Folder dataSourceFolder = mock(Folder.class);
         when(cachedTeiid.getName(transaction)).thenReturn(TEIID_SERVER);
         when(cachedTeiid.getPrimaryType(transaction)).thenReturn(cachedTeiidType);
-        when(dataSourceFolder.getName(transaction)).thenReturn(CachedTeiid.DATA_SOURCES_FOLDER);
+        when(dataSourceFolder.getName(transaction)).thenReturn(CachedTeiid.CONNECTIONS_FOLDER);
         when(dataSourceFolder.getPrimaryType(transaction)).thenReturn(folderType);
         
         Datasource dataSource = mock(Datasource.class);
@@ -227,13 +227,13 @@ public final class RestDataSourceTest implements V1Constants {
                 linkCounter++;
                 assertEquals(BASE_URI_PREFIX +
                                          FORWARD_SLASH + TEIID_SEGMENT +
-                                         FORWARD_SLASH + CachedTeiid.DATA_SOURCES_FOLDER +
+                                         FORWARD_SLASH + CachedTeiid.CONNECTIONS_FOLDER +
                                          FORWARD_SLASH + name, href);
             } else if (LinkType.PARENT.equals(link.getRel())) {
                 linkCounter++;
                 assertEquals(BASE_URI_PREFIX +
                                          FORWARD_SLASH + TEIID_SEGMENT +
-                                         FORWARD_SLASH + CachedTeiid.DATA_SOURCES_FOLDER, href);
+                                         FORWARD_SLASH + CachedTeiid.CONNECTIONS_FOLDER, href);
             } else if (LinkType.CHILDREN.equals(link.getRel())) {
                 linkCounter++;
             }

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoConnectionServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoConnectionServiceTest.java
@@ -43,7 +43,7 @@ import org.komodo.rest.relational.datasource.RestDataSource;
 import org.komodo.rest.relational.json.KomodoJsonMarshaller;
 
 @SuppressWarnings( {"javadoc", "nls"} )
-public final class KomodoDatasourceServiceTest extends AbstractKomodoServiceTest {
+public final class KomodoConnectionServiceTest extends AbstractKomodoServiceTest {
 
     public static final String DATASOURCE_NAME = "MyDataSource"; 
     
@@ -52,11 +52,11 @@ public final class KomodoDatasourceServiceTest extends AbstractKomodoServiceTest
 
     @Test
     @Ignore
-    public void shouldGetDatasources() throws Exception {
+    public void shouldGetConnections() throws Exception {
         createDatasource(DATASOURCE_NAME);
 
         // get
-        URI uri = _uriBuilder.workspaceDatasourcesUri();
+        URI uri = _uriBuilder.workspaceConnectionsUri();
         ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);
         ClientResponse<String> response = request.get(String.class);
 
@@ -95,12 +95,12 @@ public final class KomodoDatasourceServiceTest extends AbstractKomodoServiceTest
     
     @Test
     @Ignore
-    public void shouldGetDatasource() throws Exception {
+    public void shouldGetConnection() throws Exception {
         createDatasource(DATASOURCE_NAME);
 
         // get
         Properties settings = _uriBuilder.createSettings(SettingNames.DATA_SOURCE_NAME, DATASOURCE_NAME);
-        _uriBuilder.addSetting(settings, SettingNames.DATA_SOURCE_PARENT_PATH, _uriBuilder.workspaceDatasourcesUri());
+        _uriBuilder.addSetting(settings, SettingNames.DATA_SOURCE_PARENT_PATH, _uriBuilder.workspaceConnectionsUri());
 
         URI uri = _uriBuilder.dataSourceUri(LinkType.SELF, settings);
         ClientRequest request = request(uri, MediaType.APPLICATION_JSON_TYPE);

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
@@ -161,7 +161,7 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
             assertTrue(LinkType.SELF.equals(rel) || LinkType.PARENT.equals(rel) || LinkType.CHILDREN.equals(rel));
 
             if (LinkType.SELF.equals(rel)) {
-                String href = _uriBuilder.workspaceDatasourcesUri() + FORWARD_SLASH + dataSource.getId();
+                String href = _uriBuilder.workspaceConnectionsUri() + FORWARD_SLASH + dataSource.getId();
                 assertEquals(href, link.getHref().toString());
             }
         }

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoVdbServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoVdbServiceTest.java
@@ -1314,7 +1314,7 @@ public final class KomodoVdbServiceTest extends AbstractKomodoServiceTest {
 
     @Test
     public void shouldFailNameValidationWhenNameIsEmpty() throws Exception {
-        final URI vdbUri = _uriBuilder.workspaceDatasourcesUri();
+        final URI vdbUri = _uriBuilder.workspaceConnectionsUri();
         final URI uri = UriBuilder.fromUri( vdbUri )
                                   .path( V1Constants.NAME_VALIDATION_SEGMENT )
                                   .path( "" )


### PR DESCRIPTION
The rest services urls are changed to use the term 'connection' rather than 'datasource'.  This helps to better clarify the rest service terminology.
- changes the rest segments from datasource to connection
- CachedTeiid folder name was changed to align naming convention
- other service and test methods changed to adapt