### PR TITLE
Fix for TEIIDTOOLS-182

### DIFF
--- a/komodo-utils/src/main/java/org/komodo/utils/FileUtils.java
+++ b/komodo-utils/src/main/java/org/komodo/utils/FileUtils.java
@@ -836,7 +836,14 @@ public class FileUtils implements StringConstants {
         File tmpFile = null;
         ZipFile zipFile = null;
         try {
-            tmpFile = File.createTempFile(destDirectory.getName(), ZIP_SUFFIX);
+            String prefix = destDirectory.getName();
+
+            // make sure prefix is at least 3 chars
+            while ( prefix.length() < 3 ) {
+                prefix += '_';
+            }
+
+            tmpFile = File.createTempFile(prefix, ZIP_SUFFIX);
             write(fileStream, tmpFile);
 
             zipFile = new ZipFile(tmpFile);
@@ -854,7 +861,7 @@ public class FileUtils implements StringConstants {
                     final byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
 
                     zipStream = zipFile.getInputStream(entry);
-                    File newFile = new File(destDirectory + File.separator + name);
+                    File newFile = new File( destDirectory, name );
 
                     //
                     // creates all non existent directories

--- a/komodo-utils/src/test/java/org/komodo/utils/AllTests.java
+++ b/komodo-utils/src/test/java/org/komodo/utils/AllTests.java
@@ -8,7 +8,8 @@ import org.komodo.utils.i18n.UtilsI18nTest;
  * All Util Tests
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses( { TestKLog.class,
+@Suite.SuiteClasses( { FileUtilsTest.class,
+                       TestKLog.class,
                        UtilsI18nTest.class } )
 
 public class AllTests {

--- a/komodo-utils/src/test/java/org/komodo/utils/FileUtilsTest.java
+++ b/komodo-utils/src/test/java/org/komodo/utils/FileUtilsTest.java
@@ -1,0 +1,22 @@
+package org.komodo.utils;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.junit.Test;
+import org.komodo.test.utils.TestUtilities;
+
+public final class FileUtilsTest {
+
+    @Test
+    public void shouldNotFailWhenDestinationDirectoryNameIsLess3Chars() throws Exception {
+        final File parent = new File( System.getProperty( "java.io.tmpdir" ) );
+        final File destination = new File( parent, "a" );
+        destination.mkdir();
+        destination.deleteOnExit();
+
+        final InputStream zipStream = TestUtilities.sampleDataserviceExample();
+        FileUtils.zipExtract( zipStream, destination );
+    }
+
+}


### PR DESCRIPTION
- now appending underscore character(s) to the temporary directory name is less than 3 characters
- added test case