### PR TITLE
Issue 148 Data Source Name cannot be the same as the Connection

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -478,6 +478,11 @@ public final class RelationalMessages {
         DRIVER_SERVICE_GET_DRIVERS_ERROR,
 
         /**
+         * A message indicating the VDB is invalid since a data source with the given name already exists.
+         */
+        VDB_DATA_SOURCE_NAME_EXISTS,
+
+        /**
          * A message indicating that a VDB with the given name already exists.
          */
         VDB_NAME_EXISTS,

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -2428,20 +2428,17 @@ public final class KomodoDataserviceService extends KomodoService {
 
         try {
             uow = createTransaction( principal, "validateDataserviceName", true ); //$NON-NLS-1$
-            final Dataservice[] dataServices = getWorkspaceManager( uow ).findDataservices( uow );
+            final Dataservice service = findDataservice( uow, dataserviceName );
 
-            if ( dataServices.length != 0 ) {
-                for ( final Dataservice ds : dataServices ) {
-                    if ( dataserviceName.equals( ds.getName( uow ) ) ) {
-                        return Response.ok()
-                                       .entity( RelationalMessages.getString( DATASERVICE_SERVICE_NAME_EXISTS ) )
-                                       .build();
-                    }
-                }
+            if ( service == null ) {
+                // name is valid
+                return Response.ok().build();
             }
 
-            // name is valid
-            return Response.ok().build();
+            // name is a duplicate
+            return Response.ok()
+                           .entity( RelationalMessages.getString( DATASERVICE_SERVICE_NAME_EXISTS ) )
+                           .build();
         } catch ( final Exception e ) {
             if ( ( uow != null ) && ( uow.getState() != State.ROLLED_BACK ) ) {
                 uow.rollback();

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -50,6 +50,7 @@ Info.VDB_STATUS_MSG_NEW = The VDB is local
 Info.VDB_STATUS_MSG_UNKNOWN = The VDB status is unknown
 
 Error.SECURITY_FAILURE_ERROR = An error occurred when trying to authenticate and authorize use of the REST service: %s
+Error.VDB_DATA_SOURCE_NAME_EXISTS = A VDB must have a different name than an existing data source.
 Error.VDB_NAME_EXISTS = A VDB with the same name already exists.
 Error.VDB_NAME_VALIDATION_ERROR = An error occurred trying to validate the VDB name.
 Error.VDB_DESCRIPTOR_BUILDER_ERROR = An error occurred constructing the VDB descriptor JSON document in transaction %s.

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoVdbServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoVdbServiceTest.java
@@ -1298,6 +1298,25 @@ public final class KomodoVdbServiceTest extends AbstractKomodoServiceTest {
     }
 
     @Test
+    public void shouldFailNameValidationWhenDataSourceWithSameNameExists() throws Exception {
+    	final String sourceName = "elvis";
+        _restApp.createDatasource( sourceName, USER_NAME );
+
+        // try and validate the same name of an existing VDB
+        final URI vdbUri = _uriBuilder.workspaceVdbsUri();
+        final URI uri = UriBuilder.fromUri( vdbUri )
+                                  .path( V1Constants.NAME_VALIDATION_SEGMENT )
+                                  .path( sourceName )
+                                  .build();
+        final ClientRequest request = request( uri, MediaType.TEXT_PLAIN_TYPE );
+        final ClientResponse< String > response = request.get( String.class );
+        assertThat( response.getStatus(), is( Response.Status.OK.getStatusCode() ) );
+
+        final String errorMsg = response.getEntity();
+        assertThat( errorMsg, is( notNullValue() ) );
+    }
+
+    @Test
     public void shouldFailNameValidationWhenNameHasInvalidCharacters() throws Exception {
         final URI vdbUri = _uriBuilder.workspaceVdbsUri();
         final URI uri = UriBuilder.fromUri( vdbUri )


### PR DESCRIPTION
- added validation to ensure a data source cannot have the same name as a connection
- added a unit test
- changed service to be more efficient when performing data service validation