### PR TITLE
TEIIDTOOLS-180 Check for VDB conflicts when service is deployed

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoRestV1Application.java
@@ -249,6 +249,11 @@ public class KomodoRestV1Application extends Application implements RepositoryOb
         String DATA_SERVICE_PLACEHOLDER = "{dataserviceName}"; //$NON-NLS-1$
 
         /**
+         * The name of the URI path segment for DataService deployable status
+         */
+        String DEPLOYABLE_STATUS_SEGMENT = "deployableStatus"; //$NON-NLS-1$
+        
+        /**
          * The name of the URI path segment for validating a data service or connection name.
          */
         String NAME_VALIDATION_SEGMENT = "nameValidation"; //$NON-NLS-1$

--- a/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/KomodoService.java
@@ -76,6 +76,7 @@ public abstract class KomodoService implements V1Constants {
     /**
      * VDB properties for DSB
      */
+    protected final static String DSB_PROP_OWNER = "dsbOwner"; //$NON-NLS-1$
     protected final static String DSB_PROP_SERVICE_SOURCE = "dsbServiceSource"; //$NON-NLS-1$
     protected final static String DSB_PROP_SOURCE_CONNECTION = "dsbSourceConnection"; //$NON-NLS-1$
     protected final static String DSB_PROP_SOURCE_TRANSLATOR = "dsbSourceTranslator"; //$NON-NLS-1$

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -87,6 +87,16 @@ public final class RelationalMessages {
         VDB_STATUS_MSG_UNKNOWN,
 
         /**
+         * Message for VDB already deployed message
+         */
+        VDB_ALREADY_DEPLOYED,
+
+        /**
+         * Message for VDB already deployed by owner message
+         */
+        VDB_ALREADY_DEPLOYED_OWNER,
+
+        /**
          * Title for the driver deployment status
          */
         DRIVER_DEPLOYMENT_STATUS_TITLE,
@@ -131,6 +141,11 @@ public final class RelationalMessages {
          */
         CONNECTION_SUCCESSFULLY_UNDEPLOYED,
         
+        /**
+         * Data service deployable status title
+         */
+        DATA_SERVICE_DEPLOYABLE_STATUS_TITLE,
+
         /**
          * Data service status title
          */
@@ -881,6 +896,11 @@ public final class RelationalMessages {
          * An error indicating a teiid credentials failure
          */
         TEIID_SERVICE_SET_CREDENTIALS_ERROR,
+
+        /**
+         * An error determining data service deployable status
+         */
+        TEIID_SERVICE_GET_DATA_SERVICE_DEPLOYABLE_ERROR,
 
         /**
          * An error when getting vdbs

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -678,6 +678,8 @@ public final class KomodoDataserviceService extends KomodoService {
             	svcVdbObj.remove(uow);
             }
             KomodoObject vdbObj = wkspMgr.createVdb(uow, null, serviceVdbName, serviceVdbName);
+            // Set owner property on the service vdb
+            vdbObj.setProperty(uow, DSB_PROP_OWNER, uow.getUserName());
             Vdb serviceVdb = Vdb.RESOLVER.resolve(uow, vdbObj);
             
             // Add to the ServiceVdb a virtual model for the View
@@ -1020,6 +1022,8 @@ public final class KomodoDataserviceService extends KomodoService {
                 svcVdbObj.remove(uow);
             }
             KomodoObject vdbObj = wkspMgr.createVdb(uow, null, serviceVdbName, serviceVdbName);
+            // Set owner property on the service vdb
+            vdbObj.setProperty(uow, DSB_PROP_OWNER, uow.getUserName());
             Vdb serviceVdb = Vdb.RESOLVER.resolve(uow, vdbObj);
             
             // ----------------------------------------------------------------

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -23,6 +23,7 @@ Info.DRIVER_SUCCESSFULLY_UPLOADED = Driver successfully uploaded and sent for de
 Info.DRIVER_SUCCESSFULLY_DEPLOYED = Driver successfully deployed to teiid instance
 Info.DRIVER_UNDEPLOYMENT_REQUEST_SENT = Driver undeployment request sent but cannot yet be verified
 Info.DRIVER_SUCCESSFULLY_UNDEPLOYED = Driver successfully undeployed from teiid instance
+Info.DATA_SERVICE_DEPLOYABLE_STATUS_TITLE = Data Service Deployable Status
 Info.DATA_SERVICE_DEPLOYMENT_STATUS_TITLE = Data Service Deployment Status
 Info.DATA_SERVICE_SUCCESSFULLY_DEPLOYED = Data service successfully deployed to teiid instance
 Info.DATA_SERVICE_DEPLOYED_WITH_ERRORS = Data service attempted deployment but errors occurred
@@ -48,7 +49,9 @@ Info.VDB_STATUS_MSG_ACTIVE = The VDB is Active
 Info.VDB_STATUS_MSG_LOADING = The VDB is Loading
 Info.VDB_STATUS_MSG_NEW = The VDB is local
 Info.VDB_STATUS_MSG_UNKNOWN = The VDB status is unknown
-
+Info.VDB_ALREADY_DEPLOYED = A VDB '%s' is already deployed.
+Info.VDB_ALREADY_DEPLOYED_OWNER = A VDB '%s' is already deployed. [owner: '%s']
+ 
 Error.SECURITY_FAILURE_ERROR = An error occurred when trying to authenticate and authorize use of the REST service: %s
 Error.VDB_DATA_SOURCE_NAME_EXISTS = A VDB must have a different name than an existing data source.
 Error.VDB_NAME_EXISTS = A VDB with the same name already exists.
@@ -191,6 +194,7 @@ Error.TEIID_SERVICE_STATUS_ERROR = An error occurred while ascertaining the stat
 Error.TEIID_SERVICE_REQUEST_PARSING_ERROR = An error occurred while process the request body of the teiid service: %s
 Error.TEIID_SERVICE_EMPTY_CREDENTIAL_ERROR = Values are required for all the admin user/password and jdbc user/password credentials
 Error.TEIID_SERVICE_SET_CREDENTIALS_ERROR = An error occurred whilst setting the credentials of the teiid instance: %s
+Error.TEIID_SERVICE_GET_DATA_SERVICE_DEPLOYABLE_ERROR = An error occurred while trying to determine the deployable status of data service: %s
 Error.TEIID_SERVICE_GET_DATA_SOURCE_ERROR = An error occurred constructing the JSON document representing DataSource '%s' on the local teiid server
 Error.TEIID_SERVICE_GET_DATA_SOURCE_TRANSLATOR_ERROR = An error occurred getting the translator for DataSource: %s on the local teiid server
 Error.TEIID_SERVICE_GET_DATA_SOURCES_ERROR = An error occurred constructing the JSON document representing the DataSources on the local teiid server: %s


### PR DESCRIPTION
- a 'dsbOwner' property was added to the service vdb within a data service.
- KomodoDataserviceService - when the service VDB is created, the dsbOwner is set to the current user.
- KomodoTeiidService - added a service method which gets a 'deployable' status for a workspace Dataservice.  Checks whether there are currently deployed vdbs which would be in conflict.