### PR TITLE
TEIIDTOOLS-191 allow specification of import options in importer

### DIFF
--- a/komodo-importer/src/main/resources/org/komodo/importer/messages.properties
+++ b/komodo-importer/src/main/resources/org/komodo/importer/messages.properties
@@ -5,7 +5,7 @@ IMPORTER.errorFileNotReadableMsg = The specified File "{0}" is not readable
 IMPORTER.errorEmptyMsg = The supplied content string is empty
 IMPORTER.ddlDoesNotSupportVDB = The DDL importer does not support importing vdb files. Use the Vdb importer
 IMPORTER.vdbOnlySupportsVDB = The Vdb importer only support importing of vdb files.
-IMPORTER.nodeExistsReturn = The importer will not continue as node exists and HANDLE_EXISTING_NODE option = 'RETURN'
+IMPORTER.nodeExistsReturn = The importer will not import "{0}".  The node already exists, and HANDLE_EXISTING_NODE option = 'RETURN'
 IMPORTER.nodeExistCreateNew = The importer has found a node named {0} already exists. HANDLE_EXISTING_NODE option = 'CREATE_NEW' so will use the new name {1}
 IMPORTER.noNameFailure = No name has been provided.
 IMPORTER.newNameFailure = The importer failed to determine a new name from the original name {0}

--- a/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceConveyor.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/dataservice/internal/DataserviceConveyor.java
@@ -68,7 +68,6 @@ import org.komodo.utils.StringUtils;
 import org.modeshape.jcr.api.JcrConstants;
 import org.teiid.modeshape.sequencer.dataservice.DataServiceManifest;
 import org.teiid.modeshape.sequencer.dataservice.DataServiceManifestReader;
