### PR TITLE
Fix for TEIIDTOOLS-179

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoDataserviceService.java
@@ -2431,8 +2431,12 @@ public final class KomodoDataserviceService extends KomodoService {
             final Dataservice service = findDataservice( uow, dataserviceName );
 
             if ( service == null ) {
+                final Vdb vdb = findVdb( uow, dataserviceName );
+
                 // name is valid
-                return Response.ok().build();
+                if ( vdb == null) {
+                    return Response.ok().build();
+                }
             }
 
             // name is a duplicate

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -133,7 +133,7 @@ Error.DATASERVICE_SERVICE_UPDATE_MISSING_NAME = The DataService name is required
 Error.DATASERVICE_SERVICE_CLONE_MISSING_NAME = The DataService name is required when cloning a DataService.
 Error.DATASERVICE_SERVICE_CLONE_MISSING_NEW_NAME = The new DataService name is required when cloning a DataService.
 Error.DATASERVICE_SERVICE_CLONE_SAME_NAME_ERROR = The new DataService name '%s' cannot be the same as the DataService being cloned.
-Error.DATASERVICE_SERVICE_CREATE_ALREADY_EXISTS = The DataService could not be created because service with the same name already exists.
+Error.DATASERVICE_SERVICE_CREATE_ALREADY_EXISTS = The DataService could not be created because a data service, data source, or other workspace object with the same name and path already exists.
 Error.DATASERVICE_SERVICE_CLONE_ALREADY_EXISTS = The DataService could not be cloned because service with the requested name already exists.
 Error.DATASERVICE_SERVICE_FIND_VIEW_INFO_ERROR = An error occurred while attempting to locate view info for Dataservice: %s
 Error.DATASERVICE_SERVICE_FIND_SOURCE_VDB_ERROR = An error occurred while attempting to locate a source for Dataservice: %s
@@ -153,7 +153,7 @@ Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_JOIN_TYPE = The joinType is requir
 Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_JOIN_LH_COLUMN = The join left criteria column is required for this operation for DataService: %s
 Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_JOIN_RH_COLUMN = The join right criteria column is required for this operation for DataService: %s
 Error.DATASERVICE_SERVICE_SET_SERVICE_MISSING_VIEWDDL = The service view DDL is required for this operation for DataService: %s
-Error.DATASERVICE_SERVICE_NAME_EXISTS = A data service with the same name already exists.
+Error.DATASERVICE_SERVICE_NAME_EXISTS = A data service, data source, or other workspace object with the same name and path already exists.
 Error.DATASERVICE_SERVICE_NAME_VALIDATION_ERROR = An error occurred trying to validate the data service name.
 
 Error.DATASOURCE_SERVICE_GET_CONNECTIONS_ERROR = An error occurred constructing the JSON document representing the Connections in the Komodo workspace: %s

--- a/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
+++ b/server/komodo-rest/src/test/java/org/komodo/rest/service/KomodoDataserviceServiceTest.java
@@ -606,6 +606,26 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
     }
 
     @Test
+    public void shouldFailNameValidationWhenVdbWithSameNameExists() throws Exception {
+        // create a data source first
+        createVdb( DATASERVICE_NAME );
+
+        // try and validate the same name of an existing data service
+        final URI dsUri = _uriBuilder.workspaceDataservicesUri();
+        final URI uri = UriBuilder.fromUri( dsUri )
+                                  .path( V1Constants.NAME_VALIDATION_SEGMENT )
+                                  .path( DATASERVICE_NAME )
+                                  .build();
+        final ClientRequest request = request( uri, MediaType.TEXT_PLAIN_TYPE );
+        final ClientResponse< String > response = request.get( String.class );
+        assertThat( response.getStatus(), is( Response.Status.OK.getStatusCode() ) );
+
+        final String errorMsg = response.getEntity();
+        assertThat( errorMsg, is( notNullValue() ) );
+        assertThat( errorMsg.isEmpty(), is( false ) );
+    }
+
+    @Test
     public void shouldFailNameValidationWhenNameHasInvalidCharacters() throws Exception {
         final URI dsUri = _uriBuilder.workspaceDataservicesUri();
         final URI uri = UriBuilder.fromUri( dsUri )
@@ -618,6 +638,7 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
 
         final String errorMsg = response.getEntity();
         assertThat( errorMsg, is( notNullValue() ) );
+        assertThat( errorMsg.isEmpty(), is( false ) );
     }
 
     @Test
@@ -648,6 +669,7 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
 
         final String errorMsg = response.getEntity();
         assertThat( errorMsg, is( notNullValue() ) );
+        assertThat( errorMsg.isEmpty(), is( false ) );
     }
 
     @Test
@@ -663,6 +685,7 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
 
         final String errorMsg = response.getEntity();
         assertThat( errorMsg, is( notNullValue() ) );
+        assertThat( errorMsg.isEmpty(), is( false ) );
     }
 
     @Test
@@ -678,6 +701,7 @@ public final class KomodoDataserviceServiceTest extends AbstractKomodoServiceTes
 
         final String errorMsg = response.getEntity();
         assertThat( errorMsg, is( notNullValue() ) );
+        assertThat( errorMsg.isEmpty(), is( false ) );
     }
 
     @Test


### PR DESCRIPTION
- an error message is now displayed if the data service name matches an existing data source/VDB
- the Next/Finish button in the data service wizard will not enable if matching name exists
- added test case to verify new validation functionality