### PR TITLE
Addresses Null JDBC connections when using wildfly

### DIFF
--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -1081,6 +1081,11 @@ public final class RelationalMessages {
          * An error indicating data source isn not a JDBC source.
          */
         TEIID_SERVICE_GET_DATA_SOURCE_NOT_JDBC_ERROR,
+
+        /**
+         * An error indicating data source cannot be instantiated from available data sources
+         */
+        TEIID_SERVICE_GET_DATA_SOURCE_INSTANTIATION_FAILURE,
         
         /**
          * An error indicating attempt to get source JDBC connection failed.
@@ -1101,6 +1106,16 @@ public final class RelationalMessages {
          * An error indicating attempt to get source catalog and schema failed.
          */
         TEIID_SERVICE_GET_DATA_SOURCE_CATALOG_SCHEMA_ERROR,
+
+        /**
+         * An error indicating jdbc info failed to be supplied from a data source.
+         */
+        TEIID_SERVICE_GET_DATA_SOURCE_JDBC_INFO_FAILURE,
+
+        /**
+         * An error indicating the jdbc data source is not recognised.
+         */
+        TEIID_SERVICE_GET_DATA_SOURCE_UNRECOGNISED_JDBC_SOURCE,
 
            /**
          * An error indicating update attempt failed

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -232,10 +232,13 @@ Error.TEIID_SERVICE_UPDATE_ERROR = An error occurred while updating a vdb from t
 Error.TEIID_SERVICE_DEFAULT_TRANSLATOR_MAPPINGS_NOT_FOUND_ERROR = The default translator mapping file was not found.
 Error.TEIID_SERVICE_LOAD_DEFAULT_TRANSLATOR_MAPPINGS_ERROR = An error occurred attempting to load the default translator mappings: %s
 Error.TEIID_SERVICE_GET_DATA_SOURCE_NOT_JDBC_ERROR = The specified source is not a JDBC source.
+Error.TEIID_SERVICE_GET_DATA_SOURCE_INSTANTIATION_FAILURE = The data source cannot be instantiated from the underlying runtime environment
 Error.TEIID_SERVICE_GET_DATA_SOURCE_CONNECTION_ERROR = An error occurred attempting to get the source JDBC connection.
 Error.TEIID_SERVICE_GET_DATA_SOURCE_TABLE_FETCH_ERROR = An error occurred attempting to fetch the source JDBC tables.
 Error.TEIID_SERVICE_GET_DATA_SOURCE_TABLES_ERROR = An error occurred getting the source tables.
 Error.TEIID_SERVICE_GET_DATA_SOURCE_CATALOG_SCHEMA_ERROR = An error occurred getting the source catalog and schema.
+Error.TEIID_SERVICE_GET_DATA_SOURCE_JDBC_INFO_FAILURE = An error occurred trying to extract jdbc info from the data source: %s
+Error.TEIID_SERVICE_GET_DATA_SOURCE_UNRECOGNISED_JDBC_SOURCE = The JDBC source does not provide recognisable metadata
 
 Error.IMPORT_EXPORT_SERVICE_NO_PARAMETERS_ERROR = The import export service requires at least one parameter
 Error.IMPORT_EXPORT_SERVICE_UNSUPPORTED_TYPE_ERROR = The storage type requested from the import export service is unsupported


### PR DESCRIPTION
* When creating a datasource, a JDBC data-sourcec connection is required
  to fetch the metadata.
 * Using wildfly, this connection is null due to a different class being
   supplied by the naming context representing the data-sources

* Makes the code ambivalent to the name of the data-source class other
  than expecting it to end with "DataSource"

* Ensures if no connection then a definite exception is thrown

* Provides checks on all connection parameter methods and supplies exceptions
  to return http responses to provide more information to errors.