-import org.teiid.modeshape.sequencer.dataservice.lexicon.DataVirtLexicon;
 
 /**
  * Handles importing and exporting of {@link Dataservice data services}.
@@ -121,7 +120,7 @@ public class DataserviceConveyor implements StringConstants {
             // RETURN - Return 'false' - do not create a node.  Log an error message
             case RETURN:
                 importMessages.addErrorMessage(org.komodo.importer.Messages.getString(
-                                                                                      org.komodo.importer.Messages.IMPORTER.nodeExistsReturn));
+                                                                                      org.komodo.importer.Messages.IMPORTER.nodeExistsReturn, dsName));
                 return false;
             // CREATE_NEW - Return 'true' - will create a new data service with new unique name.  Log a progress message.
             case CREATE_NEW:

--- a/komodo-relational/src/main/java/org/komodo/relational/importer/connection/ConnectionImporter.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/importer/connection/ConnectionImporter.java
@@ -85,7 +85,7 @@ public class ConnectionImporter extends AbstractImporter {
                 switch ( optionValue ) {
                     case RETURN:
                     case CREATE_NEW:
-                        importMessages.addErrorMessage( Messages.getString( Messages.IMPORTER.nodeExistsReturn ) );
+                        importMessages.addErrorMessage( Messages.getString( Messages.IMPORTER.nodeExistsReturn, connection.getName() ) );
                         break;
                     case OVERWRITE:
                         shouldSequence = true;

--- a/komodo-relational/src/main/java/org/komodo/relational/importer/vdb/VdbImporter.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/importer/vdb/VdbImporter.java
@@ -99,7 +99,7 @@ public class VdbImporter extends AbstractImporter {
         switch (exNodeOption) {
             // RETURN - Return 'false' - do not create a node.  Log an error message
             case RETURN:
-                importMessages.addErrorMessage(Messages.getString(Messages.IMPORTER.nodeExistsReturn));
+                importMessages.addErrorMessage(Messages.getString(Messages.IMPORTER.nodeExistsReturn, vdbName));
                 return false;
             // CREATE_NEW - Return 'true' - will create a new VDB with new unique name.  Log a progress message.
             case CREATE_NEW:

--- a/komodo-relational/src/main/java/org/komodo/relational/workspace/WorkspaceManager.java
+++ b/komodo-relational/src/main/java/org/komodo/relational/workspace/WorkspaceManager.java
@@ -942,17 +942,37 @@ public class WorkspaceManager extends ObjectImpl implements RelationalObject {
     }
 
     /**
+    *
+    * @param transaction
+    *        the transaction (cannot be <code>null</code> or have a state that is not
+    *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
+    * @param parent the parent of the imported vdb
+    * @param storageRef the reference to the destination within the storage
+    * @return the import messages (never <code>null</code>)
+    * @throws KException if error occurs
+    */
+    public ImportMessages importArtifact(final UnitOfWork transaction,
+                                         final KomodoObject parent,
+                                         StorageReference storageRef) throws KException {
+        
+        return importArtifact(transaction,parent,storageRef,new ImportOptions());
+    }
+    
+    /**
      *
      * @param transaction
      *        the transaction (cannot be <code>null</code> or have a state that is not
      *        {@link org.komodo.spi.repository.Repository.UnitOfWork.State#NOT_STARTED})
      * @param parent the parent of the imported vdb
      * @param storageRef the reference to the destination within the storage
+     * @param importOptions options for the import
      * @return the import messages (never <code>null</code>)
      * @throws KException if error occurs
      */
     public ImportMessages importArtifact(final UnitOfWork transaction,
-                                      final KomodoObject parent, StorageReference storageRef) throws KException {
+                                         final KomodoObject parent, 
+                                         StorageReference storageRef,
+                                         ImportOptions importOptions) throws KException {
         ArgCheck.isNotNull( transaction, "transaction" ); //$NON-NLS-1$
         ArgCheck.isTrue( ( transaction.getState() == org.komodo.spi.repository.Repository.UnitOfWork.State.NOT_STARTED ),
                          "transaction state is not NOT_STARTED" ); //$NON-NLS-1$
@@ -970,7 +990,6 @@ public class WorkspaceManager extends ObjectImpl implements RelationalObject {
             connector = storageService.getConnector(storageRef.getParameters());
             stream = connector.read(storageRef.getParameters());
 
-            ImportOptions importOptions = new ImportOptions();
             ImportMessages importMessages = new ImportMessages();
 
             if (DocumentType.VDB_XML.equals(storageRef.getDocumentType())) {

--- a/komodo-relational/src/test/java/org/komodo/relational/importer/vdb/TestTeiidVdbImporter.java
+++ b/komodo-relational/src/test/java/org/komodo/relational/importer/vdb/TestTeiidVdbImporter.java
@@ -442,7 +442,7 @@ public class TestTeiidVdbImporter extends AbstractImporterTest {
         // Error messages - expect error that the node already exists
         List<String> errorMessages = importMessages.getErrorMessages();
         assertEquals(1, errorMessages.size());
-        assertEquals(Messages.getString(Messages.IMPORTER.nodeExistsReturn), errorMessages.get(0));
+        assertEquals(Messages.getString(Messages.IMPORTER.nodeExistsReturn, TestUtilities.TWEET_EXAMPLE_VDB_NAME), errorMessages.get(0));
     }
 
     @Test

--- a/komodo-spi/src/main/java/org/komodo/spi/storage/StorageConnector.java
+++ b/komodo-spi/src/main/java/org/komodo/spi/storage/StorageConnector.java
@@ -93,6 +93,11 @@ public interface StorageConnector extends StringConstants {
     String DOWNLOADABLE_PATH_PROPERTY = "downloadable-path-property";
 
     /**
+     * Parameter to specify overwrite option for imports
+     */
+    String IMPORT_OVERWRITE_PROPERTY = "import-overwrite-property";
+
+    /**
      * @return the id of the connector
      */
     StorageConnectorId getId();

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/RelationalMessages.java
@@ -122,6 +122,11 @@ public final class RelationalMessages {
         DRIVER_SUCCESSFULLY_UNDEPLOYED,
         
         /**
+         * An import export service import success message
+         */
+        IMPORT_EXPORT_SERVICE_IMPORT_SUCCESS_MESSAGE,
+        
+        /**
          * VDB undeployment request sent but not yet undeployed
          */
         VDB_UNDEPLOYMENT_REQUEST_SENT,
@@ -1182,6 +1187,11 @@ public final class RelationalMessages {
          */
         IMPORT_EXPORT_SERVICE_IMPORT_ERROR,
 
+        /**
+         * An import export service import artifact error
+         */
+        IMPORT_EXPORT_SERVICE_IMPORT_ARTIFACT_ERROR,
+        
         /**
          * An import export service storage types retrieval error
          */

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/ImportExportStatusSerializer.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/json/ImportExportStatusSerializer.java
@@ -63,6 +63,9 @@ public final class ImportExportStatusSerializer extends TypeAdapter< ImportExpor
                 case ImportExportStatus.CONTENT_LABEL:
                     status.setContent(in.nextString());
                     break;
+                case ImportExportStatus.MESSAGE_LABEL:
+                    status.setMessage(in.nextString());
+                    break;
                 case ImportExportStatus.DOWNLOADABLE_SIZE_LABEL:
                     status.setDownloadableSize(in.nextLong());
                     break;
@@ -101,6 +104,9 @@ public final class ImportExportStatusSerializer extends TypeAdapter< ImportExpor
 
         out.name(ImportExportStatus.CONTENT_LABEL);
         out.value(value.getContent());
+
+        out.name(ImportExportStatus.MESSAGE_LABEL);
+        out.value(value.getMessage());
 
         out.name(ImportExportStatus.DOWNLOADABLE_SIZE_LABEL);
         out.value(value.getDownloadableSize());

--- a/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/ImportExportStatus.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/relational/response/ImportExportStatus.java
@@ -44,12 +44,17 @@ public class ImportExportStatus implements KRestEntity {
     /**
      * Label for the size of the downloadable
      */
-    public static final String DOWNLOADABLE_SIZE_LABEL = "downloadableSize";
+    public static final String DOWNLOADABLE_SIZE_LABEL = "downloadableSize"; //$NON-NLS-1$
 
     /**
      * Label for the content
      */
     public static final String CONTENT_LABEL = "content"; //$NON-NLS-1$
+
+    /**
+     * Label for the message
+     */
+    public static final String MESSAGE_LABEL = "message"; //$NON-NLS-1$
 
     /**
      * Label for the success flag
@@ -63,6 +68,8 @@ public class ImportExportStatus implements KRestEntity {
     private boolean downloadable;
 
     private String content;
+
+    private String message;
 
     private boolean success;
 
@@ -104,6 +111,20 @@ public class ImportExportStatus implements KRestEntity {
      */
     public void setContent(String content) {
         this.content = content;
+    }
+
+    /**
+     * @return message if provided or null
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * @param message the message
+     */
+    public void setMessage(String message) {
+        this.message = message;
     }
 
     /**

--- a/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
+++ b/server/komodo-rest/src/main/java/org/komodo/rest/service/KomodoUtilService.java
@@ -236,14 +236,12 @@ public final class KomodoUtilService extends KomodoService {
                 importer.importVdb(uow, sampleStream, workspace, importOptions, importMessages);
                 uow.commit();
 
-                String existingVdbMsg = org.komodo.importer.Messages.getString(
-                                                                               org.komodo.importer.Messages.IMPORTER.nodeExistsReturn);
                 List<String> errorMsgs = importMessages.getErrorMessages();
                 if (errorMsgs.isEmpty()) {
                     msg = RelationalMessages.getString(
                                                        RelationalMessages.Error.VDB_SAMPLE_IMPORT_SUCCESS,
                                                                                                               sampleName);
-                } else if (existingVdbMsg.equals(errorMsgs.iterator().next())) {
+                } else if (errorMsgs.iterator().next().contains("node already exists")) {
                     msg = RelationalMessages.getString(
                                                        RelationalMessages.Error.VDB_SAMPLE_IMPORT_VDB_EXISTS,
                                                                                                               sampleName);

--- a/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
+++ b/server/komodo-rest/src/main/resources/org/komodo/rest/relational/relationalmessages.properties
@@ -32,6 +32,7 @@ Info.DATA_SOURCE_SUCCESSFULLY_DEPLOYED = Data source successfully deployed to te
 Info.DATA_SOURCE_SUCCESSFULLY_UNDEPLOYED = Data source successfully undeployed from the teiid instance.
 Info.DATA_SOURCE_UNDEPLOYMENT_REQUEST_SENT = Data sourve undeployment request sent but cannot yet be verified
 Info.DATA_SOURCE_DEPLOYED_WITH_ERRORS = Data source attempted deployment but errors occurred
+Info.IMPORT_EXPORT_SERVICE_IMPORT_SUCCESS_MESSAGE = '%s' was imported successfully.
 Info.VDB_DEPLOYMENT_STATUS_TITLE = Vdb Deployment Status
 Info.VDB_SUCCESSFULLY_DEPLOYED = Vdb successfully deployed to teiid instance
 Info.VDB_SUCCESSFULLY_UNDEPLOYED = Vdb successfully undeployed from the teiid instance.
@@ -254,3 +255,5 @@ Error.IMPORT_EXPORT_SERVICE_EXPORT_ERROR = An error occurred while attempting to
 Error.IMPORT_EXPORT_SERVICE_IMPORT_ERROR = An error occurred while attempting to perform an import to storage of type %s: %s
 Error.IMPORT_EXPORT_SERVICE_STORAGE_TYPES_ERROR = An error occurred while attempting to retrieve the available import/export storage types: %s
 Error.IMPORT_EXPORT_SERVICE_MISSING_PARAMETER_ERROR = The parameter %s is required for the import/export operation but was not specified in the operation call
+Error.IMPORT_EXPORT_SERVICE_IMPORT_ARTIFACT_ERROR = An error occurred while attempting to perform the import: %s
+


### PR DESCRIPTION
Modifications to the importer to allow user to specify import options
- changed node exists message to include name of the node
- overload WorkspaceManager importArtifact method to allow passing in ImportOptions
- add StorageConnector parameter for specification of import overwrite option
- add ImportStatus message to allow user to supply message with the status
- modify KomodoImportExportService to set ImportOptions based on supplied parameter 